### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2307,13 +2307,7 @@ export const extraRpcs = {
   },
   40: {
     rpcs: [
-      "https://mainnet.telos.net/evm",
-      "https://mainnet15.telos.net/evm",
-      "https://rpc3.us.telos.net/evm",
-      "https://evm.telos.detroitledger.tech/evm",
-      "https://mainnet-us.telos.net/evm",
-      "https://mainnet-eu.telos.net/evm",
-      "https://mainnet-asia.telos.net/evm",
+      "https://rpc.telos.net",
       {
         url: "https://1rpc.io/telos/evm",
         tracking: "none",


### PR DESCRIPTION
The Telos Core Developers have released our new v2.0 EVM execution client based on reth. These updates remove defunct RPCs and add new ones.

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC): telos.net

Provide a link to your privacy policy: Tracking is limited and we do not currently have a tracking policy

If the RPC has none of the above and you still think it should be added, please explain why: These are the official free-use RPC nodes owned and operated by the Telos Foundation.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.