### PR TITLE
Update extraRpcs.js - Flashbots RPC does not track

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -27,8 +27,7 @@ export default {
             },
             {
                 url: "https://rpc.flashbots.net/",
-                tracking: "yes",
-                trackingDetails: "Tracks IP address, device information, geolocation, signature, nationality and details relating to your Relay activity."
+                tracking: "none",
             },
             {
                 url: "https://cloudflare-eth.com/",


### PR DESCRIPTION
Flashbots RPC does not track. Can be confirmed in the codebase at https://github.com/flashbots/rpc-endpoint