### PR TITLE
add coti rpcs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8243,6 +8243,12 @@ export const extraRpcs = {
       },
     ],
   },
+  2632500: {
+    rpcs: ["https://coti-rpc.Hyperflow.finance", "wss://coti-rpc.Hyperflow.finance"],
+  },
+  7082400: {
+    rpcs: ["https://coti-test-rpc.Hyperflow.finance", "wss://coti-test-rpc.Hyperflow.finance"],
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

#### Provide a link to your privacy policy:
https://privacy.hyperflow.finance/

#### If the RPC has none of the above and you still think it should be added, please explain why:
Adding it improves network resilience, ensures decentralization, and provides fallback options in case the default RPC becomes unavailable or slow. Even without special features, having multiple RPC endpoints is critical for infrastructure robustness, wallet reliability, and user access continuity.

Your RPC should always be added at the end of the array.