### PR TITLE
imp: add Lava RPC endpoint as default for Evmos chain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2684,6 +2684,7 @@ export const extraRpcs = {
   },
   9001: {
     rpcs: [
+      "https://evmos.lava.build",
       "https://eth.bd.evmos.org:8545/",
       "https://evmos-mainnet.gateway.pokt.network/v1/lb/627586ddea1b320039c95205",
       "https://evmos-json-rpc.stakely.io",


### PR DESCRIPTION
At Evmos, we have engaged in a new cooperation with Lava Network who provide amazing RPC services! We would like to make this endpoint the default RPC endpoint when users connect to the Evmos network using MetaMask.

Lavanet website: https://www.lavanet.xyz/

Also if you could point me to, where I can submit a corresponding PR for the testnet configuration, I would be very grateful 🙏 