### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2769,8 +2769,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.onfinality,
       },
       "https://evmos-json-rpc.0base.dev",
-      "https://json-rpc.evmos.tcnetwork.io",
-      "https://evmos-tjson.antrixy.org/"
+      "https://json-rpc.evmos.tcnetwork.io"
     ],
   },
   836542336838601: {


### PR DESCRIPTION
This one https://evmos-tjson.antrixy.org/ is a testnet rpc that's wrongly listed under the Evmos mainnet RPC (9001) list for some reason. This confuses the users and make all the mainnet rpcs below look like they're behind the network which is not the case. See below
![image](https://github.com/DefiLlama/chainlist/assets/72661026/1d97f8f0-e1bf-49d8-a6a1-201b0322bcbc)

This PR solves the issue.