### PR TITLE
Add BASE chain RPC endpoints from notadengen.com

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -418,7 +418,7 @@ export const extraRpcs = {
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
       },
-      	"https://rpc.notadegen.com/goerli",
+      "https://rpc.notadegen.com/eth/goerli",
     ],
   },
   //Ropsten testnet deprecated
@@ -2384,6 +2384,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      "https://rpc.notadegen.com/base/goerli",
     ],
   },
   8453: {
@@ -2409,6 +2410,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
       },
+      "https://rpc.notadegen.com/base",
     ],
   },
   11235: {
@@ -2580,7 +2582,7 @@ export const extraRpcs = {
       	tracking: "limited",
       	trackingDetails: privacyStatement.zan,
       },
-      	"https://rpc.notadegen.com/sepolia",
+      "https://rpc.notadegen.com/eth/sepolia",
     ]
   },
   7762959: {


### PR DESCRIPTION
Also updates ETH goerli and sepolia rpc endpoints from notadengen.com

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

Under construction

#### Provide a link to your privacy policy:

No privacy policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

I am running archival nodes and would like to provide RPC endpoints as a public good service for other devs to use. There is no tracking and rate limits. It would be nice if my rpc endpoints could be added to the list. Thank you!