### PR TITLE
Update extraRpcs.js : add arb and opt

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -904,6 +904,11 @@ export const extraRpcs = {
         url: "https://arbitrum.meowrpc.com",
         tracking: "none",
         trackingDetails: privacyStatement.meowrpc,
+      },
+      {
+      	url: "https://api.zan.top/node/v1/arb/one/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
       }
     ],
   },
@@ -939,6 +944,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+      	url: "https://api.zan.top/node/v1/arb/goerli/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
     ],
   },
   42170: {
@@ -1113,6 +1123,11 @@ export const extraRpcs = {
         url: "https://optimism.meowrpc.com",
         tracking: "none",
         trackingDetails: privacyStatement.meowrpc,
+      },
+      {
+        url: "https://api.zan.top/node/v1/opt/mainnet/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.zan,
       }
     ],
   },
@@ -1157,6 +1172,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+      	url: "https://api.zan.top/node/v1/opt/goerli/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
     ],
   },
   1088: {


### PR DESCRIPTION
we have added some rpc and the following answers remain the same as last time

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://zan.top/home/node-service

Provide a link to your privacy policy:
https://a.zan.top/static/Privacy-Policy.pdf


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.