### PR TITLE
Update Ethereum Classic Mordor network RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1659,7 +1659,7 @@ export const extraRpcs = {
   },
   63: {
     rpcs: [
-      "https://www.ethercluster.com/mordor",
+      "https://rpc.mordor.etccooperative.org",
       {
         url: "https://geth-mordor.etc-network.info",
         tracking: "yes",


### PR DESCRIPTION
Starting from July 24th, 2023 the current endpoint will be disabled, this PR updates it with the new one listed in the announcement.

https://etccooperative.org/posts/2023-06-24-important-announcement-migrate-the-etc-and-mordor-rpc-endpoints-by-july-24-2023-en