### PR TITLE
Update extraRpcs.js - Add OriginStake ZeroGravity Newton Testnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5615,6 +5615,17 @@ export const extraRpcs = {
       "https://rpc-storyevm-testnet.aldebaranode.xyz"
     ]
   },
+  16600: {
+    rpcs: [
+      "https://0g-json-rpc-public.originstake.com",
+      {
+      url: "https://0g-json-rpc-public.originstake.com",
+      tracking: "none",
+      trackingDetails: privacyStatement.originstake,
+      },
+    ],
+  },
+  
   1750: {
     rpcs: [
       "https://rpc.metall2.com",


### PR DESCRIPTION
Add OriginStake ZeroGravity Newton Testnet RPC

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

Website: https://originstake.com/
Verified by StakingReward: https://www.stakingrewards.com/provider/originstake

#### Provide a link to your privacy policy:

https://originstake.com/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.