### PR TITLE
Remove broken blastapi.io url

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -874,11 +874,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.ankr,
       },
       {
-        url: "https://blastapi.io/public-api/avalanche",
-        tracking: "limited",
-        trackingDetails: privacyStatement.blastapi,
-      },
-      {
         url: "https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc",
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,


### PR DESCRIPTION
I've removed broken/bad url from blastapi.io on Avalanche

The correct one is: **https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc**, which is already set there.
The **removed url** is just the link to our web public api page