### PR TITLE
Update extraRpcs.js with Tenderly.co RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -272,17 +272,17 @@ export const extraRpcs = {
       },
       {
         url: "https://mainnet.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
        {
         url: "https://rpc.tenderly.co/fork/c63af728-a183-4cfb-b24e-a92801463484",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/mainnet",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -334,12 +334,12 @@ export const extraRpcs = {
       },
       {
         url: "https://polygon-mumbai.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/polygon-mumbai",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -405,12 +405,12 @@ export const extraRpcs = {
       },
       {
         url: "https://goerli.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/goerli",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -784,12 +784,12 @@ export const extraRpcs = {
       },
       {
         url: "https://polygon.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/polygon",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -1135,7 +1135,17 @@ export const extraRpcs = {
         url: "https://api.zan.top/node/v1/opt/mainnet/public",
         tracking: "limited",
         trackingDetails: privacyStatement.zan,
-      }
+      },
+      {
+        url: "https://optimism.gateway.tenderly.co",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
+      {
+        url: "https://gateway.tenderly.co/public/optimism",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   1881: {
@@ -1183,7 +1193,17 @@ export const extraRpcs = {
       	url: "https://api.zan.top/node/v1/opt/goerli/public",
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
-      }
+      },
+      {
+        url: "https://optimism-goerli.gateway.tenderly.co",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
+      {
+        url: "https://gateway.tenderly.co/public/optimism-goerli",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   1088: {
@@ -1404,12 +1424,12 @@ export const extraRpcs = {
       },
       {
         url: "https://boba-ethereum.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/boba-ethereum",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -2384,6 +2404,16 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+        url: "https://base-goerli.gateway.tenderly.co",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
+      {
+        url: "https://gateway.tenderly.co/public/base-goerli",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   8453: {
@@ -2408,6 +2438,16 @@ export const extraRpcs = {
         url: "https://base-mainnet.public.blastapi.io",
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
+      },
+      {
+        url: "https://base.gateway.tenderly.co",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
+      },
+      {
+        url: "https://gateway.tenderly.co/public/base",
+        tracking: "limited",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -2567,12 +2607,12 @@ export const extraRpcs = {
       },
       {
         url: "https://sepolia.gateway.tenderly.co",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/sepolia",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.tenderly,
       },
       {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -272,17 +272,17 @@ export const extraRpcs = {
       },
       {
         url: "https://mainnet.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
        {
         url: "https://rpc.tenderly.co/fork/c63af728-a183-4cfb-b24e-a92801463484",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/mainnet",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -334,12 +334,12 @@ export const extraRpcs = {
       },
       {
         url: "https://polygon-mumbai.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/polygon-mumbai",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -405,12 +405,12 @@ export const extraRpcs = {
       },
       {
         url: "https://goerli.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/goerli",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -784,12 +784,12 @@ export const extraRpcs = {
       },
       {
         url: "https://polygon.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/polygon",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
@@ -1138,12 +1138,12 @@ export const extraRpcs = {
       },
       {
         url: "https://optimism.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/optimism",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -1196,12 +1196,12 @@ export const extraRpcs = {
       },
       {
         url: "https://optimism-goerli.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/optimism-goerli",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -1424,12 +1424,12 @@ export const extraRpcs = {
       },
       {
         url: "https://boba-ethereum.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/boba-ethereum",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -2406,12 +2406,12 @@ export const extraRpcs = {
       },
       {
         url: "https://base-goerli.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/base-goerli",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -2441,12 +2441,12 @@ export const extraRpcs = {
       },
       {
         url: "https://base.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/base",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
     ],
@@ -2607,12 +2607,12 @@ export const extraRpcs = {
       },
       {
         url: "https://sepolia.gateway.tenderly.co",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {
         url: "https://gateway.tenderly.co/public/sepolia",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
       {


### PR DESCRIPTION
## Changes:

- added Tenderly Optimism Mainnet RPCs
- added Tenderly Optimism Goerli RPCs
- added Tenderly Base Mainnet RPCs
- added Tenderly Base Goerli RPCs

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://tenderly.co

#### Provide a link to your privacy policy:

https://tenderly.co/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.