### PR TITLE
Add Markr Go Network

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -64,7 +64,8 @@ const privacyStatement = {
   getloop:
     "Loop Network follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services' analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. https://www.getloop.network/privacypolicy",
   iota:
-    "When you visit any of our websites or use any features or resources available on or through our websites. When you visit our website, your device and browser may automatically disclose certain information (such as device type, operating system, browser type, browser settings, IP address, language settings, dates and times of connecting to a website and other technical communications information), some of which may constitute Personal Data; https://www.iota.org/privacy-policy"
+    "When you visit any of our websites or use any features or resources available on or through our websites. When you visit our website, your device and browser may automatically disclose certain information (such as device type, operating system, browser type, browser settings, IP address, language settings, dates and times of connecting to a website and other technical communications information), some of which may constitute Personal Data; https://www.iota.org/privacy-policy",
+  markrgo: "We only collect the minimum necessary information to provide our blockchain RPC service (caching). We do not use your data for commercial purposes. Any collected data is short-term and will be automatically deleted within 24 hours if not actively used. https://www.markr.io/privacy-policy",
 };
 
 export const extraRpcs = {
@@ -2220,6 +2221,15 @@ export const extraRpcs = {
         url: "https://rpc.ankr.com/polygon_zkevm",
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
+      }
+    ],
+  },
+  431140: {
+    rpcs: [
+      {
+        url: "https://rpc.markr.io/ext/",
+        tracking: "none",
+        trackingDetails: privacyStatement.markrgo,
       }
     ],
   }


### PR DESCRIPTION
Hey,

Markr Go functions as a network abstraction platform that provides users with a seamless web3 experience, although it is not a blockchain in itself.

Network already merged to the ethereum-lists / [chains].
https://github.com/ethereum-lists/chains/pull/2616

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.markr.io/

#### Provide a link to your privacy policy:
https://www.markr.io/privacy-policy

Your RPC should always be added at the end of the array.

Regards,