### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -751,6 +751,7 @@ export const extraRpcs = {
       "https://fuse-rpc.gateway.pokt.network/",
       "https://rpc.fuse.io",
       "https://fuse-mainnet.chainstacklabs.com",
+      "https://fuserpc.app.runonflux.io/",
     ],
   },
   336: {


### PR DESCRIPTION
**Adding a public Fuse RPC endpoint hosted on the decentralized Flux Web3 Cloud.**

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

The RPC Node is hosted using the service of the Flux Cloud at https://runonflux.io/, https://jetpack2.app.runonflux.io

#### Provide a link to your privacy policy: https://runonflux.io/privacy-policy.html

#### If the RPC has none of the above and you still think it should be added, please explain why:


