### PR TITLE
Updated RPC URL for GasHawk

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -180,7 +180,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.onfinality
       },
       {
-        url: "https://beta-be.gashawk.io:3001/proxy/rpc",
+        url: "https://core.gashawk.io/rpc",
         tracking: "yes",
         trackingDetails: privacyStatement.gashawk,
       },


### PR DESCRIPTION
New RPC address for GasHawk, see: https://www.gashawk.io/#/setup