### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2835,7 +2835,6 @@ export const extraRpcs = {
       },
       "https://evmos-json-rpc.0base.dev",
       "https://json-rpc.evmos.tcnetwork.io",
-      "https://evmos-tjson.antrixy.org/",
       "https://rpc-evm.evmos.dragonstake.io",
       "https://json-rpc.evmos.tcnetwork.io",
       "https://evmos-jsonrpc.stake-town.com"


### PR DESCRIPTION
This RPC node mistakenly readded under Evmos mainnet rpcs. This pr fixes it. See here for more information: https://github.com/DefiLlama/chainlist/pull/784#issuecomment-1793071351