### PR TITLE
Please change RPC for Callisto network

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2928,7 +2928,7 @@ export const extraRpcs = {
     ],
   },
   820: {
-    rpcs: ["https://rpc.callisto.network", "https://clo-geth.0xinfra.com/"],
+    rpcs: ["https://rpc.callistodao.org"],
   },
   108: {
     rpcs: [


### PR DESCRIPTION
https://callistodao.org

The previous provider of RPC no longer supports it. A new node "https://rpc.callistodao.org" was created by the Callisto DAO, which is currently the only one. The old ones ("https://rpc.callisto.network" and "https://clo-geth.0xinfra.com/") and should be removed to avoid confusion.