### PR TITLE
Updated Klaytn Testnet endpoint and allthatnode urls

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1430,7 +1430,7 @@ export const extraRpcs = {
     rpcs: [
       "https://public-en-cypress.klaytn.net",
       {
-        url: "https://klaytn-mainnet-rpc.allthatnode.com:8551",
+        url: "https://klaytn-mainnet.g.allthatnode.com/full/evm",
         tracking: "yes",
         trackingDetails: privacyStatement.allthatnode,
       },
@@ -2955,9 +2955,9 @@ export const extraRpcs = {
   },
   1001: {
     rpcs: [
-      "https://public-en-baobab.klaytn.net",
+      "https://public-en.kairos.node.kaia.io",
       {
-        url: "https://klaytn-baobab-rpc.allthatnode.com:8551",
+        url: "https://klaytn-baobab.g.allthatnode.com/full/evm",
         tracking: "yes",
         trackingDetails: privacyStatement.allthatnode,
       },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
* Updated the Klaytn Testnet url https://klaytn.foundation/kaia-testnet-kairos-launch/
* Updated the Allthatnode urls of Klaytn https://www.allthatnode.com/klaytn.dsrv

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.