### PR TITLE
Updating ETC Coop's public endpoints

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -846,8 +846,7 @@ export default {
   },
   61: {
     rpcs: [
-      "https://blockscout.com/etc/mainnet/api/eth-rpc",
-      "https://www.ethercluster.com/etc",
+      "https://etc.rivet.link",
       "https://etc.etcdesktop.com",
       "https://etc.mytokenpocket.vip",
       "https://besu-de.etc-network.info",


### PR DESCRIPTION
Ethercluster is being retired in favor of an endpoint being operated by Rivet.

Also the BlockScout ETC endpoint should never have been public.