### PR TITLE
add hydration chain id

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -135,6 +135,7 @@ export default {
   "111188": "real",
   "167000": "taiko",
   "200901": "bitlayer",
+  "222222": "hydration",
   "333999": "polis",
   "534352": "scroll",
   "420420": "kekchain",


### PR DESCRIPTION
Adding missing hydration chain id. Seems like icon is also missing yet i can see correct icon here:

https://github.com/DefiLlama/icons/blob/v2/assets/chains/rsz_hydration.jpg

Any idea? 

See:
https://chainlist.org/chain/222222
https://chainid.network/chain/222222/