### PR TITLE
add lava ipRPC to evmos rpc list

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2581,6 +2581,7 @@ export const extraRpcs = {
   },
   9001: {
     rpcs: [
+      "https://https://evmos.lava.build",
       "https://eth.bd.evmos.org:8545/",
       "https://evmos-mainnet.gateway.pokt.network/v1/lb/627586ddea1b320039c95205",
       "https://evmos-json-rpc.stakely.io",


### PR DESCRIPTION


#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.lavanet.xyz/

#### Provide a link to your privacy policy:
https://www.lavanet.xyz/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:
N/A



Your RPC should always be added at the end of the array. =>

#### Important Note
Please note - Lava in partnership with the Evmos team was tasked with providing incentivized public RPC endpoints as the default RPC for Evmos ecosystem. This PR adds ipRPC endpoint to rpc lists on 9001. The _intention_ is for Lava to be the default RPC for Evmos.