### PR TITLE
Add ETC Testnets

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1229,6 +1229,16 @@ export const extraRpcs = {
   59: {
     rpcs: ["https://api.eosargentina.io", "https://api.metahub.cash"],
   },
+  6: {
+    rpcs: [
+      "https://www.ethercluster.com/kotti",
+      {
+        url: "https://geth-kotti.etc-network.info",
+        tracking: "yes",
+        trackingDetails: privacyStatement.etcnetworkinfo,
+      },
+    ],
+  },
   61: {
     rpcs: [
       "https://etc.rivet.link",
@@ -1255,6 +1265,16 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
       "https://rpc.etcplanets.com",
+    ],
+  },
+  63: {
+    rpcs: [
+      "https://www.ethercluster.com/mordor",
+      {
+        url: "https://geth-mordor.etc-network.info",
+        tracking: "yes",
+        trackingDetails: privacyStatement.etcnetworkinfo,
+      },
     ],
   },
   64: {


### PR DESCRIPTION
+ Chain 6
+ Chain 63

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://etc-network.info

#### Provide a link to your privacy policy:
etc-network.info privacy policy is already listed.

#### If the RPC has none of the above and you still think it should be added, please explain why:
Just adding already supported RPC providers testnet RPC endpoints.