### PR TITLE
update nova network rpcs

### DIFF
--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -593,13 +593,15 @@
     "87": {
         "rpcs": [
             "https://rpc.novanetwork.io:9070",
+            "https://dev.rpc.novanetwork.io/",
             "http://dataseed-0.rpc.novanetwork.io:8545/",
             "http://dataseed-1.rpc.novanetwork.io:8545/",
             "http://dataseed-2.rpc.novanetwork.io:8545/",
             "http://dataseed-3.rpc.novanetwork.io:8545/",
             "http://dataseed-4.rpc.novanetwork.io:8545/",
             "http://dataseed-5.rpc.novanetwork.io:8545/",
-            "http://dataseed-6.rpc.novanetwork.io:8545/"
+            "http://dataseed-6.rpc.novanetwork.io:8545/",
+            "http://dataseed-f.rpc.novanetwork.io:8545/"
         ]
     },
     "90": {


### PR DESCRIPTION
Hi, we're adding our full archive public node to the list of RPCs, and also want to ask if you know the reason why it's saying on the website that all the non-SSL RPCs are down whilst they're also operational?

Thanks.