### PR TITLE
fix/outdated-klaytn-extraRPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1162,8 +1162,13 @@ export const extraRpcs = {
   },
   8217: {
     rpcs: [
-      "https://public-node-api.klaytnapi.com/v1/cypress",
-      "https://cypress.fautor.app/archive",
+      "https://public-en-cypress.klaytn.net",
+      " https://klaytn-mainnet-rpc.allthatnode.com:8551",
+      {
+        url: "https://rpc.ankr.com/klaytn ",
+        tracking: "limited",
+        trackingDetails: privacyStatement.ankr,
+      },
       {
         url: "https://klaytn.blockpi.network/v1/rpc/public",
         tracking: "limited",
@@ -2418,8 +2423,13 @@ export const extraRpcs = {
   },
   1001: {
     rpcs: [
-      "https://public-node-api.klaytnapi.com/v1/baobab",
-      "https://baobab.fautor.app/archive",
+      "https://public-en-baobab.klaytn.net",
+      "https://klaytn-baobab-rpc.allthatnode.com:8551",
+      {
+        url: "https://rpc.ankr.com/klaytn_testnet",
+        tracking: "limited",
+        trackingDetails: privacyStatement.ankr,
+      },
       {
         url: "https://klaytn-baobab.blockpi.network/v1/rpc/public",
         tracking: "limited",


### PR DESCRIPTION
This PR removes outdated RPCs for [KAS](https://support.klaytnapi.com/hc/en-us/articles/6694519652239-Termination-of-Public-Node-API-provided-by-Klaytn-API-Service) and [Fantrie's](https://twitter.com/BuildonKlaytn/status/1627950994914164736) Public endpoint respectively and updates with new ones.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

Added new RPC providers such as: 
- [AllThatNode](https://www.allthatnode.com)
- [Ankr](https://www.ankr.com/)

#### Provide a link to your privacy policy:
- [AllThatNode Privacy Policy](https://www.allthatnode.com/terms.dsrv)
- Ankr privacy policy already exists in the file.


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.