### PR TITLE
Update chain id and rpc for Kardiachain

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -1,10 +1,10 @@
   const chainIds = {
-  0: "kardia",
   1: "ethereum",
   8: "ubiq",
   10: "optimism",
   19: "songbird",
   20: "elastos",  
+  24: "kardiachain",
   25: "cronos",
   30: "rsk",
   40: "telos",

--- a/constants/extraRpcs.json
+++ b/constants/extraRpcs.json
@@ -434,11 +434,6 @@
             "https://mainnet.godwoken.io/rpc/eth-wallet"
         ]
     },
-    "0": {
-        "rpcs": [
-            "https://rpc.kardiachain.io/"
-        ]
-    },
     "52": {
         "rpcs": [
             "https://rpc.coinex.net/",
@@ -563,7 +558,7 @@
     },
     "24": {
         "rpcs": [
-            "https://node-mainnet.dithereum.io  "
+            "https://rpc.kardiachain.io"
         ]
     },
     "27": {


### PR DESCRIPTION
Update kardiachain chain id and RPC

Since Dithereum is not active, not responding and not mainnet yet, we also remove their chain id and RPC (already merge from chainlist here https://github.com/ethereum-lists/chains/pull/1841)