### PR TITLE
Add Echelon (ECH)

### DIFF
--- a/components/chains.js
+++ b/components/chains.js
@@ -39,6 +39,7 @@ export const chainIds = {
     '1284': 'moonbeam',
     '1285': 'moonriver',
     '2020': 'ronin',
+    '3000': 'echelon',
     '4689': 'iotex',
     '5050': 'xlc',
     '5551': 'nahmii',

--- a/utils/extraRpcs.json
+++ b/utils/extraRpcs.json
@@ -54,6 +54,12 @@
             "https://rpcapi.fantom.network"
         ]
     },
+    "3000":{
+        "rpcs":[
+            "https://rpc.ech.network",
+            "https://evm.ech.network"
+        ]
+    },
     "137":{
         "rpcs":[
             "https://polygon-rpc.com",


### PR DESCRIPTION
Adds Echelon (ECH) network

Official Site: https://ech.network
Official Dapp: https://app.ech.network

Chain ID: 3000

(We are now merged into the https://github.com/ethereum-lists/chains/pull/1096 repo)