### PR TITLE
Add DTEAM Privacy Policy

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -183,6 +183,8 @@ const privacyStatement = {
     "We do not log, store, or track any user data without consent with exception of data publicly available on chain.",
   owlracle:
     "For rate-limiting and to prevent abuse, we collect and store the IP address of the user making the request. This data is stored for 1 month and is not shared with any third parties. https://owlracle.info/privacy",
+  DTEAM:
+    "We do not log, store, or track your IP, location, or personal data during RPC requests. https://dteam.tech/privacy-policy",
 };
 
 export const extraRpcs = {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://dteam.tech

#### Provide a link to your privacy policy:
https://dteam.tech/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.