### PR TITLE
feat: added stakely json-rpc for taiko and fantom

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1096,6 +1096,7 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.omnia,
       },
+      "https://fantom-json-rpc.stakely.io",
     ],
   },
   137: {
@@ -4926,6 +4927,7 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
       },
+      "https://taiko-json-rpc.stakely.io/"
     ],
   },
   167009: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

- Main website: https://stakely.io/
- Fantom JSON-RPC load balancer: https://stakely.io/web3-api-load-balancer/fantom?type=json-rpc
- Taiko Mainnet JSON-RPC load balancer https://stakely.io/web3-api-load-balancer/taiko?type=json-rpc 
#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.