### PR TITLE
Adding more public RPCs from BlockPI

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -181,6 +181,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
       },
+      {
+        url: "https://polygon-mumbai.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   //Rinkeby testnet deprecated
@@ -321,6 +326,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
+      {
+        url: "https://bsc.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   97: {
@@ -442,6 +452,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
       },
+      {
+        url: "https://polygon.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   25: {
@@ -482,6 +497,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
       },
+      {
+        url: "https://arbitrum.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   421613: {
@@ -495,6 +515,11 @@ export const extraRpcs = {
         url: "https://arb-goerli.g.alchemy.com/v2/demo",
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
+      },
+      {
+        url: "https://goerli.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
       },
     ],
   },
@@ -510,6 +535,11 @@ export const extraRpcs = {
       "https://klaytn04.fandom.finance",
       "https://klaytn05.fandom.finance",
       "https://cypress.fandom.finance/archive",
+      {
+        url: "https://klaytn.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   1666600000: {
@@ -584,6 +614,11 @@ export const extraRpcs = {
         url: "https://opt-mainnet.g.alchemy.com/v2/demo",
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
+      },
+      {
+        url: "https://optimism.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
       },
     ],
   },


### PR DESCRIPTION
Adding more public RPCs from BlockPI https://public.blockpi.io/

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockpi.io/

#### Provide a link to your privacy policy:
https://public.blockpi.io/

#### If the RPC has none of the above and you still think it should be added, please explain why:
