### PR TITLE
Add GasHawk to Mainnet RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -31,6 +31,8 @@ const privacyStatement = {
     "All the data and metadata remain private to the users. No third party is able to access, analyze or track it. OMNIA leverages different technologies and approaches to guarantee the privacy of their users, from front-running protection and private mempools, to obfuscation and random dispatching. https://blog.omniatech.io/how-omnia-handles-your-personal-data",
   blockpi:
     "We do not collect request data or request origin. We only temporarily record the request method names and IP addresses for 7 days to ensure our service functionality such as load balancing and DDoS protection. All the data is automatically deleted after 7 days and we do not store any user information for longer periods of time. https://blockpi.io/privacy-policy",
+  gashawk:
+    "Sign-in with Ethereum on https://www.gashawk.io required prior to use. We may collect information that is publicly available in a blockchain when providing our services, such as: Public wallet identifier of the sender and recipient of a transaction, Unique identifier for a transaction, Date and time of a transaction, Transaction value, along with associated costs, Status of a transaction (such as whether the transaction is complete, in-progress, or resulted in an error), read the terms of service https://www.gashawk.io/#/terms and the privacy policy https://www.gashawk.io/#/privacy.",
 };
 
 export const extraRpcs = {
@@ -134,6 +136,11 @@ export const extraRpcs = {
         url: "https://eth-mainnet.g.alchemy.com/v2/demo",
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
+      },
+      {
+        url: "https://beta-be.gashawk.io:3001/proxy/rpc",
+        tracking: "yes",
+        trackingDetails: privacyStatement.gashawk,
       },
       // "http://127.0.0.1:8545",
 


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.gashawk.io

#### Provide a link to your privacy policy:
https://www.gashawk.io/#/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
Both of the above available. GasHawk helps saving on TX cost by scheduling transactions to times of lower network fees - BUT: GasHawk needs a sign-in with the Ethereum address prior to usage. 

