### PR TITLE
Update Jelliedowl Edgeware RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2966,7 +2966,10 @@ export const extraRpcs = {
     rpcs: [
       "https://mainnet2.edgewa.re/evm",
       "https://mainnet3.edgewa.re/evm",
-      "https://edgeware-evm.jelliedowl.net/",
+      "https://edgeware-evm0.jelliedowl.net/",
+      "https://edgeware-evm1.jelliedowl.net/",
+      "https://edgeware-evm2.jelliedowl.net/",
+      "https://edgeware-evm3.jelliedowl.net/",
       {
         url: "https://edgeware.api.onfinality.io/public",
         tracking: "limited",


### PR DESCRIPTION
I've rearranged the addresses for my RPCs - this corrects them to the new values.

Chainlist is also showing wss://edgeware.jelliedowl.net, which is NOT an EVM endpoint.  I'm not sure where it's pulling that data from, since I can't find it in this repo?

(Onfinality has stopped providing an RPC for Edgeware. I think their RPC address is dead and not coming back, but I'm not going to decided that it should be removed.)


I don't have a website to link to - I'm just a community member providing some RPCs.