### PR TITLE
Add SigmaCore RPC for LUKSO blockchain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -166,7 +166,9 @@ blockswap: "Blockswap RPC does not track any kind of user information at the bui
   "Nodifi AI privacy policy request no privacy intrusion. We do not track IP, wallets, or the websites connected to our nodes. For more info check https://nodifi.ai/privacy-policy",
   rockx:
     "We may automatically collect and store certain information about your interaction with our Applications including IP address, browser type, internet service provider, referring/exit pages, operating system, date/time stamps and related data. For more info check https://www.rockx.com/privacy-policy.",
- };
+  sigmacore:
+    "When you use our services, we do not track user info. Check out our privacy statement here: https://sigmacore.io/privacy-statement.pdf",  
+  };
 
 export const extraRpcs = {
   1: {
@@ -4820,6 +4822,15 @@ export const extraRpcs = {
       "https://rpc.gobob.xyz", 
       "wss://rpc.gobob.xyz"
     ]
+  },
+  42: {
+    rpcs: [
+      {
+        url: "https://rpc.lukso.sigmacore.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.sigmacore,
+      },
+    ],
   }
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
Building our landing page [here](https://sigmacore.io), we are the same team as [Stakingverse](https://stakingverse.io) with staking services for LUKSO and Ethereum. For now our RPC is free, we will add paid tiers for enterprise later on.

#### Provide a link to your privacy policy:
[https://sigmacore.io/privacy-statement.pdf](https://sigmacore.io/privacy-statement.pdf)

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.