### PR TITLE
Pocket: Update bnb/bsc public endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -518,7 +518,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.omnia,
       },
       {
-        url: "https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d",
+        url: "https://bsc-rpc.gateway.pokt.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
       },


### PR DESCRIPTION
Update pocket network bnb/bsc public RPC

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.pokt.network/

Provide a link to your privacy policy:
https://www.pokt.network/privacy-policy/

If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.