### PR TITLE
Dark mode

### DIFF
--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -1,11 +1,36 @@
 import * as React from "react";
+import { useEffect } from "react";
 import Header from "../header";
 // import { useTranslations } from "next-intl";
 import { notTranslation as useTranslations } from "../../utils";
 import Logo from "./Logo";
 import { useRouter } from "next/router";
 
+const toggleTheme = (e) => {
+  e.preventDefault();
+  const element = document.body;
+  document.getElementById("theme-toggle-dark-icon").classList.toggle("hidden");
+  document.getElementById("theme-toggle-light-icon").classList.toggle("hidden");
+  const result = element.classList.toggle("dark");
+  localStorage.setItem('theme', result ? 'dark' : 'light');
+}
+
+const initTheme = () => {
+  const element = document.body;
+  if(element.classList.contains('dark')) {
+    document.getElementById("theme-toggle-light-icon").classList.remove("hidden");
+  }
+  else {
+    document.getElementById("theme-toggle-dark-icon").classList.remove("hidden");
+  }
+}
+
+
 export default function Layout({ children, lang }) {
+  useEffect(() => {
+    initTheme();
+  }, []);
+
   const t = useTranslations("Common", lang);
 
   const router = useRouter();
@@ -16,7 +41,7 @@ export default function Layout({ children, lang }) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[40vw,_auto]">
-      <div className="relative h-full">
+      <div className="dark:text-[#B3B3B3] text-black dark:bg-[#0D0D0D] bg-white relative h-full">
         <div className="p-5 sticky top-0 bottom-0 m-auto flex flex-col items-center gap-8 justify-center h-screen max-w-[480px] mx-auto">
           <figure className="lg:mr-auto">
             <Logo />
@@ -27,7 +52,7 @@ export default function Layout({ children, lang }) {
 
           <div className="flex flex-col gap-4 w-full">
             <a
-              className="flex items-center justify-center mx-auto lg:ml-0 gap-2 rounded-[50px] max-w-[16.25rem] font-medium py-[18px] px-6 shadow-lg w-full bg-[#2F80ED] text-white"
+              className="flex items-center justify-center mx-auto lg:ml-0 gap-2 rounded-[50px] max-w-[16.25rem] font-medium py-[18px] px-6 shadow-lg w-full dark:bg-[#2F80ED] bg-[#2F80ED] dark:text-black text-white"
               href="https://github.com/ethereum-lists/chains"
               target="_blank"
               rel="noopener noreferrer"
@@ -46,7 +71,7 @@ export default function Layout({ children, lang }) {
             </a>
 
             <a
-              className="flex items-center justify-center mx-auto lg:ml-0 gap-2 rounded-[50px] max-w-[16.25rem] font-medium py-[17px] px-6 w-full bg-white text-[#2F80ED] border border-[#EAEAEA]"
+              className="flex items-center justify-center mx-auto lg:ml-0 gap-2 rounded-[50px] max-w-[16.25rem] font-medium py-[17px] px-6 w-full dark:bg-[#0D0D0D] bg-white dark:text-[#2F80ED] text-[#2F80ED] border dark:border-[#171717] border-[#EAEAEA]"
               href="https://github.com/DefiLlama/chainlist/blob/main/constants/extraRpcs.js"
               target="_blank"
               rel="noopener noreferrer"
@@ -79,9 +104,42 @@ export default function Layout({ children, lang }) {
             </svg>
             <span className="text-base font-medium">{t("view-source-code")}</span>
           </a>
+
+          <a
+            className="flex items-center gap-2 mx-auto lg:ml-0"
+            href="#"
+            onClick={toggleTheme}
+            id="theme-toggle"
+          >
+            <svg
+              id="theme-toggle-dark-icon"
+              class="w-5 h-5 hidden"
+              fill="#2F80ED"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
+              ></path>
+            </svg>
+            <svg
+              id="theme-toggle-light-icon"
+              class="w-5 h-5 hidden"
+              fill="#2F80ED"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+              ></path>
+            </svg>
+            <span className="text-base font-medium">{t("toggle-theme")}</span>
+          </a>
         </div>
       </div>
-      <div className="bg-[#f3f3f3] p-5 relative flex flex-col gap-5">
+      <div className="dark:bg-[#181818] bg-[#f3f3f3] p-5 relative flex flex-col gap-5">
         <Header lang={lang} chainName={chainName} key={chainName} />
 
         {children}

--- a/components/RPCList/index.js
+++ b/components/RPCList/index.js
@@ -82,7 +82,7 @@ export default function RPCList({ chain, lang }) {
   const isEthMainnet = chain?.name === "Ethereum Mainnet";
 
   return (
-    <div className="shadow bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden col-span-full relative overflow-x-auto">
+    <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden col-span-full relative overflow-x-auto">
       {isEthMainnet && (
         <p className="text-center">
           Follow{" "}
@@ -98,11 +98,11 @@ export default function RPCList({ chain, lang }) {
         </p>
       )}
 
-      <table className="m-0 border-collapse whitespace-nowrap">
+      <table className="m-0 border-collapse space-nowrap dark:text-[#B3B3B3] text-black">
         <caption className="relative w-full px-3 py-1 text-base font-medium border border-b-0">
           <span className="mr-4">{`${chain.name} RPC URL List`}</span>
           <button
-            className="text-sm font-normal flex items-center gap-1 absolute right-4 top-[2px] bottom-[2px] hover:bg-[#EAEAEA] px-2 rounded-[10px]"
+            className="text-sm font-normal flex items-center gap-1 absolute right-4 top-[2px] bottom-[2px] dark:hover:bg-[#171717] hover:bg-[#EAEAEA] px-2 rounded-[10px]"
             onClick={() => setSorting(!sortChains)}
           >
             {sortChains ? (
@@ -139,7 +139,7 @@ export default function RPCList({ chain, lang }) {
             let className = 'bg-inherit';
 
             if (hasLlamaNodesRpc && index === 0) {
-              className = 'bg-[#F9F9F9]';
+              className = 'dark:bg-[#0D0D0D] bg-[#F9F9F9]';
             }
 
             return (
@@ -161,7 +161,7 @@ export default function RPCList({ chain, lang }) {
 }
 
 const Shimmer = () => {
-  return <div className="rounded h-5 w-full min-w-[40px] animate-pulse bg-[#EAEAEA]"></div>;
+  return <div className="rounded h-5 w-full min-w-[40px] animate-pulse dark:bg-[#171717] bg-[#EAEAEA]"></div>;
 };
 
 function PrivacyIcon({ tracking, isOpenSource = false }) {
@@ -205,7 +205,7 @@ const Row = ({ values, chain, isEthMainnet, privacy, lang, className }) => {
 
   return (
     <tr className={className}>
-      <td className="border px-3 text-sm py-1 max-w-[40ch] overflow-hidden whitespace-nowrap text-ellipsis">
+      <td className="border px-3 text-sm py-1 max-w-[40ch] overflow-hidden space-nowrap text-ellipsis">
         {isLoading ? <Shimmer /> : data?.url}
       </td>
       <td className="px-3 py-1 text-sm text-center border">{isLoading ? <Shimmer /> : data?.height}</td>
@@ -240,7 +240,7 @@ const Row = ({ values, chain, isEthMainnet, privacy, lang, className }) => {
             ) : (
               !data.disableConnect && (
                 <button
-                  className="px-2 py-[2px] -my-[2px] text-center text-sm hover:bg-[#EAEAEA] rounded-[50px]"
+                  className="px-2 py-[2px] -my-[2px] text-center text-sm dark:hover:bg-[#171717] hover:bg-[#EAEAEA] rounded-[50px]"
                   onClick={() => addToNetwork({ address, chain, rpc: data?.url })}
                 >
                   {t(renderProviderText(account))}
@@ -267,7 +267,7 @@ const CopyUrl = ({ url = "" }) => {
 
   return (
     <button
-      className="px-2 py-[2px] -my-[2px] text-sm hover:bg-[#EAEAEA] rounded-[50px] mx-auto"
+      className="px-2 py-[2px] -my-[2px] text-sm dark:hover:bg-[#171717] hover:bg-[#EAEAEA] rounded-[50px] mx-auto"
       onClick={handleCopy}
     >
       {!hasCopied ? 'Copy URL' : 'Copied!'}

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -44,7 +44,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
   if (buttonOnly) {
     return (
       <button
-        className="border border-[#EAEAEA] px-4 py-2 rounded-[50px] text-[#2F80ED] hover:text-white hover:bg-[#2F80ED] w-fit mx-auto"
+        className="border dark:border-[#171717] border-[#EAEAEA] px-4 py-2 rounded-[50px] dark:text-[#2F80ED] text-[#2F80ED] dark:hover:text-black hover:text-white dark:hover:bg-[#2F80ED] hover:bg-[#2F80ED] w-fit mx-auto"
         onClick={() => addToNetwork({ address, chain })}
       >
         {t(renderProviderText(address))}
@@ -54,7 +54,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
 
   return (
     <>
-      <div className="shadow bg-white p-8 pb-0 rounded-[10px] flex flex-col gap-3 overflow-hidden" key={chain.chainId}>
+      <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 pb-0 rounded-[10px] flex flex-col gap-3 overflow-hidden" key={chain.chainId}>
         <Link href={`/chain/${chain.chainId}`} prefetch={false} className="flex items-center mx-auto gap-2">
           <img
             src={icon}
@@ -63,7 +63,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
             className="rounded-full flex-shrink-0 flex relative"
             alt={chain.name + " logo"}
           />
-          <span className="text-xl font-semibold whitespace-nowrap overflow-hidden text-ellipsis relative top-[1px]">
+          <span className="text-xl font-semibold space-nowrap overflow-hidden text-ellipsis relative top-[1px] dark:text-[#B3B3B3]">
             {chain.name}
           </span>
         </Link>
@@ -71,14 +71,14 @@ export default function Chain({ chain, buttonOnly, lang }) {
         <table>
           <thead>
             <tr>
-              <th className="font-normal text-gray-500">ChainID</th>
-              <th className="font-normal text-gray-500">{t("currency")}</th>
+              <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
+              <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td className="text-center font-bold px-4">{chain.chainId}</td>
-              <td className="text-center font-bold px-4">
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">{chain.chainId}</td>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
               </td>
             </tr>
@@ -86,7 +86,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
         </table>
 
         <button
-          className="border border-[#EAEAEA] px-4 py-2 rounded-[50px] mb-auto text-[#2F80ED] hover:text-white hover:bg-[#2F80ED] w-fit mx-auto"
+          className="border dark:border-[#171717] border-[#EAEAEA] px-4 py-2 rounded-[50px] mb-auto dark:text-[#2F80ED] text-[#2F80ED] dark:hover:text-black hover:text-white dark:hover:bg-[#2F80ED] hover:bg-[#2F80ED] w-fit mx-auto"
           onClick={() => addToNetwork({ address, chain })}
         >
           {t(renderProviderText(address))}
@@ -94,7 +94,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
 
         {(lang === "en" ? router.pathname === "/" : router.pathname === "/zh") && (
           <button
-            className="w-full rounded-[50px] p-2 flex items-center mb-2 justify-center hover:bg-[#f6f6f6]"
+            className="w-full rounded-[50px] p-2 flex items-center mb-2 justify-center dark:hover:bg-[#0D0D0D] hover:bg-[#f6f6f6]"
             onClick={handleClick}
           >
             <span className="sr-only">Show RPC List of {chain.name}</span>

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -59,25 +59,24 @@ function Header({ lang, chainName }) {
   const address = accountData?.address ?? null;
 
   return (
-    <div className="sticky top-0 z-50 rounded-[10px] bg-[#f3f3f3] p-5 -m-5">
+    <div className="sticky top-0 z-50 rounded-[10px] dark:bg-[#181818] bg-[#f3f3f3] p-5 -m-5">
       <header className="flex items-end gap-2 w-full sticky top-4 shadow rounded-[10px] z-50">
-        <div className="flex flex-col bg-white rounded-[10px] flex-1">
+        <div className="flex flex-col dark:bg-[#0D0D0D] bg-white rounded-[10px] flex-1">
           <div className="rounded-t-[10px] shadow-sm">
-            <label className="flex sm:items-center flex-col sm:flex-row focus-within:ring-2 ring-[#2F80ED] rounded-t-[10px]">
-              <span className="font-bold text-sm whitespace-nowrap px-3 pt-4 sm:pt-0">{t("search-networks")}</span>
+            <label className="flex sm:items-center flex-col sm:flex-row focus-within:ring-2 dark:ring-[#2F80ED] ring-[#2F80ED] rounded-t-[10px]">
+              <span className="font-bold text-sm dark:text-[#B3B3B3] text-black space-nowrap px-3 pt-4 sm:pt-0">{t("search-networks")}</span>
               <input
                 placeholder="ETH, Fantom, ..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="flex-1 px-3 sm:px-2 pb-4 pt-2 sm:py-4 outline-none"
+                className="dark:bg-[#0D0D0D] bg-white dark:text-[#B3B3B3] text-black flex-1 px-3 sm:px-2 pb-4 pt-2 sm:py-4 outline-none"
               />
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
                 strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-4 h-4 mr-3 hidden sm:block"
+                className="dark:stroke-[#B3B3B3] stroke-black w-4 h-4 mr-3 hidden sm:block"
               >
                 <path
                   strokeLinecap="round"
@@ -87,14 +86,14 @@ function Header({ lang, chainName }) {
               </svg>
             </label>
           </div>
-          <div className="py-2 px-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="dark:text-[#B3B3B3] text-black py-2 px-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <label className="flex items-center gap-2">
               <input type="checkbox" name="testnets" checked={includeTestnets} onChange={toggleTestnets} />
               <span>Include Testnets</span>
             </label>
 
             <button
-              className="flex gap-2 items-center bg-[#DEDEDE] justify-center rounded-[10px] py-[8px] px-8 font-medium text-black"
+              className="flex gap-2 items-center dark:bg-[#212121] bg-[#DEDEDE] justify-center rounded-[10px] py-[8px] px-8 font-medium dark:text-[#B3B3B3] text-black"
               onClick={connectWallet}
             >
               {address ? (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,6 +3,16 @@ import React from "react";
 
 const LANGUAGES = ["en", "zh"];
 
+function presetTheme() {
+  const dark = localStorage.getItem("theme") === "dark";
+
+  if (dark) {
+    document.body.classList.add("dark");
+  }
+}
+
+const themeScript = `(() => { ${presetTheme.toString()}; presetTheme() })()`;
+
 class MyDocument extends Document {
   render() {
     const pathPrefix = this.props.__NEXT_DATA__.page.split("/")[1];
@@ -12,6 +22,7 @@ class MyDocument extends Document {
       <Html lang={lang}>
         <Head />
         <body>
+          <script dangerouslySetInnerHTML={{ __html: themeScript, }} />
           <Main />
           <NextScript />
         </body>

--- a/pages/chain/[chain].js
+++ b/pages/chain/[chain].js
@@ -76,7 +76,7 @@ function Chain({ chain }) {
       </Head>
 
       <Layout lang="en">
-        <div className="shadow bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden">
+        <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden">
           <Link href={`/chain/${chain.chainId}`} prefetch={false} className="flex items-center mx-auto gap-2">
             <img
               src={icon}
@@ -85,20 +85,20 @@ function Chain({ chain }) {
               className="rounded-full flex-shrink-0 flex relative"
               alt={chain.name + " logo"}
             />
-            <span className="text-xl font-semibold overflow-hidden text-ellipsis relative top-[1px]">{chain.name}</span>
+            <span className="text-xl font-semibold overflow-hidden text-ellipsis relative top-[1px] dark:text-[#B3B3B3]">{chain.name}</span>
           </Link>
 
           <table>
             <thead>
               <tr>
-                <th className="font-normal text-gray-500">ChainID</th>
-                <th className="font-normal text-gray-500">{t("currency")}</th>
+                <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
+                <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="text-center font-bold px-4">{chain.chainId}</td>
-                <td className="text-center font-bold px-4">
+                <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">{chain.chainId}</td>
+                <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                   {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
                 </td>
               </tr>

--- a/pages/index.js
+++ b/pages/index.js
@@ -72,7 +72,7 @@ function Home({ chains }) {
 
       <Layout>
         <React.Suspense fallback={<div className="h-screen"></div>}>
-          <div className="grid gap-5 grid-cols-1 place-content-between pb-4 sm:pb-10 sm:grid-cols-[repeat(auto-fit,_calc(50%_-_15px))] 3xl:grid-cols-[repeat(auto-fit,_calc(33%_-_20px))] isolate grid-flow-dense">
+          <div className="dark:text-[#B3B3B3] text-black grid gap-5 grid-cols-1 place-content-between pb-4 sm:pb-10 sm:grid-cols-[repeat(auto-fit,_calc(50%_-_15px))] 3xl:grid-cols-[repeat(auto-fit,_calc(33%_-_20px))] isolate grid-flow-dense">
             {filteredChains.map((chain, idx) => (
               <Chain chain={chain} key={idx} lang="en" />
             ))}

--- a/pages/zh/chain/[chain].js
+++ b/pages/zh/chain/[chain].js
@@ -76,7 +76,7 @@ function Chain({ chain }) {
       </Head>
 
       <Layout lang="zh">
-        <div className="shadow bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden">
+        <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden">
           <Link href={`/chain/${chain.chainId}`} prefetch={false} className="flex items-center mx-auto gap-2">
             <img
               src={icon}
@@ -85,20 +85,20 @@ function Chain({ chain }) {
               className="rounded-full flex-shrink-0 flex relative"
               alt={chain.name + " logo"}
             />
-            <span className="text-xl font-semibold overflow-hidden text-ellipsis relative top-[1px]">{chain.name}</span>
+            <span className="text-xl font-semibold overflow-hidden text-ellipsis relative top-[1px] dark:text-[#B3B3B3]">{chain.name}</span>
           </Link>
 
           <table>
             <thead>
               <tr>
-                <th className="font-normal text-gray-500">ChainID</th>
-                <th className="font-normal text-gray-500">{t("currency")}</th>
+                <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
+                <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="text-center font-bold px-4">{chain.chainId}</td>
-                <td className="text-center font-bold px-4">
+                <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">{chain.chainId}</td>
+                <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                   {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
                 </td>
               </tr>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {

--- a/translations/en.json
+++ b/translations/en.json
@@ -16,6 +16,7 @@
     "add-to-brave": "Add to Brave",
     "add-to-coinbase": "Add to Coinbase Wallet",
     "add-to-trust": "Add to Trust Wallet",
-    "no-privacy-info": "No privacy info"
+    "no-privacy-info": "No privacy info",
+    "toggle-theme": "Toggle Theme"
   }
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -12,6 +12,7 @@
     "language": "English",
     "add-to-metamask": "添加到Metamask",
     "add-to-imToken": "添加到imToken",
-    "add-to-wallet": "添加到Wallet"
+    "add-to-wallet": "添加到Wallet",
+    "toggle-theme": "Toggle Theme"
   }
 }


### PR DESCRIPTION
This adds togglable dark mode to the site. It uses Tailwinds Dark Mode functionality with the `dark`-prefix to classes, triggered by finding a class `dark` higher in the hierarchy (instead of auto-triggering based on OS-preference).

It is manually (visually) tested on most pages I'm able to find. It mostly adds `dark:text-...`,  `dark:hover:text-...` and `dark:bg-...`, but also some `text-...` and similar, as it would otherwise display poorly in light mode.

It relies on some `dangerouslySetInnerHTML`-functionality in `_document.js` to get flicker-free dark theme when loading.

It lacks translation of the string "Toggle Theme" for `zh`.