### PR TITLE
Add Tenderly RPCs for Boba ETH Mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1085,7 +1085,6 @@ export const extraRpcs = {
       "http://gateway.tenderly.co/public/boba-ethereum",
       "https://mainnet.boba.network/",
       "https://boba-mainnet.gateway.pokt.network/v1/lb/623ad21b20354900396fed7f",
-      "https://lightning-replica.boba.network/",
     ],
   },
   321: {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1081,6 +1081,8 @@ export const extraRpcs = {
   },
   288: {
     rpcs: [
+      "http://boba-ethereum.gateway.tenderly.co",
+      "http://gateway.tenderly.co/public/boba-ethereum",
       "https://mainnet.boba.network/",
       "https://boba-mainnet.gateway.pokt.network/v1/lb/623ad21b20354900396fed7f",
       "https://lightning-replica.boba.network/",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://tenderly.co/
https://boba.network


#### Provide a link to your privacy policy:
https://tenderly.co/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.

Added in the beginning, because these are now the recommended RPCs, please let me know if that's not supported. 