### PR TITLE
Update: etc-network.info Limited Tracking setting

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2195,7 +2195,7 @@ export const extraRpcs = {
       "https://www.ethercluster.com/kotti",
       {
         url: "https://geth-kotti.etc-network.info",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
     ],

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2195,7 +2195,7 @@ export const extraRpcs = {
       "https://www.ethercluster.com/kotti",
       {
         url: "https://geth-kotti.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
     ],
@@ -2207,35 +2207,24 @@ export const extraRpcs = {
       "https://etc.mytokenpocket.vip",
       {
         url: "https://besu-de.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
       {
         url: "https://geth-de.etc-network.info",
-        tracking: "yes",
-        trackingDetails: privacyStatement.etcnetworkinfo,
-      },
-      {
-        url: "https://erigon-de.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
       {
         url: "https://besu-at.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
       {
         url: "https://geth-at.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
-      {
-        url: "https://erigon-at.etc-network.info",
-        tracking: "yes",
-        trackingDetails: privacyStatement.etcnetworkinfo,
-      },
-      "https://rpc.etcplanets.com",
     ],
   },
   63: {
@@ -2243,7 +2232,7 @@ export const extraRpcs = {
       "https://rpc.mordor.etccooperative.org",
       {
         url: "https://geth-mordor.etc-network.info",
-        tracking: "yes",
+        tracking: "limited",
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
     ],


### PR DESCRIPTION
+ Update to reflect limited tracking for RPC endpoints.
+ Remove offline RPC endpoints

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
Not new. Update to reflect current privacy statement.


#### Provide a link to your privacy policy:
Existing privacy statement at ".etcnetworkinfo"

Note: I'm not associated with RPC endpoints, I am simply cleaning up the Ethereum Classic RPC pages for the general public as we are seeing increased adoption on the network.