### PR TITLE
Extend Hedera Mainnet and Testnet JSON RPC Relay list

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8228,6 +8228,13 @@ export const extraRpcs = {
       "https://mainnet.hedera.validationcloud.io/v1/<YOUR_API_KEY_HERE>"
     ],
   },
+  296: {
+    rpcs: [
+      "https://testnet.hedera.api.hgraph.io/rpc",
+      "https://296.rpc.thirdweb.com/${THIRDWEB_API_KEY}",
+      "https://testnet.hedera.validationcloud.io/v1/<YOUR_API_KEY_HERE>"
+    ],
+  },
   2741: {
     rpcs: [
       {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://docs.hedera.com/hedera/core-concepts/smart-contracts/json-rpc-relay#json-rpc-relay-endpoints

#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.