### PR TITLE
RPC endpoint

### DIFF
--- a/pages/api/chain/[chain].js
+++ b/pages/api/chain/[chain].js
@@ -1,0 +1,29 @@
+import { fetcher, populateChain, arrayMove } from "../../../utils";
+import { llamaNodesRpcs } from "../../../constants/llamaNodesRpcs";
+
+export default async function handler(req, res) {
+  const { chain: chainIdOrName } = req.query;
+
+  if (req.method === "GET") {
+    const chains = await fetcher("https://chainid.network/chains.json");
+
+    let chain = chains.find((chain) => chain.chainId.toString() === chainIdOrName || chain.shortName === chainIdOrName);
+    if (!chain) {
+      return res.status(404).json({ message: "chain not found" });
+    }
+
+    chain = populateChain(chain, []);
+
+    const llamaNodesRpc = llamaNodesRpcs[chain.chainId] ?? null;
+
+    if (llamaNodesRpc) {
+      const llamaNodesRpcIndex = chain.rpc.findIndex((rpc) => rpc.url === llamaNodesRpc.rpcs[0].url);
+
+      if (llamaNodesRpcIndex || llamaNodesRpcIndex === 0) {
+        chain.rpc = arrayMove(chain.rpc, llamaNodesRpcIndex, 0);
+      }
+    }
+
+    return res.status(200).json(chain);
+  }
+}

--- a/pages/api/chain/[chain].js
+++ b/pages/api/chain/[chain].js
@@ -2,6 +2,8 @@ import { fetcher, populateChain, arrayMove } from "../../../utils";
 import { llamaNodesRpcs } from "../../../constants/llamaNodesRpcs";
 
 export default async function handler(req, res) {
+  res.setHeader("Cache-Control", "s-maxage=3600, stale-while-revalidate");
+
   const { chain: chainIdOrName } = req.query;
 
   if (req.method === "GET") {


### PR DESCRIPTION
Add endpoint to return Chain RPC data by slug or chain id. 

This allows users to dynamically pull and use the list of public RPC for a specific chain.

I wanted to update `pages/chain/[chain].js` but we can't return a JSON page from `getStaticProps`. We could also simply upload the json file in `/public` but we'd need a cron to update them on a regular basis so that's why I added this endpoint.

Note: we'll need to enable CORS access if we want people to access this API endpoint from the outside. 

ex:

```
GET https://chainid.network/api/chain/1
GET https://chainid.network/api/chain/eth
```