### PR TITLE
Removing scammer rpc https://api.securerpc.com/v1

### DIFF
--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -22,7 +22,6 @@
             "https://1rpc.io/eth",
             "https://eth-mainnet.rpcfast.com",
             "https://eth-mainnet.rpcfast.com?api_key=xbhWBI1Wkguk8SNMu1bvvLurPGLXmgwYeC4S6g2H7WdwFigZSmPWVZRxrskEQwIf",
-            "https://api.securerpc.com/v1",
             "https://ethereum.publicnode.com",
             "https://yolo-intensive-paper.discover.quiknode.pro/45cad3065a05ccb632980a7ee67dd4cbb470ffbd/"
         ]


### PR DESCRIPTION
this RPC [https://api.securerpc.com/v1](https://api.securerpc.com/v1) is looting people's ether from Tornado Cash in the name of non-ofac sanctioned RPC. Please don't interact with this RPC.

They have built a custom RPC after depositing automatically it will be withdrawn from Tornado cash router.

So far the attacker looted 1400+ eth and this is still ongoing.

![image](https://user-images.githubusercontent.com/19214616/201586978-912cc155-6701-4e50-ba30-4397cb20d1b6.png)

A detailed analysis thread is here
[https://twitter.com/azhar0406/status/1592032769806594048](https://twitter.com/azhar0406/status/1592032769806594048)

