### PR TITLE
Updated extraRpcs.js for Oasys.

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4384,8 +4384,17 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blockpi,
       },
-	"https://oasys-mainnet.gateway.pokt.network/v1/lb/c967bd31",
-	"https://oasys-mainnet-archival.gateway.pokt.network/v1/lb/c967bd31",
+      {
+        url: "https://oasys-mainnet.rpc.grove.city/v1/167fa7a3",
+        tracking: "none",
+        trackingDetails: privacyStatement.pokt
+      },
+      {
+        url: "https://oasys-mainnet-archival.rpc.grove.city/v1/167fa7a3",
+        tracking: "none",
+        trackingDetails: privacyStatement.pokt
+      },
+      "wss://ws.mainnet.oasys.games/",
     ],
   },
   3501: {


### PR DESCRIPTION
The management of POKT's RPCs has been transferred from POKT to Grove, and the RPC URLs have changed. Therefore, we will be updating to the new valid URLs.

The new RPC to be added is the official WebSocket URL of Oasys.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.oasys.games/
https://docs.oasys.games/docs/staking/rpc-endpoint/1-1-rpc-endpoint#mainnet

#### Provide a link to your privacy policy:
https://www.oasys.games/app/uploads/2024/03/Oasys-Privacy-Policy_Mar2024.pdf