### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5471,12 +5471,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blockpi,
       },
       {
-        url: "https://oasys-mainnet.rpc.grove.city/v1/167fa7a3",
-        tracking: "none",
-        trackingDetails: privacyStatement.pokt,
-      },
-      {
-        url: "https://oasys-mainnet-archival.rpc.grove.city/v1/167fa7a3",
+        url: "https://oasys.rpc.grove.city/v1/167fa7a3",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
       },


### PR DESCRIPTION
Grove has requested us to use a new RPC URL that integrates the mainnet and mainnet-archival RPC URLs moving forward. Therefore, we will submit a pull request to update the RPC URL accordingly.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://www.oasys.games/
https://docs.oasys.games/docs/staking/rpc-endpoint/1-1-rpc-endpoint#mainnet

#### Provide a link to your privacy policy:

https://www.oasys.games/app/uploads/2024/03/Oasys-Privacy-Policy_Mar2024.pdf