### PR TITLE
Note Deprecated Chains 6, 62

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2190,14 +2190,10 @@ export const extraRpcs = {
       },
     ],
   },
+  //Kotti testnet deprecated
   6: {
     rpcs: [
       "https://www.ethercluster.com/kotti",
-      {
-        url: "https://geth-kotti.etc-network.info",
-        tracking: "yes",
-        trackingDetails: privacyStatement.etcnetworkinfo,
-      },
     ],
   },
   61: {
@@ -2236,6 +2232,12 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.etcnetworkinfo,
       },
       "https://rpc.etcplanets.com",
+    ],
+  },
+  //Morden testnet deprecated
+  62: {
+    rpcs: [
+      "https://www.ethercluster.com/morden",
     ],
   },
   63: {


### PR DESCRIPTION
Note deprecated Ethereum Classic testnet chains to prevent replay attacks.

+ Chain6 Kotti (PoA deprecated in 2022 for Chain63)
+ Chain62 Morden (PoW with old 2016 baggage, replaced by Chain63 in 2019).

Chain 63 Mordor is the preferred testnet for Ethereum Classic. Supported by core-geth, the main Ethereum Classic client.
https://etclabscore.github.io/core-geth/