### PR TITLE
add chain_id for Conflux in chainIds.json

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -48,6 +48,7 @@
   "592": "astar",
   "820": "callisto",
   "888": "wanchain",
+  "1030": "conflux",
   "1088": "metis",
   "1101": "polygon_zkevm",
   "1116": "core",


### PR DESCRIPTION
To fix the issue of the Conflux icon not displaying due to the absence of the chainid of Conflux.


If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://confluxnetwork.org/

#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.