### PR TITLE
Update extraRpcs.js -- Etherlink mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4714,6 +4714,11 @@ export const extraRpcs = {
       },
     ]
   },
+  42793: {
+    rpcs: [
+      "https://node.mainnet.etherlink.com"
+    ]
+  },
   881: {
     rpcs:[
       "https://rpc.hypr.network"


### PR DESCRIPTION
Add Etherlink mainnet. Currently, the network is not launched yet. More information, including a privacy policy, will be added once everything goes live

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://etherlink.com

#### Provide a link to your privacy policy:

None at the moment. We will create a follow-up PR as soon as we have more precise information to provide.