### PR TITLE
Remove Taiko ws endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4829,7 +4829,6 @@ export const extraRpcs = {
   167000: {
     rpcs: [
       "https://rpc.taiko.xyz",
-      "wss://ws.taiko.xyz",
       {
         url: "https://taiko.blockpi.network/v1/rpc/public",
         tracking: "limited",


### PR DESCRIPTION
We are shutting down our public ws endpoint within the week, also need to remove wss://ws.mainnet.taiko.xyz but unsure where to do so