### PR TITLE
Add Rivet's privacy policy

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -129,8 +129,10 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
   projectpi:
     "When you use Project Pi as an RPC provider we will not store your IP address or any data for more than 24 hours. IP addresses are not connected or correlated to wallet addresses",
   hybrid:
-  "HybridChain may automatically collect information regarding your computer hardware and software. This data can encompass details like your IP address, browser type, domain names, access times, and referring website addresses. This collection is in line with HybridChain's privacy policy and aims to optimize service provision and enhance user experience."
-  };
+  "HybridChain may automatically collect information regarding your computer hardware and software. This data can encompass details like your IP address, browser type, domain names, access times, and referring website addresses. This collection is in line with HybridChain's privacy policy and aims to optimize service provision and enhance user experience.",
+  rivet:
+    "Rivet's unyielding privacy policy ensures no data sharing or selling to third parties—guaranteed",
+};
 
 export const extraRpcs = {
   1: {
@@ -2209,10 +2211,14 @@ export const extraRpcs = {
   },
   61: {
     rpcs: [
-      "https://etc.rivet.link",
       "https://etc.mytokenpocket.vip",
       "https://rpc.etcinscribe.com",
       "https://etc.etcdesktop.com",
+      {
+        url: "https://etc.rivet.link",
+        tracking: "none",
+        trackingDetails: privacyStatement.rivet
+      },
       {
         url: "https://besu-de.etc-network.info",
         tracking: "limited",


### PR DESCRIPTION
This PR adds the privacy policy for [Rivet](https://rivet.cloud/)'s Ethereum Classic RPC endpoint. From their [FAQ](https://rivet.cloud/FAQ's):
> Q: What can you do with my request data?
> A: Request data contains substantially more information than what appears on the public ledger. Users' wallet addresses, token balances, web3 browsing activity along with PII that can be connected back to web2 services like Facebook. If you or your users' idiosyncratic usernames, email addresses and even IP addresses can be tied to activity on Facebook or Google, web3 might become just another vector for information-miners, advertizers and oppressive regimes to exploit. That's why we've created an armored privacy policy that we promise to stand over on principle. We will never sell or willingly share your data with 3rd parties—full stop.
