### PR TITLE
Fix issue with build time formatting in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,7 +26,7 @@ BUILD_STATUS=${PIPESTATUS[0]}
 
 BUILD_TIME_SEC=$(($(date -u +"%s") - $START_TIME_TS))
 BUILD_TIME_MIN=$(($BUILD_TIME_SEC / 60))
-BUILD_TIME_STR=$(printf "%ss" $(($BUILD_TIME_SEC % 60)))
+BUILD_TIME_STR=$(printf "%s seconds" $(($BUILD_TIME_SEC % 60)))
 if [ $BUILD_TIME_MIN -gt 0 ]; then
   BUILD_TIME_STR=$(printf "%sm %s" $BUILD_TIME_MIN $BUILD_TIME_STR)
 fi


### PR DESCRIPTION
**Description:**

This update addresses an issue in the build script where the build time was being displayed incorrectly due to a formatting mistake.

### Key Fix:
The line responsible for formatting the build time:
```bash
BUILD_TIME_STR=$(printf "%ss" $(($BUILD_TIME_SEC % 60)))
```
was using the incorrect format `"%ss"`. This would have resulted in an incorrect output, as the intention was to display the build time in seconds. The fix replaces it with:
```bash
BUILD_TIME_STR=$(printf "%s seconds" $(($BUILD_TIME_SEC % 60)))
```

### Importance:
This change ensures that the build time is displayed correctly, with the appropriate units ("seconds") in the output. Without this fix, the script could produce misleading or inconsistent information, making it harder to track the build duration accurately. This update improves the clarity of the build output, making it more user-friendly and professional.