### PR TITLE
feat: add hubble exchange chain - hubblenet

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -59,6 +59,7 @@
   "1440": "living assets mainnet",
   "1559": "tenet",
   "1975": "onus",
+  "1992": "hubblenet",
   "2000": "dogechain",
   "2222": "kava",
   "2332": "soma",
@@ -97,5 +98,5 @@
   "1666600000": "harmony",
   "11297108109": "palm",
   "836542336838601": "curio",
-  "463":"areon"
+  "463": "areon"
 }

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4366,6 +4366,12 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.q,
       },
     ]
+  },
+  1992: {
+    rpcs: [
+      "https://rpc.hubble.exchange",
+      "wss://ws-rpc.hubble.exchange"
+    ]
   }
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
Adding new Perp Chain Hubble Exchange(Hubblenet). The PR is still open on [ethereum-lists/chains](https://github.com/ethereum-lists/chains/pull/4486) to add this chain to the list.


#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.hubble.exchange


#### Provide a link to your privacy policy: https://www.hubble.exchange/legal-docs/terms


#### If the RPC has none of the above and you still think it should be added, please explain why:
Terms & Condition don't have anything related to privacy policy but the RPC don't collect any information of the users and it's the public and only one rpc atm.