### PR TITLE
delete non-ssl rpcs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1134,14 +1134,6 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc.novanetwork.io:9070",
       "https://dev.rpc.novanetwork.io/",
-      "http://dataseed-0.rpc.novanetwork.io:8545/",
-      "http://dataseed-1.rpc.novanetwork.io:8545/",
-      "http://dataseed-2.rpc.novanetwork.io:8545/",
-      "http://dataseed-3.rpc.novanetwork.io:8545/",
-      "http://dataseed-4.rpc.novanetwork.io:8545/",
-      "http://dataseed-5.rpc.novanetwork.io:8545/",
-      "http://dataseed-6.rpc.novanetwork.io:8545/",
-      "http://dataseed-f.rpc.novanetwork.io:8545/",
     ],
   },
   90: {


### PR DESCRIPTION
With the new archive node available, the old http RPCs became redundant.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:


