### PR TITLE
Added Rise of the Warbots testnet RPCs

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -46,6 +46,7 @@ const chainIds = {
   4689: "iotex",
   5050: "xlc",
   5551: "nahmii",
+  7777: "nmactest"
   8217: "klaytn",
   10000: "smartbch",
   32659: "fusion",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -1341,6 +1341,15 @@
         "rpc": [
             "https://mainnet.sherpax.io/rpc"
         ]
-    }
+    },
+    "7777":{
+        "rpcs":[
+            "https://testnet1.rotw.games",
+            "https://testnet2.rotw.games",
+            "https://testnet3.rotw.games",
+            "https://testnet4.rotw.games",
+            "https://testnet5.rotw.games"
+        ]
+    },
 }
 


### PR DESCRIPTION
This pull request will add the NMAC EVM Subnet of the NFT-based game project *Rise of the Warbots*. See https://riseofthewarbots.com for details.