### PR TITLE
add Coha05 vana testnet rpc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5766,6 +5766,7 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc.moksha.vana.org",
       "https://rpc-moksha-vana-josephtran.xyz",
+      "https://moksha-vana-rpc.tech-coha05.xyz",
     ],
   },
   


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://services.tech-coha05.xyz/

#### Provide a link to your privacy policy:
https://services.tech-coha05.xyz/privacy_policy.html

#### If the RPC has none of the above and you still think it should be added, please explain why:
For user more choice when some rpcs get congestion
Your RPC should always be added at the end of the array.