### PR TITLE
Add Story Testnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5596,7 +5596,8 @@ export const extraRpcs = {
   1513: {
     rpcs: [
       "https://testnet.storyrpc.io",
-      "https://story-rpc-evm.validatorvn.com",
+      "https://story-rpc-evm.validatorvn.com"
+      "https://story-evm-testnet-rpc.tech-coha05.xyz",
       {
         url: "https://story-rpc01.originstake.com",
         tracking: "none",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://services.tech-coha05.xyz
#### Provide a link to your privacy policy:
https://services.tech-coha05.xyz/privacy_policy.html
#### If the RPC has none of the above and you still think it should be added, please explain why:
It helps more RPCs come to Story networks becuz there is not much avl RPCs then.
Your RPC should always be added at the end of the array.