### PR TITLE
Added SubQuery RPC for Blast & Ethereum

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -411,10 +411,7 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.lava,
       },
-      {
-        url: "https://gateway.subquery.network/rpc/eth",
-        tracking: "unspecified",
-      },
+     "https://gateway.subquery.network/rpc/eth"
     ],
   },
   2: {
@@ -3499,10 +3496,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.stackup,
       },
-      {
-        url: "https://gateway.subquery.network/rpc/base",
-        tracking: "unspecified",
-      },
+     "https://gateway.subquery.network/rpc/base"
     ],
   },
   11235: {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -406,10 +406,14 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.lava,
       },
-	    {
+      {
         url: "https://eth1.lava.build/lava-referer-16223de7-12c0-49f3-8d87-e5f1e6a0eb3b/",
         tracking: "yes",
         trackingDetails: privacyStatement.lava,
+      },
+      {
+        url: "https://gateway.subquery.network/rpc/eth",
+        tracking: "unspecified",
       },
     ],
   },
@@ -3494,6 +3498,10 @@ export const extraRpcs = {
         url: "https://public.stackup.sh/api/v1/node/base-mainnet",
         tracking: "limited",
         trackingDetails: privacyStatement.stackup,
+      },
+      {
+        url: "https://gateway.subquery.network/rpc/base",
+        tracking: "unspecified",
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
Ethereum: https://app.subquery.network/explorer/project/0x04/overview
Base: https://app.subquery.network/explorer/project/0x06/overview

#### Provide a link to your privacy policy:
https://subquery.foundation/public-rpc-terms

Your RPC should always be added at the end of the array.