### PR TITLE
add polysplit rpc for chain ids 56 and 1

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -140,6 +140,7 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
     "We may collect information about how you interact with our Service. This may include information about your operating system, IP address, and browser type : https://nodeconnect.org/privacy.txt",
   decubate:
     "With the exception of data that will be public on chain, all the other metadata should remain private to users and other parties should not be able to access or collect it. Decubate doesn't store any data related to the user using the RPC. https://docs.decubate.com/rpc-privacy/",
+  polysplit: "When you use our Service, we may collect information that you provide to us voluntarily. This may include: accessed chain id and status of response."
   };
 
 export const extraRpcs = {
@@ -355,6 +356,11 @@ export const extraRpcs = {
         url: "https://eth.nodeconnect.org/",
         tracking: "yes",
         trackingDetails: privacyStatement.nodeconnect,
+      },
+      {
+        url: "https://rpc.polysplit.cloud/v1/chain/1",
+        tracking: "no",
+        trackingDetails: privacyStatement.polysplit,
       },
     ],
   },
@@ -726,6 +732,11 @@ export const extraRpcs = {
         url: "https://services.tokenview.io/vipapi/nodeservice/bsc?apikey=qVHq2o6jpaakcw3lRstl",
         tracking: "yes",
         trackingDetails: privacyStatement.tokenview,
+      },
+      {
+        url: "https://rpc.polysplit.cloud/v1/chain/56",
+        tracking: "no",
+        trackingDetails: privacyStatement.polysplit,
       },
     ],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -140,7 +140,7 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
     "We may collect information about how you interact with our Service. This may include information about your operating system, IP address, and browser type : https://nodeconnect.org/privacy.txt",
   decubate:
     "With the exception of data that will be public on chain, all the other metadata should remain private to users and other parties should not be able to access or collect it. Decubate doesn't store any data related to the user using the RPC. https://docs.decubate.com/rpc-privacy/",
-  polysplit: "When you use our Service, we may collect information that you provide to us voluntarily. This may include: accessed chain id and status of response."
+  polysplit: "When you use our Service, we does not track the IP address or other user info."
   };
 
 export const extraRpcs = {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://polysplit.cloud

#### Provide a link to your privacy policy:
https://polysplit.cloud/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.