### PR TITLE
Rootstock rebranding

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -6,7 +6,7 @@
   "20": "elastos",
   "24": "kardiachain",
   "25": "cronos",
-  "30": "rsk",
+  "30": "rootstock",
   "40": "telos",
   "50": "xdc",
   "52": "csc",


### PR DESCRIPTION
Changes "rsk" to "rootstock".  Also see https://github.com/DefiLlama/icons/pull/138