### PR TITLE
add rpc endpoints from notadegen.com

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -418,9 +418,7 @@ export const extraRpcs = {
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
       },
-      {
-      	url: "https://rpc.notadegen.com/goerli"
-      },
+      	"https://rpc.notadegen.com/goerli",
     ],
   },
   //Ropsten testnet deprecated
@@ -2499,9 +2497,7 @@ export const extraRpcs = {
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
       },
-      {
-      	url: "https://rpc.notadegen.com/sepolia"
-      },
+      	"https://rpc.notadegen.com/sepolia",
     ]
   },
   7762959: {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -418,6 +418,10 @@ export const extraRpcs = {
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
       },
+      {
+      	url: "https://rpc.notadegen.com/goerli",
+      	tracking: "none"
+      },
     ],
   },
   //Ropsten testnet deprecated
@@ -2495,6 +2499,10 @@ export const extraRpcs = {
       	url: "https://api.zan.top/node/v1/eth/sepolia/public",
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
+      },
+      {
+      	url: "https://rpc.notadegen.com/sepolia",
+      	tracking: "none"
       },
     ]
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -419,8 +419,7 @@ export const extraRpcs = {
       	trackingDetails: privacyStatement.zan,
       },
       {
-      	url: "https://rpc.notadegen.com/goerli",
-      	tracking: "none"
+      	url: "https://rpc.notadegen.com/goerli"
       },
     ],
   },
@@ -2501,8 +2500,7 @@ export const extraRpcs = {
       	trackingDetails: privacyStatement.zan,
       },
       {
-      	url: "https://rpc.notadegen.com/sepolia",
-      	tracking: "none"
+      	url: "https://rpc.notadegen.com/sepolia"
       },
     ]
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

The website is being worked on and it will be up soon.

#### Provide a link to your privacy policy:

No privacy policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

I am running archival nodes and would like to provide RPC endpoints as a public good service for other devs to use. There is no tracking and rate limits. It would be nice if my rpc endpoints could be added to the list. Thank you!