### PR TITLE
Add Mova Beta (chainid:10323)

### DIFF
--- a/constants/additionalChainRegistry/chainid-10323.js
+++ b/constants/additionalChainRegistry/chainid-10323.js
@@ -1,0 +1,23 @@
+{
+  "name": "Mova Beta",
+  "chain": "MOVA",
+  "rpc": [
+    "https://mars.rpc.movachain.com",
+  ],
+  "faucets": [https://faucet.mars.movachain.com],
+  "nativeCurrency": {
+    "name": "Mova",
+    "symbol": "MOVA",
+    "decimals": 18
+  },
+  "infoURL": "https://movachain.com",
+  "shortName": "mova",
+  "chainId": 10323,
+  "networkId": 10323,
+  "icon": "mova",
+  "explorers": [{
+    "name": "marsscan",
+    "url": "https://scan.mars.movachain.com",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.

This PR adds a new network named Mova Beta, with RPC provided by the official team.