### PR TITLE
Update extraRpcs.js with new blockpi public endpoint for Meter and Zetachain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1854,6 +1854,15 @@ export const extraRpcs = {
       },
     ],
   },
+  7001: { 
+    rpcs: [ 
+      { 
+        url: "https://zetachain-athens-evm.blockpi.network/v1/rpc/public", 
+        tracking: "limited", 
+        trackingDetails: privacyStatement.blockpi, 
+      }, 
+    ], 
+  }, 
   2025: {
     rpcs: ["https://mainnet.rangersprotocol.com/api/jsonrpc"],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1299,6 +1299,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.jellypool,
       },
+      { 
+        url: "https://meter.blockpi.network/v1/rpc/public", 
+        tracking: "limited", 
+        trackingDetails: privacyStatement.blockpi, 
+      }, 
     ],
   },
   5551: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
blockpi.io

#### Provide a link to your privacy policy:
https://blockpi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.