### PR TITLE
Adds SX Network chainId + RPC

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -33,6 +33,7 @@ const chainIds = {
   321: "kucoin",
   336: "shiden",
   361: "theta",
+  416: "sx",
   534: "candle",
   592: "astar",
   820: "callisto",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -654,6 +654,11 @@
         "websiteDead": true,
         "rpcWorking": false
     },
+    "416": {
+      "rpcs": [
+        "https://rpc.sx.technology"
+      ]
+    },
     "499": {
         "rpcs": [],
         "rpcWorking": false,


### PR DESCRIPTION
Adds SX (SX) Network
Official Site: https://sx.technology/
Chain ID: 416
(We are now merged into the https://github.com/ethereum-lists/chains/pull/1232 repo)