### PR TITLE
fix: json-rpc body correct json

### DIFF
--- a/hooks/useRPCData.js
+++ b/hooks/useRPCData.js
@@ -5,10 +5,10 @@ import axios from "axios";
 const refetchInterval = 60_000;
 
 export const rpcBody = JSON.stringify({
-  jsonrpc: "2.0",
-  method: "eth_getBlockByNumber",
-  params: ["latest", false],
-  id: 1,
+  "jsonrpc": "2.0",
+  "method": "eth_getBlockByNumber",
+  "params": ["latest", false],
+  "id": 1,
 });
 
 const fetchChain = async (baseURL) => {


### PR DESCRIPTION
The current json-rpc query looks like this:
```
'{jsonrpc: "2.0", method: "eth_getBlockByNumber", params: ["latest", false], id: 1}'
```
This is invalid, as the property name values have to be enclosed in `""`