### PR TITLE
Removed wrong rpc from kaia kairos testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3558,11 +3558,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.ankr,
       },
       {
-        url: "https://klaytn.api.onfinality.io/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.onfinality,
-      },
-      {
         url: "https://node.histori.xyz/kaia-testnet/8ry9f6t9dct1se2hlagxnd9n2a",
         tracking: "none",
         trackingDetails: privacyStatement.Histori,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Removed wrong rpc from kaia kairos testnet. its configured mainnet url instead of testnet. however onfinality doesnt provide free public kaia testnet url.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://onfinality.io/networks/klaytn