### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -451,6 +451,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
+	 {
+        url: "https://getblock.io/nodes/matic/",
+        tracking: "none",
+        trackingDetails: privacyStatement.getblock,
+      },
       {
         url: "https://goerli.gateway.tenderly.co",
         tracking: "yes",


### PR DESCRIPTION
Add GetBlock RPc endpoints to the list

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://getblock.io/nodes/matic/


#### Provide a link to your privacy policy: https://getblock.io/privacy-policy/


