### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -816,7 +816,6 @@ export const extraRpcs = {
   },
   1666600000: {
     rpcs: [
-      "https://harmony-0-rpc.gateway.pokt.network",
       "https://api.harmony.one",
       "https://a.api.s0.t.hmny.io",
       "https://api.s0.t.hmny.io",
@@ -825,7 +824,6 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
       },
-      "https://harmony-mainnet.chainstacklabs.com",
       {
         url: "https://harmony.api.onfinality.io/public",
         tracking: "limited",


### PR DESCRIPTION
Removing two Harmony $ONE RPCs that have shut down. The site is defaulting Harmony $ONE to a dead rpc currently causing issues.

Pokt removal posting --> https://twitter.com/PoktNews/status/1644008759994228737

Chainstack removal posting --> https://twitter.com/ChainstackHQ/status/1650892432832167936