### PR TITLE
Add optimism.meowrpc.com and arbitrum.meowrpc.com

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -854,6 +854,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
+      {
+        url: "https://arbitrum.meowrpc.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.meowrpc,
+      }
     ],
   },
   421613: {
@@ -1038,6 +1043,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
+      {
+        url: "https://optimism.meowrpc.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.meowrpc,
+      }
     ],
   },
   1881: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

#### Provide a link to your privacy policy:
https://privacy.meowrpc.com

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.