### PR TITLE
Add Spectrum Nodes to RPC Providers

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -196,7 +196,7 @@ const privacyStatement = {
   therpc:
     "We temporarily record request method names and IP addresses for 7 days solely for service functionality, such as load balancing and DDoS protection.https://therpc.io/agreement/privacy-policy",
   Spectrum:
-    "Privacy Statement: Spectrum does not collect, store, or log personal user data. This includes IP addresses, device identifiers, wallet information, and network metadata. IPs may be briefly processed in-memory for rate limiting and DDoS protection, but are never stored. We use no cookies, analytics, or tracking technologies. No user data is sold, shared, or retained. For full details, visit: https://spectrumnodes.com/privacy-policy",
+    "At SpectrumNodes.com, we collect and process personal information to deliver, secure, and improve our RPC services, and we do so only with a valid legal basis such as your consent or to fulfill contractual obligations. We do not process sensitive personal data, sell user information, or collect from third parties, and we employ strong technical safeguards to protect your privacy. Users have rights to access, correct, or delete their data, and can contact us anytime at privacy@spectrumnodes.com or https://spectrumnodes.com/contact",
 };
 
 export const extraRpcs = {
@@ -749,7 +749,7 @@ export const extraRpcs = {
       },
       {
         url: "https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.Spectrum,
       },
     ],
@@ -3854,7 +3854,7 @@ export const extraRpcs = {
       "https://rpc.hyperliquid-testnet.xyz/evm",
       {
         url: "https://spectrum-01.simplystaking.xyz/hyperliquid-tn-rpc/evm",
-        tracking: "limited",
+        tracking: "yes",
         trackingDetails: privacyStatement.Spectrum,
       },
     ],

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -195,6 +195,8 @@ const privacyStatement = {
     "Reliable Ninjas does not collect or track personal user information. IP addresses are only temporarily processed in volatile memory for the sole purpose of rate limiting RPC usage and are purged as soon as they are no longer needed. No identifiable or sensitive information is logged, stored, or retained. Reliable Ninjas does not use cookies or tracking technologies. We do not sell, share, or disclose user data to third parties. For more information, please visit: https://reliableninjas.com/privacy-policy",
   therpc:
     "We temporarily record request method names and IP addresses for 7 days solely for service functionality, such as load balancing and DDoS protection.https://therpc.io/agreement/privacy-policy",
+  Spectrum:
+    "Privacy Statement: Spectrum does not collect, store, or log personal user data. This includes IP addresses, device identifiers, wallet information, and network metadata. IPs may be briefly processed in-memory for rate limiting and DDoS protection, but are never stored. We use no cookies, analytics, or tracking technologies. No user data is sold, shared, or retained. For full details, visit: https://spectrumnodes.com/privacy-policy",
 };
 
 export const extraRpcs = {
@@ -744,6 +746,11 @@ export const extraRpcs = {
         url: "wss://avalanche-fuji.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.Spectrum,
       },
     ],
   },
@@ -3843,7 +3850,14 @@ export const extraRpcs = {
     rpcWorking: false,
   },
   998: {
-    rpcs: ["https://rpc.hyperliquid-testnet.xyz/evm"],
+    rpcs: [
+      "https://rpc.hyperliquid-testnet.xyz/evm",
+      {
+        url: "https://spectrum-01.simplystaking.xyz/hyperliquid-tn-rpc/evm",
+        tracking: "limited",
+        trackingDetails: privacyStatement.Spectrum,
+      },
+    ],
   },
   1001: {
     rpcs: [


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://spectrumnodes.com/

#### Provide a link to your privacy policy:
https://spectrumnodes.com/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.