### PR TITLE
Added StakeTown rpc and jsonrpc for evmos testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2726,7 +2726,9 @@ export const extraRpcs = {
         "https://evmos-testnet-json.qubelabs.io",
         "https://evmos-tjson.antrixy.org",
         "https://rpc.evmos.test.theamsolutions.info",
-        "https://api.evmos-test.theamsolutions.info"
+        "https://api.evmos-test.theamsolutions.info",
+        "https://evmos-testnet-rpc.stake-town.com",
+        "https://evmos-testnet-jsonrpc.stake-town.com"
     ],
   },
   9001: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
individual

#### Provide a link to your privacy policy:
individual

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.