### PR TITLE
update 48Club rpc url

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -775,7 +775,12 @@ export const extraRpcs = {
         trackingDetails: privacyStatement["48Club"],
       },
       {
-        url: "https://koge-rpc-bsc.48.club",
+        url: "https://0.48.club",
+        tracking: "limited",
+        trackingDetails: privacyStatement["48Club"],
+      },
+      {
+        url: "wss://rpc-bsc.48.club/ws/",
         tracking: "limited",
         trackingDetails: privacyStatement["48Club"],
       },


### PR DESCRIPTION
- remove deprecated rpc addresses
- added 0.48.club, it is different from rpc-bsc.48.club in that eth_gasPrice returns 1wei. Here is its usage description https://docs.48.club/privacy-rpc/0-gwei-rpc & https://docs.48.club/48-soul-point
- added websocket protocol rpc, btw wss://0.48.club/ws/ also works