### PR TITLE
Fix `Rootstock` chain logo

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -7,7 +7,7 @@ export default {
   "20": "elastos",
   "24": "kardia",
   "25": "cronos",
-  "30": "rsk",
+  "30": "rootstock",
   "40": "telos",
   "42": "lukso",
   "44": "crab",

--- a/utils/fetch.js
+++ b/utils/fetch.js
@@ -44,18 +44,15 @@ export function populateChain(chain, chainTvls) {
 
     const chainSlug = chainIds[chain.chainId];
 
-    if (chainSlug !== undefined) {
-        const defiChain = chainTvls.find((c) => c.name.toLowerCase() === chainSlug);
+    const defiChain = chainTvls.find((c) => c.chainId === chain.chainId);
 
-        return defiChain === undefined
+    return defiChain === undefined
         ? chain
         : {
             ...chain,
             tvl: defiChain.tvl,
             chainSlug,
             };
-    }
-    return chain;
 }
 
 export function mergeDeep(target, source) {


### PR DESCRIPTION
## Description

This PR fixes the Rootstock chain logo which is based on chain name. 

Where: https://chainlist.org/chain/30

## Changes
- Update `rsk` to `rootstock` in list of chains
- Fix match tvl logic to base it on chainId instead of chain slug

## Demo
<img width="1503" alt="Screenshot 2024-12-04 at 8 54 32 PM" src="https://github.com/user-attachments/assets/126c277d-8938-471a-8e0e-6531088c10e0">

