### PR TITLE
Replace old WadzChain to Rebranded W Chain (chainid-171717.js)

### DIFF
--- a/constants/additionalChainRegistry/chainid-171717.js
+++ b/constants/additionalChainRegistry/chainid-171717.js
@@ -1,0 +1,23 @@
+{
+  "name": "W Chain Mainnet",
+  "chain": "WCN",
+  "rpc": [
+    "https://rpc.w-chain.com",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "W Coin",
+    "symbol": "WCO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://w-chain.com",
+  "shortName": "wcn",
+  "chainId": 171717,
+  "networkId": 171717,
+  "icon": "wco",
+  "explorers": [{
+    "name": "W Scan",
+    "url": "https://scan.w-chain.com"
+  }]
+}


### PR DESCRIPTION
WadzChain rebranded to W Chain, the RPC url also migrated to new one.
I am the maintainer of the blockchain, and authorized to answer to anything required for this update.

---------------------
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://w-chain.com

#### Provide a link to your privacy policy:
https://w-chain.com/privacy-policy/

