### PR TITLE
Add Crystaleum 💎

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -48,6 +48,7 @@ const chainIds = {
   5551: "nahmii",
   8217: "klaytn",
   10000: "smartbch",
+  103090: "crystaleum",
   32659: "fusion",
   42161: "arbitrum",
   42220: "celo",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -1341,6 +1341,12 @@
         "rpc": [
             "https://mainnet.sherpax.io/rpc"
         ]
+    },
+    "103090":{
+        "rpcs":[
+            "https://evm.cryptocurrencydevs.org",
+            "https://rpc.crystaleum.org"
+        ]
     }
 }
 


### PR DESCRIPTION
Adds Crystaleum (💎) network
Official Site: https://crystaleum.org/
Chain ID: 103090
(PR 1213 of official chain list https://github.com/ethereum-lists/chains/pull/1213)