### PR TITLE
Add Evmos RPC by NodeStake

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2699,6 +2699,7 @@ export const extraRpcs = {
       "https://jsonrpc-evmos-ia.cosmosia.notional.ventures",
       "https://json-rpc.evmos.blockhunters.org",
       "https://evmos-json-rpc.agoranodes.com",
+      "https://jsonrpc.evmos.nodestake.top",
       {
         url: "https://evmos-mainnet.public.blastapi.io",
         tracking: "limited",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://nodestake.top/

#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.