### PR TITLE
Update extraRpcs.js : add avax and polygonzkevm in zan

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -485,6 +485,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
+      {
+      	url: "https://api.zan.top/node/v1/avax/fuji/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
     ],
   },
   56: {
@@ -673,6 +678,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.meowrpc,
       },
+      {
+      	url: "https://api.zan.top/node/v1/avax/mainnet/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
     ],
   },
   250: {
@@ -2132,6 +2142,15 @@ export const extraRpcs = {
       },
     ],
   },
+  1442: {
+    rpcs: [
+        {
+      	url: "https://api.zan.top/node/v1/polygonzkevm/testnet/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
+    ],
+  },
   1618: {
     rpcs: ["https://send.catechain.com"],
   },
@@ -2968,6 +2987,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
       },
+      {
+      	url: "https://api.zan.top/node/v1/polygonzkevm/mainnet/public",
+      	tracking: "limited",
+      	trackingDetails: privacyStatement.zan,
+      }
     ],
   },
   59144: {


### PR DESCRIPTION
we have added some rpc and the following answers remain the same as last time

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://zan.top/home/node-service

Provide a link to your privacy policy:
https://a.zan.top/static/Privacy-Policy.pdf

If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.