### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1440,6 +1440,11 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
+        url: "https://getblock.io/nodes/bsc/",
+        tracking: "none",
+        trackingDetails: privacyStatement.getblock,
+      },
+      {
         url: "https://1rpc.io/astr",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,


### PR DESCRIPTION
Add GetBlock BSC RPC endpoints to the list

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://getblock.io/nodes/bsc/ 


#### Provide a link to your privacy policy: https://getblock.io/privacy-policy/ 


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.