### PR TITLE
Migrate sps mainnet into new rpc URI

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -154,7 +154,7 @@ export default {
         ]
     },
     //Rinkeby testnet deprecated
-    "4": { 
+    "4": {
         "rpcs": [
             "https://rpc.ankr.com/eth_rinkeby",
             "https://rinkeby.infura.io/3/9aa3d95b3bc440fa88ea12eaa4456161"
@@ -1502,7 +1502,7 @@ export default {
             "https://mainnet-rpc.ohoscan.com",
             "https://mainnet-rpc2.ohoscan.com"
         ]
-    },    
+    },
     "42069": {
         "rpcs": [
             "rpcWorking:false"
@@ -1918,7 +1918,7 @@ export default {
     },
     "13000": {
         "rpcs": [
-            "https://marketplace.ssquad.games",
+            "https://rpc.ssquad.games",
         ]
     },
     "14000": {


### PR DESCRIPTION
Hi team

The sps mainnet's rpc is migrated into

https://rpc.ssquad.games/

Thanks