### PR TITLE
Update extraRpcs-add-1rpc-scroll-mainnet-support

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3037,6 +3037,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
+      {
+        url: "https://1rpc.io/scroll",
+        tracking: "none",
+        trackingDetails: privacyStatement.onerpc,
+      },
     ],
   },
   534353: {


### PR DESCRIPTION
1RPC now supports Scroll Mainnet: https://1rpc.io/scroll

Announcement: https://blog.ata.network/use-1rpc-with-scroll-mainnet-53a06eb7d616

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.1rpc.io/

#### Provide a link to your privacy policy:
https://www.1rpc.io/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.