### PR TITLE
Add Tenderly.co Node RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -733,6 +733,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.tatum,
       },
+      {
+        url: "https://polygon-amoy.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   56: {
@@ -1011,6 +1016,11 @@ export const extraRpcs = {
         url: "https://avax-x-mainnet.gateway.tatum.io",
         tracking: "yes",
         trackingDetails: privacyStatement.tatum,
+      },
+      {
+        url: "https://avalanche-mainnet.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -1351,6 +1361,11 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.stateless,
       },
       "https://arbitrum.rpc.subquery.network/public",
+      {
+        url: "https://arbitrum.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   421613: {
@@ -1425,6 +1440,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.tatum,
       },
+      {
+        url: "https://arbitrum-nova.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   421614: {
@@ -1443,6 +1463,11 @@ export const extraRpcs = {
         url: "https://endpoints.omniatech.io/v1/arbitrum/sepolia/public",
         tracking: "none",
         trackingDetails: privacyStatement.omnia,
+      },
+      {
+        url: "https://arbitrum-sepolia.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -1592,6 +1617,11 @@ export const extraRpcs = {
         url: "wss://blast.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://blast.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -1874,6 +1904,11 @@ export const extraRpcs = {
         url: "https://endpoints.omniatech.io/v1/op/sepolia/public",
         tracking: "none",
         trackingDetails: privacyStatement.omnia,
+      },
+      {
+        url: "https://optimism-sepolia.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -2725,6 +2760,11 @@ export const extraRpcs = {
         url: "https://holesky-rpc.nocturnode.tech",
         tracking: "none",
         trackingDetails: privacyStatement.nocturnDao,
+      },
+      {
+        url: "https://holesky.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -3874,6 +3914,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.stackup,
       },
+      {
+        url: "https://base-sepolia.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   84531: {
@@ -4869,6 +4914,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.porters,
       },
+      {
+        url: "https://taiko-mainnet.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   167008: {
@@ -4921,6 +4971,11 @@ export const extraRpcs = {
         url: "https://hekla-testnet.rpc.porters.xyz/taiko-public",
         tracking: "none",
         trackingDetails: privacyStatement.porters,
+      },
+      {
+        url: "https://taiko-hekla.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -5147,6 +5202,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://mode.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   217: {
@@ -5264,6 +5324,11 @@ export const extraRpcs = {
         url: "wss://bob.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://bob.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },
@@ -5444,6 +5509,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://fraxtal.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   13371: {
@@ -5461,6 +5531,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://immutable.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   1135: {
@@ -5475,6 +5550,11 @@ export const extraRpcs = {
         url: "wss://lisk.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://lisk.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
       },
     ],
   },


### PR DESCRIPTION
## New RPCs

- Tenderly Polygon Amoy Node RPC
- Tenderly Avalanche Mainnet Node RPC
- Tenderly Arbitrum Node RPC
- Tenderly Arbitrum Nova Node RPC
- Tenderly Arbitrum Sepolia Node RPC
- Tenderly Blast Node RPC
- Tenderly Optimism Sepolia Node RPC
- Tenderly Holesky Node RPC
- Tenderly Base Sepolia Node RPC
- Tenderly Taiko Node RPC
- Tenderly Taiko Hekla Node RPC
- Tenderly Taiko Node RPC
- Tenderly Mode Node RPC
- Tenderly BOB Node RPC
- Tenderly Fraxtal Node RPC
- Tenderly Immutable Node RPC
- Tenderly Lisk Node RPC

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://tenderly.co

#### Provide a link to your privacy policy:

https://tenderly.co/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.