### PR TITLE
Fix navigation bug on /chain page

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -37,10 +37,11 @@ function Header({ lang, chainName }) {
         return;
       }
 
+      let path = router.pathname.includes("/chain/") ? "/" : router.pathname
       router.push(
         {
-          pathname: router.pathname,
-          query: { ...router.query, search: debouncedSearchTerm },
+          pathname: path,
+          query: { search: debouncedSearchTerm },
         },
         undefined,
         { shallow: true },

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -37,10 +37,9 @@ function Header({ lang, chainName }) {
         return;
       }
 
-      let path = router.pathname.includes("/chain/") ? "/" : router.pathname
       router.push(
         {
-          pathname: path,
+          pathname: router.pathname.includes("/chain/") ? "/" : router.pathname,
           query: { search: debouncedSearchTerm },
         },
         undefined,

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -40,7 +40,7 @@ function Header({ lang, chainName }) {
       router.push(
         {
           pathname: router.pathname.includes("/chain/") ? "/" : router.pathname,
-          query: { search: debouncedSearchTerm },
+          query: { ...router.query, search: debouncedSearchTerm },
         },
         undefined,
         { shallow: true },


### PR DESCRIPTION
Currently you cannot re-use the search bar once you navigate to a `/chain/ ` page. This minor inconvenience is fixed with this simple pr.