### PR TITLE
Added Chainstack endpoint to Fuse

### DIFF
--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -377,7 +377,8 @@
     "122": {
         "rpcs": [
             "https://fuse-rpc.gateway.pokt.network/",
-            "https://rpc.fuse.io"
+            "https://rpc.fuse.io",
+            "https://fuse-mainnet.chainstacklabs.com"
         ]
     },
     "336": {


### PR DESCRIPTION
Fuse recently got a high-performance public RPC from Chainstack, it has now been included on here to account.