### PR TITLE
add Linea RPC urls

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4124,8 +4124,22 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
        },
+       {
+        url: "https://linea-goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+        tracking: "limited",
+        trackingDetails: privacyStatement.infura,
+      },       
      ],
    },
+   59141: {
+    rpcs: [
+      {
+        url: "https://linea-sepolia.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+        tracking: "limited",
+        trackingDetails: privacyStatement.infura,
+      }, 
+     ],
+   },   
   534351: {
     rpcs: [
       {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://infura.io/

#### Provide a link to your privacy policy:
https://consensys.io/privacy-policy for Infura

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.