### PR TITLE
Filter out deprecated chains

### DIFF
--- a/pages/best-rpcs/[chain].js
+++ b/pages/best-rpcs/[chain].js
@@ -10,12 +10,14 @@ export async function getStaticProps({ params, locale }) {
 
   const chain = chains.find(
     (c) =>
+      (
       c.chainId?.toString() === params.chain ||
       c.chainId?.toString() ===
         Object.entries(chainIds).find(
           ([, name]) => params.chain === name
         )?.[0] ||
-      c.name === params.chain.split("%20").join(" ")
+      c.name.toLowerCase() === params.chain.toLowerCase().split("%20").join(" ")
+      ) && c.status?.toString() !== "deprecated" // remove deprecated
   );
 
   if (!chain) {

--- a/pages/chain/[chain].js
+++ b/pages/chain/[chain].js
@@ -17,12 +17,14 @@ export async function getStaticProps({ params, locale }) {
 
   const chain = chains.find(
     (c) =>
+      (
       c.chainId?.toString() === params.chain ||
       c.chainId?.toString() ===
         Object.entries(chainIds).find(
           ([, name]) => params.chain === name
         )?.[0] ||
       c.name.toLowerCase() === params.chain.toLowerCase().split("%20").join(" ")
+      ) && c.status?.toString() !== "deprecated" // remove deprecated
   );
 
   if (!chain) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,7 @@ export async function getStaticProps({ locale }) {
   const chainTvls = await fetcher("https://api.llama.fi/chains");
 
   const sortedChains = chains
+    .filter((c) => c.status !== "deprecated") // remove deprecated
     .filter((c) => c.name !== "420coin") // same chainId as ronin
     .map((chain) => populateChain(chain, chainTvls))
     .sort((a, b) => {
@@ -63,6 +64,7 @@ function Home({ changeTheme, theme, sortedChains }) {
             ? chains
             : chains.filter((chain) => {
                 //filter
+                console.log(search)
                 return (
                   chain.chain.toLowerCase().includes(search.toLowerCase()) ||
                   chain.chainId

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,7 +64,6 @@ function Home({ changeTheme, theme, sortedChains }) {
             ? chains
             : chains.filter((chain) => {
                 //filter
-                console.log(search)
                 return (
                   chain.chain.toLowerCase().includes(search.toLowerCase()) ||
                   chain.chainId

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -65,8 +65,11 @@ export async function getServerSideProps({ res }) {
   const request = await fetch('https://chainid.network/chains.json');
   const chains = await request.json();
 
+  var filteredChains = chains
+                    .filter((c) => c.status !== "deprecated") // remove deprecated
+
   // We generate the XML sitemap with the chains data
-  const sitemap = generateSiteMap(chains);
+  const sitemap = generateSiteMap(filteredChains);
 
   res.setHeader("Content-Type", "text/xml");
   // we send the XML to the browser

--- a/pages/top-rpcs/[chain].js
+++ b/pages/top-rpcs/[chain].js
@@ -10,12 +10,14 @@ export async function getStaticProps({ params, locale }) {
 
   const chain = chains.find(
     (c) =>
+      (
       c.chainId?.toString() === params.chain ||
       c.chainId?.toString() ===
         Object.entries(chainIds).find(
           ([, name]) => params.chain === name
         )?.[0] ||
-      c.name === params.chain.split("%20").join(" ")
+      c.name.toLowerCase() === params.chain.toLowerCase().split("%20").join(" ")
+      ) && c.status?.toString() !== "deprecated" // remove deprecated
   );
 
   if (!chain) {


### PR DESCRIPTION
[EVM-based Chains](https://github.com/ethereum-lists/chains) readme specifies:

> You can add a `status` field e.g. to `deprecate` a chain (a chain should never be deleted as this would open the door to replay attacks)
Other options for `status` are `active` (default) or `incubating`

I propose to filter out "deprecate" status chains.