### PR TITLE
Update Arbitrum Sepolia RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1708,19 +1708,14 @@ export const extraRpcs = {
   421614: {
     rpcs: [
       {
-        url: "https://arbitrum-sepolia.blockpi.network/v1/rpc/private ",
-        tracking: "limited",
-        trackingDetails: privacyStatement.blockpi,
+        url: "https://endpoints.omniatech.io/v1/arbitrum/sepolia/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.omnia,
       },
       {
         url: "https://public.stackup.sh/api/v1/node/arbitrum-sepolia",
         tracking: "limited",
         trackingDetails: privacyStatement.stackup,
-      },
-      {
-        url: "https://endpoints.omniatech.io/v1/arbitrum/sepolia/public",
-        tracking: "none",
-        trackingDetails: privacyStatement.omnia,
       },
       {
         url: "https://arbitrum-sepolia.gateway.tenderly.co",


### PR DESCRIPTION
The default arbitrum sepolia rpc, when clicking "Add to metamask" is deprecated:

Metamask warning 
> According to our records the submitted RPC URL value does not match a known provider for this chain ID.

Curl check
```
curl -X POST https://arbitrum-sepolia.blockpi.network/v1/rpc/private \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Apikey not found"}}
```
Blockpi website check (sepolia greyed out):

https://blockpi.io/chain/arbitrum