### PR TITLE
Add 0base.vc's EVMOS json-rpc.

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2720,6 +2720,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
+      "https://evmos-json-rpc.0base.dev/",
     ],
   },
   836542336838601: {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2720,7 +2720,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
-      "https://evmos-json-rpc.0base.dev/",
+      "https://evmos-json-rpc.0base.dev",
     ],
   },
   836542336838601: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://0base.vc

#### Provide a link to your privacy policy:
N/A

#### If the RPC has none of the above and you still think it should be added, please explain why:
This needs to be added for a reliable JSON RPC service in EVMOS.

Your RPC should always be added at the end of the array.