### PR TITLE
Add BearNetwork RPC 

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1679,7 +1679,7 @@ export const extraRpcs = {
       "https://brnkc-mainnet1.bearnetwork.net",
       tracking: "yes",
       trackingDetails: privacyStatement.nodereal,
-      },
+      }
     ],
   },
 };

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1670,14 +1670,12 @@ export const extraRpcs = {
   },
   641230: {
     rpcs: [
-      {
       "https://brnkc-mainnet.bearnetwork.net",
       "https://brnkc-mainnet1.bearnetwork.net",
-      },
       {
-      tracking: "yes",
-      trackingDetails: privacyStatement.nodereal,
-      }
+        url: "https://bearnetwork.net",
+        tracking: "yes",
+        trackingDetails: privacyStatement.nodereal,
       },
     ],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1672,14 +1672,13 @@ export const extraRpcs = {
     rpcs: [
       {
       "https://brnkc-mainnet.bearnetwork.net",
-      tracking: "yes",
-      trackingDetails: privacyStatement.nodereal,
+      "https://brnkc-mainnet1.bearnetwork.net",
       },
       {
-      "https://brnkc-mainnet1.bearnetwork.net",
       tracking: "yes",
       trackingDetails: privacyStatement.nodereal,
       }
+      },
     ],
   },
 };

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1672,10 +1672,14 @@ export const extraRpcs = {
     rpcs: [
       {
       "https://brnkc-mainnet.bearnetwork.net",
+      tracking: "yes",
+      trackingDetails: privacyStatement.nodereal,
+      },
+      {
       "https://brnkc-mainnet1.bearnetwork.net",
       tracking: "yes",
       trackingDetails: privacyStatement.nodereal,
-      }
+      },
     ],
   },
 };

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1670,8 +1670,12 @@ export const extraRpcs = {
   },
   641230: {
     rpcs: [
+      {
       "https://brnkc-mainnet.bearnetwork.net",
       "https://brnkc-mainnet1.bearnetwork.net",
+      tracking: "yes",
+      trackingDetails: privacyStatement.nodereal,
+      }
     ],
   },
 };

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1668,6 +1668,12 @@ export const extraRpcs = {
     rpcWorking: false,
     websiteDead: true,
   },
+  641230: {
+    rpcs: [
+      "https://brnkc-mainnet.bearnetwork.net",
+      "https://brnkc-mainnet1.bearnetwork.net",
+    ],
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):

individual : Bear Network Chain

Web1 : https://bearnetwork.net/

Web2: https://docs.bearnetwork.net/

RPC: https://brnkc-mainnet.bearnetwork.net/

RPC: https://brnkc-mainnet1.bearnetwork.net/

Provide a link to your privacy policy:
https://bearnetwork.net/privacy-policy/

If the RPC has none of the above and you still think it should be added, please explain why: