### PR TITLE
Add chain IDs for Zilliqa

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -63,6 +63,8 @@
   "17777": "eos_evm",
   "32520": "bitgert",
   "32659": "fusion",
+  "32769": "zilliqa",
+  "33101": "zilliqa",
   "39815": "oho",
   "42161": "arbitrum",
   "42170": "arbitrum_nova",

--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -64,7 +64,6 @@
   "32520": "bitgert",
   "32659": "fusion",
   "32769": "zilliqa",
-  "33101": "zilliqa",
   "39815": "oho",
   "42161": "arbitrum",
   "42170": "arbitrum_nova",


### PR DESCRIPTION
This ensures the correct logo gets loaded from icons.llamao.fi.