### PR TITLE
add: Humans RPCs to extraRpcs.js by ITRocket

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -134,6 +134,8 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
     "We collect End Users’ information when they use our Customers’ web3-enabled websites, web applications, and APIs. This information may include but is not limited to IP addresses, system configuration information, and other information about traffic to and from Customers’ websites (collectively, “Log Data”). We collect and use Log Data to operate, maintain, and improve our Services in performance of our obligations under our Customer agreements.https://rivet.cloud/privacy-policy",
   tokenview:
     "Information about your computer hardware and software may be automatically collected by Tokenview. This information can include such details as your IP address, browser type, domain names, access times, etc.https://services.tokenview.io/en/protocol",
+  itrocket:
+    "ITRocket does not track or store any user information that transits through our RPCs (location, IP, wallet, etc)",
   };
 
 export const extraRpcs = {
@@ -4071,6 +4073,25 @@ export const extraRpcs = {
       "https://rpc-l1.jibchain.net",
       'https://jib-rpc.inan.in.th',
     ]
+  },
+  1089: {
+    rpcs: [
+      {
+        url: "https://humans-mainnet-rpc.itrocket.net/",
+        tracking: "none",
+        trackingDetails: privacyStatement.itrocket,
+      },
+     
+    ],
+  },
+  4139: {
+    rpcs: [
+      {
+        url: "https://humans-testnet-rpc.itrocket.net/",
+        tracking: "none",
+        trackingDetails: privacyStatement.itrocket,
+      },     
+    ],
   },
 };
 


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://itrocket.net/
https://itrocket.net/services/mainnet/humans/
https://itrocket.net/services/testnet/humans/

#### Provide a link to your privacy policy:
ITRocket does not track or store user information that transits through our RPCs (location, IP, wallet, etc). 

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.

Adding Humans.AI RPCs with chain ID 1089 for mainnet and 4139 for testnet. As far as I can see, those IDs should be also defined in [chainIds.json](https://github.com/DefiLlama/chainlist/blob/main/constants/chainIds.json). If so, please consider doing it.