### PR TITLE
Rollux: Remove malfunctioning third-party endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3759,7 +3759,6 @@ export const extraRpcs = {
   },
   570: {
     rpcs: [
-      "https://rollux.public-rpc.com",
       "wss://rpc.rollux.com/wss",			
       "https://rpc.rollux.com",
       "https://rollux.rpc.syscoin.org",


### PR DESCRIPTION
Removing endpoint https://rollux.public-rpc.com because it is unstable and has been negatively impacting user experiences for weeks with no resolution. Will consider adding again once issue is confirmed resolved and service is stable.

-- Syscoin Foundation, Rollux team