### PR TITLE
Update extraRpcs.js with new blockpi public endpoint for ETH-Holesky

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2132,6 +2132,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
+      {
+        url: "https://ethereum-holesky.blockpi.network/v1/rpc/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blockpi,
+      },
     ],
   },
   22: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://blockpi.io/
#### Provide a link to your privacy policy:

https://blockpi.io/privacy-policy
#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.