### PR TITLE
Add Lava RPC endpoints for movement

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7663,7 +7663,14 @@ export const extraRpcs = {
     ],
   },
   3073: {
-    rpcs: ["https://mainnet.movementnetwork.xyz/v1"],
+    rpcs: [
+      "https://mainnet.movementnetwork.xyz/v1",
+      {
+        url: "https://movement.lava.build",
+        tracking: "yes",
+        trackingDetails: privacyStatement.lava,
+      },
+    ],
   },
 };
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.lavanet.xyz/

#### Provide a link to your privacy policy:
https://www.lavanet.xyz/privacy-policy 

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.