### PR TITLE
Add PHI (PHI)

### DIFF
--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -123,6 +123,11 @@
             "https://mainnet.aurora.dev"
         ]
     },
+    "4181":{
+        "rpcs":[
+            "https://rpc1.phi.network"
+        ]
+    },
     "128":{
         "rpcs":[
             "https://http-mainnet-node.huobichain.com",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -87,6 +87,13 @@
             "https://evm-t3.cronos.org/"
         ]
     },
+    },
+    "4181":{
+        "rpcs":[
+            "https://rpc1.phi.network",
+            "https://rpc2.phi.network"
+        ]
+    },
     "42161":{
         "rpcs":[
             "https://arb1.arbitrum.io/rpc",


### PR DESCRIPTION
Adds PHI (PHI) network
Official Site: https://phi.network/  Official Dapp: https://app.phiswap.com/
Chain ID: 4181
(We are now merged into the [ethereum-lists/chains#1200](https://github.com/ethereum-lists/chains/pull/1200) repo)