### PR TITLE
Add block gas limit in each chain card

### DIFF
--- a/components/RPCList/index.js
+++ b/components/RPCList/index.js
@@ -80,7 +80,7 @@ export default function RPCList({ chain, lang }) {
   const { rpcData, hasLlamaNodesRpc } = useLlamaNodesRpcData(chain.chainId, data);
 
   return (
-    <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 rounded-[10px] flex flex-col gap-3 overflow-hidden col-span-full relative overflow-x-auto">
+    <div className="shadow dark:bg-[#0D0D0D] bg-white p-8 rounded-[10px] flex flex-col gap-3 col-span-full relative overflow-x-auto">
       <table className="m-0 border-collapse whitespace-nowrap dark:text-[#B3B3B3] text-black">
         <caption className="relative w-full px-3 py-1 text-base font-medium border border-b-0">
           <span className="mr-4">{`${chain.name} RPC URL List`}</span>

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -8,6 +8,7 @@ import { notTranslation as useTranslations } from "../../utils";
 import { useChain } from "../../stores";
 import useAccount from "../../hooks/useAccount";
 import useAddToNetwork from "../../hooks/useAddToNetwork";
+import { Tooltip } from "../Tooltip";
 
 export default function Chain({ chain, buttonOnly, lang }) {
   const t = useTranslations("Common", lang);
@@ -115,7 +116,11 @@ export default function Chain({ chain, buttonOnly, lang }) {
               <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
               </td>
-              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">{blockGasLimit}</td>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
+                <Tooltip content={blockGasLimit}>
+                  <span>Hover to see</span>
+                </Tooltip>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -8,7 +8,6 @@ import { notTranslation as useTranslations } from "../../utils";
 import { useChain } from "../../stores";
 import useAccount from "../../hooks/useAccount";
 import useAddToNetwork from "../../hooks/useAddToNetwork";
-import { Tooltip } from "../Tooltip";
 
 export default function Chain({ chain, buttonOnly, lang }) {
   const t = useTranslations("Common", lang);
@@ -37,37 +36,6 @@ export default function Chain({ chain, buttonOnly, lang }) {
   const address = accountData?.address ?? null;
 
   const { mutate: addToNetwork } = useAddToNetwork();
-
-  const [blockGasLimit, setBlockGasLimit] = React.useState('Unknown');
-
-  React.useEffect(() => {
-    async function fetchBlockGasLimit() {
-      try {
-        const response = await fetch(chain.rpc[0].url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'eth_getBlockByNumber',
-            params: ['latest', false],
-            id: 1,
-          }),
-        });
-        const data = await response.json();
-        if (data.result && data.result.gasLimit) {
-          setBlockGasLimit(parseInt(data.result.gasLimit, 16));
-        }
-      } catch (error) {
-        console.error('Error fetching block gas limit:', error);
-      }
-    }
-
-    if (chain.rpc && chain.rpc.length > 0) {
-      fetchBlockGasLimit();
-    }
-  }, [chain.rpc]);
 
   if (!chain) {
     return <></>;
@@ -105,7 +73,6 @@ export default function Chain({ chain, buttonOnly, lang }) {
             <tr>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
-              <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">Block Gas Limit</th>
             </tr>
           </thead>
           <tbody>
@@ -115,11 +82,6 @@ export default function Chain({ chain, buttonOnly, lang }) {
               ).toString(16)})`}</td>
               <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
-              </td>
-              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
-                <Tooltip content={blockGasLimit}>
-                  <span>Hover to see</span>
-                </Tooltip>
               </td>
             </tr>
           </tbody>

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -37,6 +37,37 @@ export default function Chain({ chain, buttonOnly, lang }) {
 
   const { mutate: addToNetwork } = useAddToNetwork();
 
+  const [blockGasLimit, setBlockGasLimit] = React.useState('Unknown');
+
+  React.useEffect(() => {
+    async function fetchBlockGasLimit() {
+      try {
+        const response = await fetch(chain.rpc[0].url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'eth_getBlockByNumber',
+            params: ['latest', false],
+            id: 1,
+          }),
+        });
+        const data = await response.json();
+        if (data.result && data.result.gasLimit) {
+          setBlockGasLimit(parseInt(data.result.gasLimit, 16));
+        }
+      } catch (error) {
+        console.error('Error fetching block gas limit:', error);
+      }
+    }
+
+    if (chain.rpc && chain.rpc.length > 0) {
+      fetchBlockGasLimit();
+    }
+  }, [chain.rpc]);
+
   if (!chain) {
     return <></>;
   }
@@ -73,6 +104,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
             <tr>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">ChainID</th>
               <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">{t("currency")}</th>
+              <th className="font-normal text-gray-500 dark:text-[#B3B3B3]">Block Gas Limit</th>
             </tr>
           </thead>
           <tbody>
@@ -83,6 +115,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
               <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">
                 {chain.nativeCurrency ? chain.nativeCurrency.symbol : "none"}
               </td>
+              <td className="text-center font-bold px-4 dark:text-[#B3B3B3]">{blockGasLimit}</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Related to #1426

Add block gas limit display to each chain card.

* Add a new state variable `blockGasLimit` with a default value of 'Unknown'.
* Fetch the block gas limit data for each chain using the chain's RPC URL.
* Update the table in the chain card to include a new column for the block gas limit.
* Display the fetched block gas limit in the new column, or 'Unknown' if the data is not available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DefiLlama/chainlist/pull/1511?shareId=8a005e07-bf5d-4416-9545-681bc77e0d97).