### PR TITLE
Add BlockPI Public RPC on Ethereum

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -27,6 +27,8 @@ const privacyStatement = {
   zmok: `API requests - we do NOT store any usage data, additionally, we do not store your logs. No KYC - "Darknet" style of sign-up/sign-in. Only provider that provides Ethereum endpoints as TOR/Onion hidden service. Analytical data are stored only on the landing page/web.  https://zmok.io/privacy-policy`,
   infura:
     "We collect wallet and IP address information. The purpose of this collection is to ensure successful transaction propagation, execution, and other important service functionality such as load balancing and DDoS protection. IP addresses and wallet address data relating to a transaction are not stored together or in a way that allows our systems to associate those two pieces of data. We retain and delete user data such as IP address and wallet address pursuant to our data retention policy. https://consensys.net/blog/news/consensys-data-retention-update/",
+  blockpi:
+    "We do not collect request data or request origin. We only temporarily record the request method names and IP addresses for 7 days to ensure our service functionality such as load balancing and DDoS protection. All the data is automatically deleted after 7 days and we do not store any user information for longer periods of time. https://blockpi.io/privacy-policy",
 };
 
 export const extraRpcs = {
@@ -109,6 +111,11 @@ export const extraRpcs = {
       {
         url: "https://eth-mainnet-public.unifra.io",
         tracking: "unspecified",
+      },
+      {
+        url: "https://ethereum.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
       },
       // Distributed cluster of Ethereum nodes designed for speed and anonymity!
       {


### PR DESCRIPTION
Add BlockPI Public RPC on Ethereum from https://public.blockpi.io/

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockpi.io/

#### Provide a link to your privacy policy:
https://blockpi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:


