### PR TITLE
Adds PHI (PHI) network

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -41,6 +41,7 @@ const chainIds = {
   1285: "moonriver",
   2020: "ronin",
   2612: "ezchain",
+  4181: "phi",
   4689: "iotex",
   5050: "xlc",
   5551: "nahmii",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -116,6 +116,11 @@
             "https://mainnet.aurora.dev"
         ]
     },
+    "4181":{
+        "rpcs":[
+            "https://rpc1.phi.network"
+        ]
+    },
     "128":{
         "rpcs":[
             "https://http-mainnet-node.huobichain.com",


### PR DESCRIPTION
Adds PHI (PHI) network
Official Site: https://phi.network/ Official Dapp: https://app.phiswap.com/
Chain ID: 4181
(We are now merged into the [ethereum-lists/chains#1200](https://github.com/ethereum-lists/chains/pull/1200) repo)