### PR TITLE
Delete OnFinality RPC endpoint for Harmony

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1540,11 +1540,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.ankr,
       },
       {
-        url: "https://harmony.api.onfinality.io/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.onfinality,
-      },
-      {
         url: "https://1rpc.io/one",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,


### PR DESCRIPTION
OnFinality has removed Harmony's RPC, so this endpoint is no longer valid: 
`https://harmony.api.onfinality.io/public`