### PR TITLE
Update extraRpcs with new blockpi public endpoint for zksync-era-testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2001,6 +2001,15 @@ export const extraRpcs = {
   1280: {
     rpcs: ["https://nodes.halo.land"],
   },
+  280: {
+    rpcs: [
+      {
+        url: "https://zksync-era-testnet.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
+    ]
+  },
   1287: {
     rpcs: [
       "https://rpc.testnet.moonbeam.network",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockpi.io/

#### Provide a link to your privacy policy:
https://blockpi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.