### PR TITLE
fix: remove testnet rpc from mainnet rpcs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2770,7 +2770,6 @@ export const extraRpcs = {
       },
       "https://evmos-json-rpc.0base.dev",
       "https://json-rpc.evmos.tcnetwork.io",
-      "https://evmos-tjson.antrixy.org/"
     ],
   },
   836542336838601: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

The rpc `https://evmos-tjson.antrixy.org` belongs to Evmos testnet (chain id 9000)
This PR removes this RPC from the Evmos mainnet RPCs (chain id 9001) 