### PR TITLE
Fix Oasis Sapphire shortname in mapping of chainIds

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -111,7 +111,7 @@ export default {
   "16507": "genesys",
   "17777": "eos evm",
   "22776": "map protocol",
-  "23294": "oasis_sapphire",
+  "23294": "sapphire",
   "32520": "bitgert",
   "32659": "fusion",
   "32769": "zilliqa",


### PR DESCRIPTION
## Description

I think there is still an inconsistency between the normalized name and the chainId mapping. 

The icon logo [server](https://api.llama.fi/chains) returns `sapphire`.

```json
  {
    "gecko_id": null,
    "tvl": 4693817.56340488,
    "tokenSymbol": "ROSE",
    "cmcId": null,
    "name": "Sapphire",
    "chainId": 23294
  },
```

Or maybe we need to rename "sapphire" [here](https://github.com/DefiLlama/defillama-server/blob/2eed7f3275bfed16cab2118cd3250923b79032dc/defi/src/utils/normalizeChain.ts#L29)?