### PR TITLE
Update BNB Chain brand names

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -11,7 +11,7 @@
   "50": "xdc",
   "52": "csc",
   "55": "zyx",
-  "56": "bnbchain",
+  "56": "binance",
   "57": "syscoin",
   "60": "gochain",
   "61": "ethereumclassic",

--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -11,7 +11,7 @@
   "50": "xdc",
   "52": "csc",
   "55": "zyx",
-  "56": "binance",
+  "56": "bnbchain",
   "57": "syscoin",
   "60": "gochain",
   "61": "ethereumclassic",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -481,7 +481,7 @@ export const extraRpcs = {
   },
   56: {
     rpcs: [
-      "https://bsc-dataseed.binance.org/",
+      "https://bsc-dataseed.bnbchain.org/",
       "https://bsc-dataseed1.defibit.io/",
       "https://bsc-dataseed1.ninicoin.io/",
       "https://bsc-dataseed2.defibit.io/",
@@ -490,10 +490,10 @@ export const extraRpcs = {
       "https://bsc-dataseed2.ninicoin.io/",
       "https://bsc-dataseed3.ninicoin.io/",
       "https://bsc-dataseed4.ninicoin.io/",
-      "https://bsc-dataseed1.binance.org/",
-      "https://bsc-dataseed2.binance.org/",
-      "https://bsc-dataseed3.binance.org/",
-      "https://bsc-dataseed4.binance.org/",
+      "https://bsc-dataseed1.bnbchain.org/",
+      "https://bsc-dataseed2.bnbchain.org/",
+      "https://bsc-dataseed3.bnbchain.org/",
+      "https://bsc-dataseed4.bnbchain.org/",
       {
         url: "https://rpc-bsc.48.club",
         tracking: "limited",
@@ -527,11 +527,7 @@ export const extraRpcs = {
       },
       "https://bscrpc.com",
       "https://bsc.rpcgator.com/",
-      {
-        url: "https://binance.nodereal.io",
-        tracking: "yes",
-        trackingDetails: privacyStatement.nodereal,
-      },
+      ,
       "https://bsc-mainnet.rpcfast.com?api_key=xbhWBI1Wkguk8SNMu1bvvLurPGLXmgwYeC4S6g2H7WdwFigZSmPWVZRxrskEQwIf",
       "https://nodes.vefinetwork.org/smartchain",
       {


### PR DESCRIPTION
**Summary**
Binance Chain has been rebranded into BNB Chain. This PR is to update the brand names and RPC URLs to the correct version. Refer to the [official BNB Chain documentation](https://docs.bnbchain.org/docs/rpc#bsc-mainnet-chainid-0x38-56-in-decimal).

**Changes**
- Update `binance` to `bnbchain`
- Update all RPC URLs domain from `binance` to `bnbchain`
- Remove `"https://binance.nodereal.io"` item since it no longer exists 