### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -118,6 +118,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
       },
+       {
+        url: "https://eth.getblock.io/&lt;api_key&gt;/mainnet/",
+        tracking: "none",
+        trackingDetails: privacyStatement.getblock,
+      },
       {
         url:
           "https://eth-mainnet.nodereal.io/v1/1659dfb40aa24bbb8153a677b98064d7",


### PR DESCRIPTION
Add GetBlock RPC endpoints to the list

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://getblock.io/


#### Provide a link to your privacy policy: https://getblock.io/privacy-policy/


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array. I'm not sure I did that, you may change this 