### PR TITLE
Update extraRpcs.js with new blockpi public endpoint for Scroll and Oasys

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1997,7 +1997,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.unifra,
       },
       {
-        url: "https://scroll-prealpha.blockpi.network/v1/rpc/public",
+        url: "https://scroll-testnet.blockpi.network/v1/rpc/public",
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       }
@@ -2346,6 +2346,15 @@ export const extraRpcs = {
         url: "https://rpc.markr.io/ext/",
         tracking: "none",
         trackingDetails: privacyStatement.markrgo,
+      }
+    ],
+  },
+  248: {
+    rpcs: [
+      {
+        url: "https://oasys.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
       }
     ],
   }


### PR DESCRIPTION
Update the old BlockPI endpoint for Scroll with the new one. And add the Oasys chain and the public endpoint from BlockPI. Thanks!

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockpi.io/

#### Provide a link to your privacy policy:
https://blockpi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.