### PR TITLE
Add Logo to Mordor Testnet

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -15,6 +15,7 @@
   "57": "syscoin",
   "60": "gochain",
   "61": "ethereumclassic",
+  "63": "ethereumclassic",
   "66": "okexchain",
   "70": "hoo",
   "82": "meter",


### PR DESCRIPTION
Add Ethereum Classic logo to Mordor Testnet Chain 63
