### PR TITLE
feat: add alchemy and quiknode rpcs for nova

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1570,6 +1570,21 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.Histori,
       },
+      {
+        url: "https://arbnova-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
+        tracking: "yes",
+        trackingDetails: privacyStatement.alchemy,
+      },
+      {
+        url: "https://${QUICKNODE_IDENTIFIER}.nova-mainnet.quiknode.pro/${QUICKNODE_API_KEY}",
+        tracking: "yes",
+        trackingDetails: privacyStatement.quicknode,
+      },
+      {
+        url: "https://docs-demo.nova-mainnet.quiknode.pro",
+        tracking: "yes",
+        trackingDetails: privacyStatement.quicknode,
+      },
     ],
   },
   421614: {
@@ -6438,9 +6453,6 @@ export const extraRpcs = {
     ],
   },
 
-
-
-
   16600: {
     rpcs: [
       "https://rpc-testnet.0g.ai",
@@ -6665,14 +6677,14 @@ export const extraRpcs = {
       },
     ],
   },
-30311: {
+  30311: {
     rpcs: [
       {
         url: "https://dream-rpc.somnia.network",
         tracking: "none",
         trackingDetails: privacyStatement.somnia,
-      }
-    ]
+      },
+    ],
   },
   763373: {
     rpcs: ["https://rpc-gel-sepolia.inkonchain.com", "wss://ws-gel-sepolia.inkonchain.com"],
@@ -6706,7 +6718,7 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
-{
+      {
         url: "wss://apechain.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
@@ -6790,12 +6802,12 @@ export const extraRpcs = {
     ],
   },
 
-1480: {
+  1480: {
     rpcs: [
       "https://rpc.vana.org",
       "https://evm-rpc-vana.josephtran.xyz",
       "https://evm-rpc-vana.j-node.net",
-      "https://islander-vana-rpc.spidernode.net"
+      "https://islander-vana-rpc.spidernode.net",
     ],
   },
 


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
QuickNode: https://www.quicknode.com/docs/arbitrum-nova#endpoint-authentication-options
https://www.quicknode.com/docs/arbitrum-nova/eth_accounts

Alchemy: https://docs.alchemy.com/reference/arbitrum-nova-api-quickstart#3-make-your-first-request

#### Provide a link to your privacy policy:
Already exist in the repo