### PR TITLE
Add PublicNode RPC Endpoints for Fantom & BSC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -398,6 +398,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality
       },
+      {
+        url: "https://bsc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
     ],
   },
   97: {
@@ -508,6 +513,11 @@ export const extraRpcs = {
         url: "https://fantom.blockpi.network/v1/rpc/public",
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
+      },
+      {
+        url: "https://fantom.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://www.publicnode.com (RPC is not new. Already presented in Polygon, Ethereum, Avalanche, Evmos)

#### Provide a link to your privacy policy:

https://www.publicnode.com/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:


