### PR TITLE
Add BlastAPI to Scroll Alpha and fix previous Network ID error

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1866,17 +1866,21 @@ export const extraRpcs = {
   281121: {
     rpcs: ["rpcWorking:false"],
   },
-  534354: {
-    rpcs: [
-      {
-        url: "https://scroll-prealpha.blockpi.network/v1/rpc/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.blockpi,
-      },
+  534353:{
+    rpcs:[
       {
         url: "https://scroll-alphanet.public.blastapi.io",
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
+      },
+    ]
+  },
+  534354:{
+    rpcs:[
+      {
+        url: "https://scroll-prealpha.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
       },
     ]
   },


### PR DESCRIPTION
Scroll Pre Alpha has network ID 534354 and Scroll Alpha has network ID 534353 - we previously added by mistake on a wrong ID.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blastapi.io/

#### Provide a link to your privacy policy:
https://blastapi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.