### PR TITLE
  1 Update extraRpcs.js with new blockpi public endpoint for x1-testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -494,6 +494,15 @@ export const extraRpcs = {
       "https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
     ],
   },
+  195: {
+      rpcs [
+	  {
+        url: "https://x1-testnet.blockpi.network/v1/rpc/public ",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi
+      },
+    ]
+  }
   4002: {
     rpcs: [
       "https://rpc.testnet.fantom.network/",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockpi.io/

#### Provide a link to your privacy policy:
https://blockpi.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.