### PR TITLE
update fusion network rpc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1744,10 +1744,8 @@ export const extraRpcs = {
   },
   32659: {
     rpcs: [
-      "https://mainnet.anyswap.exchange",
-      "https://mainway.freemoon.xyz/gate",
-      "https://fsn.dev/api",
       "https://mainnet.fusionnetwork.io",
+      "wss://mainnet.fusionnetwork.io",
     ],
   },
   1284: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
N/A

#### Provide a link to your privacy policy:
All RPC are public for all users.

#### If the RPC has none of the above and you still think it should be added, please explain why:

Update the RPC info from Official Fusion Network. All the existing community rpc such as anyswap / fsn.dev are not function. Hence we request to delete those rpc in order to not misleading user

Your RPC should always be added at the end of the array.