### PR TITLE
Add payload.de RPC & privacy policy to the Ethereum extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -32,7 +32,7 @@ const privacyStatement = {
   blockpi:
     "We do not collect request data or request origin. We only temporarily record the request method names and IP addresses for 7 days to ensure our service functionality such as load balancing and DDoS protection. All the data is automatically deleted after 7 days and we do not store any user information for longer periods of time. https://blockpi.io/privacy-policy",
   payload:
-    "Sent transactions are private: https://payload.de/docs. By default, no data is collected when using the RPC endpoint. If provided by the user, the public address for authentication is captured when using the RPC endpoint in order to prioritize requests under high load. This information is optional and solely provided at the user's discretion. https://payload.de/privacy/"
+    "Sent transactions are private: https://payload.de/docs. By default, no data is collected when using the RPC endpoint. If provided by the user, the public address for authentication is captured when using the RPC endpoint in order to prioritize requests under high load. This information is optional and solely provided at the user's discretion. https://payload.de/privacy/",
 };
 
 export const extraRpcs = {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -31,6 +31,8 @@ const privacyStatement = {
     "All the data and metadata remain private to the users. No third party is able to access, analyze or track it. OMNIA leverages different technologies and approaches to guarantee the privacy of their users, from front-running protection and private mempools, to obfuscation and random dispatching. https://blog.omniatech.io/how-omnia-handles-your-personal-data",
   blockpi:
     "We do not collect request data or request origin. We only temporarily record the request method names and IP addresses for 7 days to ensure our service functionality such as load balancing and DDoS protection. All the data is automatically deleted after 7 days and we do not store any user information for longer periods of time. https://blockpi.io/privacy-policy",
+  payload:
+    "Sent transactions are private: https://payload.de/docs. By default, no data is collected when using the RPC endpoint. If provided by the user, the public address for authentication is captured when using the RPC endpoint in order to prioritize requests under high load. This information is optional and solely provided at the user's discretion. https://payload.de/privacy/"
 };
 
 export const extraRpcs = {
@@ -123,6 +125,11 @@ export const extraRpcs = {
         url: "https://ethereum.blockpi.network/v1/rpc/public",
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
+      },
+      {
+        url: "https://rpc.payload.de",
+        tracking: "none",
+        trackingDetails: privacyStatement.payload,
       },
       // Distributed cluster of Ethereum nodes designed for speed and anonymity!
       {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

`https://payload.de`


#### Provide a link to your privacy policy:

`https://payload.de/privacy/`




