### PR TITLE
add canto RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2573,6 +2573,19 @@ export const extraRpcs = {
   7341: {
     rpcs: ["https://rpc.shyft.network/"],
   },
+  7700: {
+    rpcs: [
+    "https://canto.slingshot.finance",
+    "https://canto.neobase.one",
+    "https://mainnode.plexnode.org:8545",
+    "https://canto.gravitychain.io/",
+    "https://canto.evm.chandrastation.com/",
+    "https://jsonrpc.canto.nodestake.top/",
+    "https://canto.dexvaults.com/",
+    "wss://canto.gravitychain.io:8546",
+    "wss://canto.dexvaults.com/ws"
+    ]
+  },
   8000: {
     rpcs: ["https://dataseed.testnet.teleport.network"],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2575,9 +2575,6 @@ export const extraRpcs = {
   },
   7700: {
     rpcs: [
-    "https://canto.slingshot.finance",
-    "https://canto.neobase.one",
-    "https://mainnode.plexnode.org:8545",
     "https://canto.gravitychain.io/",
     "https://canto.evm.chandrastation.com/",
     "https://jsonrpc.canto.nodestake.top/",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

- https://www.gravitybridge.net/
- https://www.chandrastation.com/
- https://nodestake.top/
- https://dexvaults.com/

#### Provide a link to your privacy policy:

Unable to find (RPC-specific) privacy policies for any of the providers.

#### If the RPC has none of the above and you still think it should be added, please explain why:

These are popular RPCs for the Canto blockchain.