### PR TITLE
fix polysplit

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -362,11 +362,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.nodeconnect,
       },
-      /*{
-        url: "https://rpc.polysplit.cloud/v1/chain/1", // rpc is reporting blocks that don't exist
+      {
+        url: "https://rpc.polysplit.cloud/v1/chain/1",
         tracking: "none",
         trackingDetails: privacyStatement.polysplit,
-      },*/
+      },
     ],
   },
   2: {
@@ -738,11 +738,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.tokenview,
       },
-      /*{
-        url: "https://rpc.polysplit.cloud/v1/chain/56", // rpc is reporting blocks that don't exist
+      {
+        url: "https://rpc.polysplit.cloud/v1/chain/56",
         tracking: "none",
         trackingDetails: privacyStatement.polysplit,
-      },*/
+      },
     ],
   },
   97: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://polysplit.cloud/

Provide a link to your privacy policy:
https://polysplit.cloud/privacy

If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.

We fixed issues happened previously, did not expect such high traffic