### PR TITLE
Add block gas limit in each chain card

### DIFF
--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -73,6 +73,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
             <tr>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
+              <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">Block Gas Limit</th>
             </tr>
           </thead>
           <tbody>
@@ -82,6 +83,9 @@ export default function Chain({ chain, buttonOnly, lang }) {
               ).toString(16)})`}</td>
               <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
+              </td>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
+                {chain.blockGasLimit ? chain.blockGasLimit : "Unknown"}
               </td>
             </tr>
           </tbody>

--- a/hooks/useRPCData.js
+++ b/hooks/useRPCData.js
@@ -51,13 +51,14 @@ const fetchChain = async (baseURL) => {
 const formatData = (url, data) => {
   let height = data?.result?.number ?? null;
   let latency = data?.latency ?? null;
+  let blockGasLimit = data?.result?.gasLimit ?? null;
   if (height) {
     const hexString = height.toString(16);
     height = parseInt(hexString, 16);
   } else {
     latency = null;
   }
-  return { url, height, latency };
+  return { url, height, latency, blockGasLimit };
 };
 
 const useHttpQuery = (url) => {


### PR DESCRIPTION
Related to #1426

Add block gas limit display to each chain card.

* **components/chain/index.js**
  - Add a new column in the chain card table to display the block gas limit.
  - Set the default value of the block gas limit to 'Unknown' if not available.

* **hooks/useRPCData.js**
  - Modify the `formatData` function to include block gas limit in the returned data.
  - Add logic to extract block gas limit from the fetched data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DefiLlama/chainlist/pull/1510?shareId=36e79b99-639c-4df2-b8e5-778875177cb7).