### PR TITLE
Kaia testnet kairos RPC update

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2956,6 +2956,7 @@ export const extraRpcs = {
   1001: {
     rpcs: [
       "https://public-en-baobab.klaytn.net",
+      "https://public-en.kairos.node.kaia.io",
       {
         url: "https://klaytn-baobab-rpc.allthatnode.com:8551",
         tracking: "yes",


### PR DESCRIPTION
Kaia Testnet Kairos RPC update(Kaia is klaytn's new name)
Kaia Testnet Kairos Launch Announcement Blog: https://klaytn.foundation/kaia-testnet-kairos-launch/