### PR TITLE
Add Blast

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -616,6 +616,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+        url: "https://arbitrum-one.public.blastapi.io",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blastapi,
+      },
     ],
   },
   421613: {
@@ -630,10 +635,22 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
       },
+      {
+        url: "https://arbitrum-goerli.public.blastapi.io",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blastapi,
+      },
     ],
   },
   42170: {
-    rpcs: ["https://nova.arbitrum.io/rpc"],
+    rpcs: [
+       "https://nova.arbitrum.io/rpc",
+      {
+        url: "https://arbitrum-nova.public.blastapi.io",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blastapi,
+      },
+     ],
   },
   8217: {
     rpcs: [


### PR DESCRIPTION
Added Blast for Arbitrum blockchains.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blastapi.io/

#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:


