### PR TITLE
feat: Add STOchain Network (Mainnet & Testnet)

### DIFF
--- a/_data/chains/eip155-700.json
+++ b/_data/chains/eip155-700.json
@@ -1,0 +1,27 @@
+{
+  "name": "STOchain Network Mainnet",
+  "chain": "STO",
+  "rpc": ["https://api-stoc-mainnet.stochainscan.io/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "STOchain Mainnet Token",
+    "symbol": "STO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://stochain.io",
+  "shortName": "STO",
+  "chainId": 700,
+  "networkId": 700,
+  "slip44": 1,
+  "icon": "sto",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://stochainscan.io/en",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/chains/eip155-701.json
+++ b/_data/chains/eip155-701.json
@@ -1,0 +1,27 @@
+{
+  "name": "STOchain Network Testnet",
+  "chain": "STO",
+  "rpc": ["https://api-stoc-testnet.stochainscan.io/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "STOchain Testnet Token",
+    "symbol": "STO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://stochain.io",
+  "shortName": "STO",
+  "chainId": 701,
+  "networkId": 701,
+  "slip44": 1,
+  "icon": "sto",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://testnet.stochainscan.io/en",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/icons/sto.json
+++ b/_data/icons/sto.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreihxzd5zg6cxujlmesfeq7jdv2agppz3d2g2iq3bvd77oc42vwmp3i",
+    "width": 66,
+    "height": 69,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Add STOchain network configuration:
- Mainnet (chainId: 700)
- Testnet (chainId: 701)
- Chain icon with IPFS address

Network Details:
- RPC endpoints for both networks
- Block explorer URLs
- Native currency: STO token
- EIP155 and EIP1559 support

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.