### PR TITLE
Add DTEAM Story Odyssey RPC to extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6474,6 +6474,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blockpi,
       },
       "https://story-odyssey-rpc.auranode.xyz",
+      "https://evm-rpc.story.testnet.dteam.tech"
     ],
   },
 


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://dteam.tech

#### Provide a link to your privacy policy:

#### If the RPC has none of the above and you still think it should be added, please explain why:
Add extra Story Protocol Odyssey testnet RPC. Chain already registered.

Your RPC should always be added at the end of the array.