### PR TITLE
Add evmos RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2837,6 +2837,7 @@ export const extraRpcs = {
       "https://evmos-json.antrixy.org",
       "https://jsonrpc.evmos.nodestake.top",
       "https://evmos-jsonrpc.alkadeta.com",
+      "https://evmos-json.qubelabs.io",    
       {
         url: "https://evmos-mainnet-jsonrpc.autostake.com",
         tracking: "limited",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): **https://qubelabs.io/**


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.