### PR TITLE
Add blast.gasswap.org

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -153,7 +153,9 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
   tornadoRPC:
     "TornadoRPC prioritizes user privacy and data security. We do not track or store any user information that passes through our RPC, except for data that is clearly visible on the blockchain. For detailed information about our privacy practices, see our Privacy Policy: https://rpc.tornadoeth.cash/privacy",
   q:
-    "Our system records data and information about the computer used by the user automatically and with every visit on our website. The following data are collected: Information regarding the type and version of internet browser used to access the website, Operating system, IP address, Date and time of each access, Web page from which the user was redirected to our page, Web pages and resources that were visited, The data mentioned above are saved for a maximum time period of 30 days.https://q.org/privacy-policy"
+    "Our system records data and information about the computer used by the user automatically and with every visit on our website. The following data are collected: Information regarding the type and version of internet browser used to access the website, Operating system, IP address, Date and time of each access, Web page from which the user was redirected to our page, Web pages and resources that were visited, The data mentioned above are saved for a maximum time period of 30 days.https://q.org/privacy-policy",
+  gasswap:
+    "GasSwap nodes are provided as a public good and we never store any identifiable information for users. See https://docs.gasswap.org/gasswap/public-node",
   };
 
 export const extraRpcs = {
@@ -1385,6 +1387,16 @@ export const extraRpcs = {
         url: "https://rpc.ankr.com/blast",
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
+      },
+      {
+        url: "https://blast.gasswap.org",
+        tracking: "none",
+        trackingDetails: privacyStatement.gasswap,
+      },
+      {
+        url: "wss://blast.gasswap.org/ws",
+        tracking: "none",
+        trackingDetails: privacyStatement.gasswap,
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://gasswap.org

#### Provide a link to your privacy policy:

https://docs.gasswap.org/gasswap/public-node#privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.