### PR TITLE
Add Kalia json rpc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2820,7 +2820,8 @@ export const extraRpcs = {
         "https://api.evmos-test.theamsolutions.info",
         "https://jsonrpc-t.evmos.nodestake.top",
         "https://evmos-testnet-jsonrpc.autostake.com",
-        "https://evmos-testnet-jsonrpc.alkadeta.com"
+        "https://evmos-testnet-jsonrpc.alkadeta.com",
+        "https://t-evmos-jsonrpc.kalia.network"
     ],
   },
   9001: {
@@ -2884,6 +2885,7 @@ export const extraRpcs = {
       "https://evmosevm.rpc.stakin-nodes.com",
       "https://evmos-jsonrpc.stake-town.com",
       "https://json-rpc-evmos.mainnet.validatrium.club",
+      "https://evmos-jsonrpc.kalia.network"
     ],
   },
   836542336838601: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://kalia.network


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.