### PR TITLE
Add Lisk Chain ID

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -64,6 +64,7 @@
   "1100": "dymension",
   "1101": "polygon zkevm",
   "1116": "core",
+  "1135": "lisk",
   "1231": "ultron",
   "1234": "step",
   "1284": "moonbeam",


### PR DESCRIPTION
This PR will add the Lisk Chain ID to the ChainID constants.

Lisk is already merged into Ethereum Chainlist:
https://github.com/ethereum-lists/chains/pull/4988

RPC for Lisk is already available: 
https://github.com/DefiLlama/chainlist/blob/main/constants/extraRpcs.js#L5545

Thanks!


