### PR TITLE
feat: add quicknode RPC for Sophon

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7501,7 +7501,7 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc.testnet.sophon.xyz",
       {
-        url: "https://testnet.rpc-quicknode.sophon.xyz",
+        url: "https://rpc-quicknode.testnet.sophon.xyz",
         tracking: "yes",
         trackingDetails: privacyStatement.quicknode,
       },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7498,10 +7498,16 @@ export const extraRpcs = {
     ],
   },
   531050104: {
-    rpcs: ["https://rpc.testnet.sophon.xyz"],
+    rpcs: [
+      "https://rpc.testnet.sophon.xyz",
+      "https://testnet.rpc-quicknode.sophon.xyz",
+    ],
   },
   50104: {
-    rpcs: ["https://rpc.sophon.xyz"],
+    rpcs: [
+      "https://rpc.sophon.xyz",
+      "https://rpc-quicknode.sophon.xyz",
+    ],
   },
   33139: {
     rpcs: [

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7500,13 +7500,21 @@ export const extraRpcs = {
   531050104: {
     rpcs: [
       "https://rpc.testnet.sophon.xyz",
-      "https://testnet.rpc-quicknode.sophon.xyz",
+      {
+        url: "https://testnet.rpc-quicknode.sophon.xyz",
+        tracking: "yes",
+        trackingDetails: privacyStatement.quicknode,
+      },
     ],
   },
   50104: {
     rpcs: [
       "https://rpc.sophon.xyz",
-      "https://rpc-quicknode.sophon.xyz",
+      {
+        url: "https://rpc-quicknode.sophon.xyz",
+        tracking: "yes",
+        trackingDetails: privacyStatement.quicknode,
+      },
     ],
   },
   33139: {


### PR DESCRIPTION
I am adding the public endpoint of an existing RPC (Quicknode) to Sophon Mainnet and Testnet

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.