### PR TITLE
Update extraRpcs.js - Graffiti WebSocket Endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -433,6 +433,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.radiumblock,
       },
+      {
+        url: "wss://ws-rpc.graffiti.farm",
+        tracking: "limited",
+        trackingDetails: privacyStatement.graffiti,
+      },
     ],
   },
   2: {


### PR DESCRIPTION
Add WebSocket endpoint for Graffiti RPC

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://graffiti.farm

#### Provide a link to your privacy policy:

https://graffiti.farm/privacy-policy/