### PR TITLE
Add DTEAM Story mainnet RPC to extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6905,6 +6905,7 @@ export const extraRpcs = {
     rpcs: [
       "https://mainnet.storyrpc.io",
       "https://story-evm-rpc.spidernode.net",
+      "https://evm-rpc.story.mainnet.dteam.tech"
     ],
   },
 };


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://dteam.tech/

#### Provide a link to your privacy policy:

#### If the RPC has none of the above and you still think it should be added, please explain why:
Story mainnet preparation, pre-adding DTEAM Story mainnet RPC. Chain already registered.

Your RPC should always be added at the end of the array.