### PR TITLE
Add gateway.fm RPC for Arbitrum and Optimism

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -797,6 +797,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
+      {
+        url: "https://rpc.arb1.arbitrum.gateway.fm",
+        tracking: "yes",
+        trackingDetails: privacyStatement.gateway,
+      },
     ],
   },
   421613: {
@@ -815,6 +820,11 @@ export const extraRpcs = {
         url: "https://arbitrum-goerli.public.blastapi.io",
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
+      },
+      {
+        url: "https://rpc.goerli.arbitrum.gateway.fm",
+        tracking: "yes",
+        trackingDetails: privacyStatement.gateway,
       },
     ],
   },
@@ -941,6 +951,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
+      {
+        url: "https://rpc.optimism.gateway.fm",
+        tracking: "yes",
+        trackingDetails: privacyStatement.gateway,
+      },
     ],
   },
   1881: {
@@ -968,6 +983,11 @@ export const extraRpcs = {
         url: "https://optimism-goerli.public.blastapi.io",
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
+      },
+      {
+        url: "https://rpc.goerli.optimism.gateway.fm",
+        tracking: "yes",
+        trackingDetails: privacyStatement.gateway,
       },
     ],
   },


### PR DESCRIPTION

#### Link the service provider's website (the company/protocol/individual providing the RPC):
 https://gateway.fm/

#### Provide a link to your privacy policy:
https://gateway.fm/privacy-policy/
