### PR TITLE
Add CheeseChain RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5806,6 +5806,13 @@ export const extraRpcs = {
       tracking: "yes",
       trackingDetails: privacyStatement.bctech,
     }]
+  },
+  383353: {
+    rpcs: [
+      "https://rpc.cheesechain.xyz/http",
+      "https://cheesechain.calderachain.xyz/http",
+      "wss://cheesechain.calderachain.xyz/ws",
+    ],
   }
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://cheesechain.xyz


#### If the RPC has none of the above and you still think it should be added, please explain why:

CheeseChain has been added in https://chainid.network/

https://chainid.network/chain/383353/