### PR TITLE
bug fix: change networkId calls to chainId

### DIFF
--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -105,7 +105,7 @@ export default function Chain({ chain, buttonOnly }) {
           </div>
 
           <Tooltip title={chain.name}>
-            <span className={classes.name}><Link href={`/chain/${chain.networkId}`}>{chain.name}</Link></span>
+            <span className={classes.name}><Link href={`/chain/${chain.chainId}`}>{chain.name}</Link></span>
           </Tooltip>
         </div>
         <div className={classes.chainInfoContainer}>

--- a/pages/chain/[chain].js
+++ b/pages/chain/[chain].js
@@ -14,7 +14,7 @@ export async function getStaticProps({ params, locale }) {
 
   const chainTvls = await fetcher("https://api.llama.fi/chains");
 
-  const chain = chains.find((c) => c.networkId?.toString() === params.chain);
+  const chain = chains.find((c) => c.chainId?.toString() === params.chain);
 
   return {
     props: {
@@ -29,7 +29,7 @@ export async function getStaticPaths() {
   const res = await fetcher("https://chainid.network/chains.json");
 
   const paths = res.map((chain) => ({
-    params: { chain: chain?.networkId?.toString() ?? null },
+    params: { chain: chain?.chainId?.toString() ?? null },
   }));
 
   return { paths, fallback: "blocking" };

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -8,10 +8,10 @@ function generateSiteMap(chains) {
        <loc>https://chainlist.org/</loc>
      </url>
      ${chains
-       .map(({ networkId }) => {
+       .map(({ chainId }) => {
          return `
        <url>
-           <loc>${`${EXTERNAL_DATA_URL}/${networkId}`}</loc>
+           <loc>${`${EXTERNAL_DATA_URL}/${chainId}`}</loc>
        </url>
      `;
        })


### PR DESCRIPTION
Currently, chainlist accesses chaindata for a network by calling `networkId`, rather than `chainId`

1) this is a bug, as these are two different things (bug has gone undetected bc `chainId == networkId` in most EVM networks). This is not true for 31 of the networks in your data source (https://chainid.network/chains.json)

Some networks have equivalent networkIds but differing chainIds (most notably ethereumclassic, which has a `networkId=1`), where this proves to be a bug seen in two flows
- clicking on Ethereum Classic (or other networks w `networkId=1` from homepage directs user to Ethereum)
- https://chainlist.org/chain/61 (Ethereum Classic's chainId) returns internal server error

See side by side of bug fix below

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/39510610/183363508-95071ecf-5f30-4ab6-9796-11d1dd61809e.png">
