### PR TITLE
Add callStatic Sonic mainnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6869,6 +6869,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
       },
+      {
+        url: "wss://sonic.callstaticrpc.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.callstatic,
+      },
     ],
   },
   57054: {


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://callstatic.com

#### Provide a link to your privacy policy:

https://callstatic.com/privacy-policy/

#### If the RPC has none of the above and you still think it should be added, please explain why:

\-