### PR TITLE
Added ShimmerEVM Testnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2175,6 +2175,14 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.teamblockchain,
       }
     ],
+  },
+  1071: {
+    rpcs: [
+      {
+        url: "https://json-rpc.evm.testnet.shimmer.network/",
+        tracking: "none"
+      }
+    ],
   }
 };
 


### PR DESCRIPTION
ShimmerEVM is the EVM chain developed by [IOTA Foundation](https://iota.org) as L2 running on top of [Shimmer Network](https://shimmer.network/), which is L1.

[Wiki Reference](https://wiki.iota.org/shimmer/smart-contracts/guide/chains_and_nodes/testnet/#interact-with-evm)

[IOTA Privacy Policy](https://www.iota.org/privacy-policy)

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.