### PR TITLE
remove the cfx rpc for unifra

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2514,7 +2514,6 @@ export const extraRpcs = {
   1030: {
     rpcs: [
       "https://evm.confluxrpc.com",
-      "https://conflux-espace-public.unifra.io",
     ],
   },
   1115: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.