### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2726,7 +2726,8 @@ export const extraRpcs = {
         "https://evmos-testnet-json.qubelabs.io",
         "https://evmos-tjson.antrixy.org",
         "https://rpc.evmos.test.theamsolutions.info",
-        "https://api.evmos-test.theamsolutions.info"
+        "https://api.evmos-test.theamsolutions.info",
+        "https://rpc.evmos.testnet.node75.org"
     ],
   },
   9001: {


### PR DESCRIPTION
add evmos testnet rpc endpoint

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://node75.org/

#### Provide a link to your privacy policy:
We dont have any. But we dont collect and process any personal data,  except those, which could be extract from the blockchain

#### If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.

We are small individual validator service, supporting Evmos testnet. For this testnet not so many endpoints are available.
