### PR TITLE
Add another RPC for wanchain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -870,7 +870,7 @@ export const extraRpcs = {
     ],
   },
   888: {
-    rpcs: ["https://gwan-ssl.wandevs.org:56891"],
+    rpcs: ["https://gwan-ssl.wandevs.org:56891","https://gwan2-ssl.wandevs.org"],
   },
   106: {
     rpcs: [


### PR DESCRIPTION
Add another Wanchain Rpc running in Flux OS.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://runonflux.io

#### Provide a link to your privacy policy:
https://github.com/wanchain/go-wanchain/blob/develop/COPYING

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is an unrestricted open RPC service created by wanchain official and flux in cooperation.
This is the wanchain official tweet about this:
https://twitter.com/wanchain_org/status/1621132361785135105?s=20&t=u2v8W54QozWrzJyPzc3CoA
