### PR TITLE
Updated Kaia chain extraRpcs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1521,11 +1521,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
       {
-        url: "https://klaytn-cypress.gateway.tatum.io",
-        tracking: "yes",
-        trackingDetails: privacyStatement.tatum,
-      },
-      {
         url: "https://rpc.ankr.com/klaytn ",
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Tatum currently doesnt provide free public RPC endpoints.
https://tatum.io/nodes

So, removing from the chainlist accordingly. 
Thanks.
