### PR TITLE
add zircuit load balanced rpc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6437,6 +6437,11 @@ export const extraRpcs = {
   48900: {
     rpcs: [
       {
+        url: "https://mainnet.zircuit.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.drpc,
+      },
+      {
         url: "https://zircuit1-mainnet.p2pify.com",
         tracking: "yes",
         trackingDetails: privacyStatement.chainstack,

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6436,6 +6436,7 @@ export const extraRpcs = {
   },
   48900: {
     rpcs: [
+	"https://mainnet.zircuit.com",
       {
         url: "https://mainnet.zircuit.com",
         tracking: "none",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://docs.zircuit.com/dev-tools/rpc-endpoints

#### Provide a link to your privacy policy:
https://drpc.org/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array. -> Official RPC, putting at front of array