### PR TITLE
fix: random banners hydration issue

### DIFF
--- a/components/AdBanner/index.js
+++ b/components/AdBanner/index.js
@@ -1,5 +1,5 @@
 import * as Fathom from "fathom-client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { FATHOM_ADS_ID } from "../../hooks/useAnalytics";
 import { notTranslation as useTranslations, shuffleArray } from "../../utils";
@@ -22,12 +22,18 @@ const BANNERS = [
   // },
 ];
 
+const randomBanners = shuffleArray(BANNERS);
+
 export const AdBanner = ({ timer = 15000, startTransition = true, showControls = false }) => {
   const t = useTranslations("Common");
+  const [isMounted, setIsMounted] = useState(false);
 
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  const randomBanners = useMemo(() => shuffleArray(BANNERS), []);
+  // only render the image client-side to prevent hydration errors due to the random banners
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -95,7 +101,7 @@ export const AdBanner = ({ timer = 15000, startTransition = true, showControls =
               className="rounded-[10px] duration-500 w-full h-full"
             />
 
-            <img src={srcLarge} alt={srcName} className="rounded-[10px] duration-500 w-full h-full" />
+            {isMounted && <img src={srcLarge} alt={srcName} className="rounded-[10px] duration-500 w-full h-full" />}
           </picture>
         </a>
 


### PR DESCRIPTION
Banners would sometimes "flash" as there's some randomness involved in the shuffle function and the image rendered on the server can be different from the image rendered on the client