### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1836,28 +1836,16 @@ export const extraRpcs = {
 },
 2330: {
     rpcs: [
-      {
-        url: "http://138.197.152.181:8145",
-        tracking: "none",
-        trackingDetails: privacyStatement.gitshock,
-      },
-      {
-        url: "https://rpc0.altcoinchain.org/rpc",
-        tracking: "none",
-        trackingDetails: privacyStatement.gitshock,
-      }
+      "http://138.197.152.181:8145",
+      "https://rpc0.altcoinchain.org/rpc"
     ]
   },	
  1773: {
     rpcs: [
-      {
-        url: "http://138.197.152.181:8245",
-        tracking: "none",
-        trackingDetails: privacyStatement.gitshock,
-      }
+     "http://138.197.152.181:8245"
     ]
   },
-  1881: {
+1881: {
     rpcs: [
       {
         url: "https://rpc.cartenz.works",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1834,6 +1834,29 @@ export const extraRpcs = {
       },
    ],
 },
+2330: {
+    rpcs: [
+      {
+        url: "http://138.197.152.181:8145",
+        tracking: "none",
+        trackingDetails: privacyStatement.gitshock,
+      },
+      {
+        url: "https://rpc0.altcoinchain.org/rpc",
+        tracking: "none",
+        trackingDetails: privacyStatement.gitshock,
+      }
+    ]
+  },	
+ 1773: {
+    rpcs: [
+      {
+        url: "http://138.197.152.181:8245",
+        tracking: "none",
+        trackingDetails: privacyStatement.gitshock,
+      }
+    ]
+  },
   1881: {
     rpcs: [
       {


### PR DESCRIPTION
added to lines 1837-1858 added the following chains and rpc nodes

```2330: {
    rpcs: [
      {
        url: "http://138.197.152.181:8145",
        tracking: "none",
        trackingDetails: privacyStatement.gitshock,
      },
      {
        url: "https://rpc0.altcoinchain.org/rpc",
        tracking: "none",
        trackingDetails: privacyStatement.gitshock,
      }
    ]
  },	
 1773: {
    rpcs: [
      {
        url: "http://138.197.152.181:8245",
        tracking: "none",
        trackingDetails: privacyStatement.gitshock,
      }
    ]
  },```

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.