### PR TITLE
Add NetworkCoin Ai Mainnet and NetworkCoin Ai Testnet  RPC endpoints …

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7722,6 +7722,25 @@ export const extraRpcs = {
     rpcs: ["https://hedera.linkpool.pro"],
   }
 };
+// NetworkCoin Ai Mainnet
+  // Network ID / ChainID: 101888 (0x18E00)
+  // Currency: Ai
+  101888: {
+    rpcs: [
+      "https://rpc.mainnet.networkcoin.ai/"
+    ]
+  },
+
+  // NetworkCoin Ai Testnet
+  // Network ID / ChainID: 1018888 (0xF8C08)
+  // Currency: Ai
+  1018888: {
+    rpcs: [
+      "https://rpc.testnet.networkcoin.ai/"
+    ]
+  },
+
+};
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 


### PR DESCRIPTION
…(Chain IDs: 101888 and 1018888)

Add NetworkCoin Mainnet and Testnet RPC endpoints (Chain IDs: 101888 and 1018888)

This commit introduces new RPC endpoints for the NetworkCoin Ai blockchain, allowing users to connect to both the Mainnet and Testnet through Chainlist. Specifically:

- Added an entry for NetworkCoin Ai  Mainnet with Chain ID 101888 (0x18E00) and its RPC endpoint at https://rpc.mainnet.networkcoin.ai/.

- Added an entry for NetworkCoin Ai Testnet with Chain ID 1018888 (0xF8C08) and its RPC endpoint at https://rpc.testnet.networkcoin.ai/.

These additions follow the repository's existing format for extra RPC endpoints and ensure that the NetworkCoin Ai blockchain is accessible via supported wallets like MetaMask. The changes improve network visibility and usability for the community.

If you are adding a new RPC, please answer the following questions.

##Link the service provider's website (the company/protocol/individual providing the RPC):
https://networkcoin.ai/

##Provide a link to your privacy policy:
https://networkcoin.ai/privacy-policy

##If the RPC has none of the above and you still think it should be added, please explain why:
Not applicable – our RPC endpoints are provided by NetworkCoin Ai, which has both a dedicated website and a published privacy policy outlining our data handling practices.

Your RPC should always be added at the end of the array.