### PR TITLE
Updated the RPC to fix the issue while adding network

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6522,7 +6522,7 @@ export const extraRpcs = {
 
   16600: {
     rpcs: [
-      "https://rpc-testnet.0g.ai",
+      "https://evmrpc-testnet.0g.ai",
       "https://lightnode-json-rpc-0g.grandvalleys.com",
       "https://0g-json-rpc-public.originstake.com",
       {


### PR DESCRIPTION
This update fixes the issue while adding 0g chain to metamask


If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): [0g.ai](https://0g.ai/)


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.