### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1875,16 +1875,12 @@ export const extraRpcs = {
   40: {
     rpcs: [
       "https://mainnet.telos.net/evm",
-      "https://rpc1.eu.telos.net/evm",
-      "https://rpc1.us.telos.net/evm",
-      "https://rpc2.us.telos.net/evm",
-      "https://api.kainosbp.com/evm",
-      "https://rpc2.eu.telos.net/evm",
-      "https://evm.teloskorea.com/evm",
-      "https://rpc2.teloskorea.com/evm",
-      "https://rpc01.us.telosunlimited.io/evm",
-      "https://rpc02.us.telosunlimited.io/evm",
+      "https://mainnet15.telos.net/evm,
+      "https://rpc3.us.telos.net/evm",
       "https://evm.telos.detroitledger.tech/evm",
+      "https://mainnet-us.telos.net/evm",
+      "https://mainnet-eu.telos.net/evm",
+      "https://mainnet-asia.telos.net/evm",
       {
         url: "https://1rpc.io/telos/evm",
         tracking: "none",


### PR DESCRIPTION
The Telos Core Developers released our new v1.5 EVM software today. These updates remove defunct RPCs and add new ones.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): telos.net

#### Provide a link to your privacy policy: 

#### If the RPC has none of the above and you still think it should be added, please explain why: These are the official free-use RPC nodes owned and operated by the Telos Foundation. 

Your RPC should always be added at the end of the array.