### PR TITLE
update Clover RPC Endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1588,11 +1588,7 @@ export const extraRpcs = {
     rpcWorking: false,
   },
   1024: {
-    rpcs: [
-      "https://rpc-ivy.clover.finance",
-      "https://rpc-ivy-2.clover.finance",
-      "https://rpc-ivy-3.clover.finance",
-    ],
+    rpcs: ["https://api-para.clover.finance"],
   },
   1030: {
     rpcs: [


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Just updating no EVM obsolete rpc endpoints，No new rpc endpoint added
- “https://rpc-ivy.clover.finance”
- “https://rpc-ivy-2.clover.finance”
- “https://rpc-ivy-3.clover.finance”