### PR TITLE
Add block gas limit in each chain card

### DIFF
--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -84,6 +84,12 @@ export default function Chain({ chain, buttonOnly, lang }) {
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
               </td>
             </tr>
+            <tr>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">Block Gas Limit</td>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
+                {chain.blockGasLimit ? chain.blockGasLimit : "Unknown"}
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/hooks/useRPCData.js
+++ b/hooks/useRPCData.js
@@ -51,13 +51,14 @@ const fetchChain = async (baseURL) => {
 const formatData = (url, data) => {
   let height = data?.result?.number ?? null;
   let latency = data?.latency ?? null;
+  let blockGasLimit = data?.result?.gasLimit ?? null;
   if (height) {
     const hexString = height.toString(16);
     height = parseInt(hexString, 16);
   } else {
     latency = null;
   }
-  return { url, height, latency };
+  return { url, height, latency, blockGasLimit };
 };
 
 const useHttpQuery = (url) => {

--- a/stores/index.js
+++ b/stores/index.js
@@ -2,7 +2,8 @@ import create from "zustand";
 
 export const useChain = create((set) => ({
   id: null,
-  updateChain: (id) => set(() => ({ id })),
+  blockGasLimit: 'Unknown',
+  updateChain: (id, blockGasLimit = 'Unknown') => set(() => ({ id, blockGasLimit })),
 }));
 
 export const useRpcStore = create((set) => ({


### PR DESCRIPTION
Related to #1426

Add block gas limit display to each chain card.

* Modify `components/chain/index.js` to include a new row in the table for displaying the block gas limit, with a default value of 'Unknown' if not available.
* Update `hooks/useRPCData.js` to fetch the block gas limit and include it in the formatted data.
* Change `stores/index.js` to manage the block gas limit state, adding a new state variable and updating the `updateChain` function to include the block gas limit.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DefiLlama/chainlist/pull/1509?shareId=e448e62d-f781-4cf4-b81f-82969ad32713).