### PR TITLE
Add base.meowrpc.com to extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2376,6 +2376,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+        url: "https://base.meowrpc.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.meowrpc,
+      },
     ],
   },
   11235: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://meowrpc.com/

#### Provide a link to your privacy policy:
https://privacy.meowrpc.com/

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.