### PR TITLE
Add Powerloom Mainnet V2

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6414,6 +6414,15 @@ export const extraRpcs = {
       },
     ],
   },
+  7869: {
+    rpcs: [
+      {
+        url: "https://rpc-v2.powerloom.network",
+        tracking: "yes",
+        trackingDetails: privacyStatement.conduit,
+      },
+    ],
+  },
   17071: {
     rpcs: [
       {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://www.conduit.xyz

`rpc-v2.powerloom.network.	300	IN	CNAME	rpc-powerloom-mainnet-v2-v52tbqo4if.t.conduit.xyz.`

#### Provide a link to your privacy policy:

https://www.conduit.xyz/privacy-policy

Your RPC should always be added at the end of the array.

**_Note: Merged chainid with lists repo as well:_  https://github.com/ethereum-lists/chains/pull/6999**

Context for the new chain: https://x.com/Powerloom/status/1897669070688022845

`TL;DR: OP Stack has discontinued support for custom gas tokens. Powerloom has a new Arbitrum Orbit based chain with a new chainid but the same icon. The older chain will continue to run until migration is complete.`