### PR TITLE
Remove non-registered RPC for network 19

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2215,7 +2215,7 @@ export const extraRpcs = {
     ],
   },
   19: {
-    rpcs: ["https://songbird.towolabs.com/rpc"],
+    rpcs: [],
   },
   122: {
     rpcs: [


### PR DESCRIPTION
The registered set of RPCs for network 19 (Songbird) is defined in:

https://github.com/ethereum-lists/chains/blob/40c4b1a0a33ecc656c17f16ec2b0930c62b2ba51/_data/chains/eip155-19.json#L5

`chainlist/constants/extraRpcs.js` defines an RPC outside of that registered set. 

https://github.com/DefiLlama/chainlist/blob/0b99ad83072207b649c057b593237752ba222d5f/constants/extraRpcs.js#L2218

This is also the default Chainlist chooses, leading to warnings when adding the network via Chainlist to wallets like Metamask etc.

Perhaps the simplest solution here is to just remove this RPC from `extraRPCs.js`, which I have done in this PR. This should let Chainlist use the registered RPCs defined in `ethereum-lists/chains`.

Please let me know if this is not the case, and I will modify the PR accordingly. Thanks.