### PR TITLE
Add SX L2 Rollup Mainnet & Toronto RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5526,6 +5526,20 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
     ],
+  },
+  4162: {
+    rpcs: [
+      {
+        url: "https://rpc.sx-rollup.gelato.digital",
+      },
+    ],
+  },
+  79479957: {
+    rpcs: [
+      {
+        url: "https://rpc.sx-rollup-testnet.t.raas.gelato.cloud",
+      },
+    ],
   }
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
`https://www.sx.technology/`

#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.


Added to https://github.com/ethereum-lists/chains/pull/5575