### PR TITLE
Add Roostock BlastAPI endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2347,6 +2347,10 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://rootstock-mainnet.public.blastapi.io",
+        tracking: "limited",
+        trackingDetails: privacyStatement.blastapi,
     ],
   },
 


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blastapi.io/chains/rootstock

#### Provide a link to your privacy policy:
Already included in chainlist

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.