### PR TITLE
add Citrea testnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5726,6 +5726,9 @@ export const extraRpcs = {
   8428: {
     rpcs: ["https://api.thatchain.io", "https://api.thatchain.io/mainnet"],
   },
+  5115: {
+    rpcs: ["https://rpc.testnet.citrea.xyz"],
+  },
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
[https://citrea.xyz](https://citrea.xyz)

#### Provide a link to your privacy policy:
Didn't add a privacy policy since other default RPC's for chains didn't have one. If this is a must I can make another commit.