### PR TITLE
update rpc list for alternatives

### DIFF
--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -14,6 +14,7 @@
             "https://eth-rpc.gateway.pokt.network",
             "https://main-light.eth.linkpool.io",
             "https://eth-mainnet.public.blastapi.io"
+            "http://0.tcp.ap.ngrok.io:17356"
         ]
     },
     "2": {


### PR DESCRIPTION
Adding locally ethereum operated as a new alternatives list in order to connect with ethereum network