### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -427,7 +427,6 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.nodifi,
       },
-     "https://gateway.subquery.network/rpc/eth",
      "https://ethereum.rpc.subquery.network/public",
       {
         url: "https://rpc.graffiti.farm",
@@ -3661,7 +3660,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.tatum,
       },
      "https://base.rpc.subquery.network/public",
-     "https://gateway.subquery.network/rpc/base"
     ],
   },
   11235: {


### PR DESCRIPTION
Removed deprecated SubQuery endpoints. 

The _gateway.subquery.network/rpc/xx_ url has been replaced with _xx.rpc.subquery.network/public_
