### PR TITLE
Update omplatform RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2542,7 +2542,7 @@ export const extraRpcs = {
     ],
   },
   1246: {
-    rpcs: ["https://rpc-cnx.omplatform.com"],
+    rpcs: ["https://rpc.omplatform.com"],
   },
   100: {
     rpcs: [


### PR DESCRIPTION
# Update RPC endpoint for omplatform.com
This PR updates the existing RPC endpoint for `omplatform.com` from the old URL to the new canonical URL.

## Changes
Updated RPC endpoint from `https://rpc-cnx.omplatform.com` to `https://rpc.omplatform.com`

## Reason for Update
The service provider has migrated to a new RPC endpoint URL. The new endpoint `https://rpc.omplatform.com` is the updated canonical URL for their RPC service.