### PR TITLE
Add an RPC for Edgeware

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1548,7 +1548,7 @@ export const extraRpcs = {
     ],
   },
   2021: {
-    rpcs: ["https://mainnet2.edgewa.re/evm", "https://mainnet3.edgewa.re/evm"],
+    rpcs: ["https://mainnet2.edgewa.re/evm", "https://mainnet3.edgewa.re/evm", "https://edgeware-evm.jelliedowl.net/"],
   },
   2025: {
     rpcs: ["https://mainnet.rangersprotocol.com/api/jsonrpc"],


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://gov.edgewa.re/discussion/6607-public-rpc-and-bootnodes-jelliedowl

(JelliedOwl, the contributor to Edgeware DAO do not store any user information and they do not parse it to any third party.)