### PR TITLE
Add dexrouting Canto RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3842,6 +3842,7 @@ export const extraRpcs = {
       "wss://canto.gravitychain.io:8546",
       "wss://canto.dexvaults.com/ws",
       "https://canto-rpc.ansybl.io",
+      "https://canto.dexrouting.com",
     ],
   },
   7924: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
[https://dexrouting.com](https://dexrouting.com/)

#### Provide a link to your privacy policy:
[https://dexrouting.com/privacy](https://dexrouting.com/privacy)

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.