### PR TITLE
Add zeta.rpcgrid.com RPCs (+WS) for ZetaChain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -146,6 +146,8 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
     "When you use our Service, we does not track the IP address or other user info.https://polysplit.cloud/privacy",
   nocturnDao:
     "As a fundamental practice, we do not collect, store, or process any personal information from our users. This non-collection policy ensures absolute data security and privacy for our users.https://nocturnode.tech/privacy",
+  rpcgrid:
+    "Only strictly functional data is automatically collected by the RPC. None of this data is directly exported or used for commercial purposes.",
   };
 
 export const extraRpcs = {
@@ -2829,6 +2831,16 @@ export const extraRpcs = {
         url: "wss://zetachain-mainnet-archive.allthatnode.com:8546",
         tracking: "yes",
         trackingDetails: privacyStatement.allthatnode,
+      },
+      {
+        url: "http://zeta.rpcgrid.com:8545",
+        tracking: "none",
+        trackingDetails: privacyStatement.rpcgrid,
+      },
+      {
+        url: "ws://zeta.rpcgrid.com:8546",
+        tracking: "none",
+        trackingDetails: privacyStatement.rpcgrid,
       },
     ],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -147,7 +147,7 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
   nocturnDao:
     "As a fundamental practice, we do not collect, store, or process any personal information from our users. This non-collection policy ensures absolute data security and privacy for our users.https://nocturnode.tech/privacy",
   rpcgrid:
-    "Only strictly functional data is automatically collected by the RPC. None of this data is directly exported or used for commercial purposes.",
+    "Only strictly functional data is automatically collected by the RPC. None of this data is directly exported or used for commercial purposes. https://rpcgrid.com/privacy-policy",
   };
 
 export const extraRpcs = {
@@ -2833,12 +2833,12 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.allthatnode,
       },
       {
-        url: "http://zeta.rpcgrid.com:8545",
+        url: "https://zeta.rpcgrid.com",
         tracking: "none",
         trackingDetails: privacyStatement.rpcgrid,
       },
       {
-        url: "ws://zeta.rpcgrid.com:8546",
+        url: "wss://zeta.rpcgrid.com",
         tracking: "none",
         trackingDetails: privacyStatement.rpcgrid,
       },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://rpcgrid.com/ (under construction)

#### Provide a link to your privacy policy:
`Only strictly functional data is automatically collected by the RPC. None of this data is directly exported or used for commercial purposes.`

#### If the RPC has none of the above and you still think it should be added, please explain why:
RpcGrid provides free and unlimited access for ZetaChain RPC & WS.

Your RPC should always be added at the end of the array.