### PR TITLE
Updated Kaia RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3528,7 +3528,7 @@ export const extraRpcs = {
   },
   1001: {
     rpcs: [
-      "https://public-en.kairos.node.kaia.io",
+      "https://public-en-kairos.node.kaia.io",
       {
         url: "https://responsive-green-emerald.kaia-kairos.quiknode.pro/",
         tracking: "yes",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://docs.kaia.io/references/public-en/#testnet-kairos-public-json-rpc-endpoints

#### Provide a link to your privacy policy:
https://docs.kaia.io/misc/terms-of-use/

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.