### PR TITLE
Remove wrong rpc

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -45,7 +45,7 @@
   "1284": "moonbeam",
   "1285": "moonriver",
   "2000": "dogechain",
-  "2020": "ronin",
+  "2020": "publicmint",
   "2222": "kava",
   "4689": "iotex",
   "5050": "xlc",

--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -45,7 +45,6 @@
   "1284": "moonbeam",
   "1285": "moonriver",
   "2000": "dogechain",
-  "2020": "publicmint",
   "2222": "kava",
   "4689": "iotex",
   "5050": "xlc",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -865,9 +865,6 @@ export const extraRpcs = {
       "https://rpc.etcplanets.com",
     ],
   },
-  2020: {
-    rpcs: ["https://api.roninchain.com/rpc"],
-  },
   64: {
     rpcs: [],
     websiteDead: true,


### PR DESCRIPTION
Removing RPC for chain 2020 as it is not representing Public Mint chain.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://publicmint.com

#### Provide a link to your privacy policy:
https://publicmint.com/privacy-policy


#### If the RPC has none of the above and you still think it should be added, please explain why:


