### PR TITLE
Remove the Omnia RPC on Arbitrum

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -597,11 +597,6 @@ export const extraRpcs = {
   },
   42161: {
     rpcs: [
-      {
-        url: "https://endpoints.omniatech.io/v1/arbitrum/one/public",
-        tracking: "none",
-        trackingDetails: privacyStatement.omnia,
-      },
       "https://arb1.arbitrum.io/rpc",
       {
         url: "https://rpc.ankr.com/arbitrum",


### PR DESCRIPTION
I don't know if this is happening only to me, but for some reason when I submit a transaction to Arbitrum using the Omnia RPC it fails with the following error:

```
MetaMask - RPC Error: [ethjs-query] while formatting outputs from RPC '{"value":{}}'
```

The transactions also appear as failed on Metamask:

![Screenshot 2023-03-13 at 11 59 05](https://user-images.githubusercontent.com/11708035/224682906-53c722fb-1a73-4406-8812-2caaff0b6ad2.png)

However, when they show as successful on Arbiscan. As you can see from the screenshot, this happens with every dApp. Whether the transaction originated from `localhost:3000` or `arbiscan.io`, it shows as failed (but all succeeded).

This error doesn't happen with the official Arbitrum RPC endpoint. I suggest to remove the Omnia endpoint.

Does anyone else have the same error?