### PR TITLE
Add Croswap Arbitrum RPC & Add privacy to Croswap Cronos RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -62,7 +62,9 @@ const privacyStatement = {
   getloop:
     "Loop Network follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services' analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. https://www.getloop.network/privacypolicy",
   iota:
-    "When you visit any of our websites or use any features or resources available on or through our websites. When you visit our website, your device and browser may automatically disclose certain information (such as device type, operating system, browser type, browser settings, IP address, language settings, dates and times of connecting to a website and other technical communications information), some of which may constitute Personal Data; https://www.iota.org/privacy-policy"
+    "When you visit any of our websites or use any features or resources available on or through our websites. When you visit our website, your device and browser may automatically disclose certain information (such as device type, operating system, browser type, browser settings, IP address, language settings, dates and times of connecting to a website and other technical communications information), some of which may constitute Personal Data; https://www.iota.org/privacy-policy",
+  croswap:
+    "CroSwap records limited metadata from requests, including the number of requests, User-Agent, IP, and ASN. This data is stored for a maximum of 90 days and is solely used for debugging, identifying suspicious activity, and generating analytics."
 };
 
 export const extraRpcs = {
@@ -607,7 +609,11 @@ export const extraRpcs = {
     rpcs: [
       "https://evm.cronos.org",
       "https://cronos-rpc.elk.finance/",
-      "https://node.croswap.com/rpc",
+      {
+        url: "https://node.croswap.com/rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.croswap,
+      },
       {
         url: "https://cronos.blockpi.network/v1/rpc/public",
         tracking: "limited",
@@ -626,6 +632,11 @@ export const extraRpcs = {
   42161: {
     rpcs: [
       "https://arb1.arbitrum.io/rpc",
+      {
+        url: "https://arb1.croswap.com/rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.croswap,
+      },
       {
         url: "https://rpc.ankr.com/arbitrum",
         tracking: "limited",


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://croswap.com

#### Provide a link to your privacy policy:
https://croswap.com/legal/privacy/

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.