### PR TITLE
Add Lerax Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-8125.js
+++ b/constants/additionalChainRegistry/chainid-8125.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Lerax Chain Testnet",
+  "chain": "LERAX",
+  "rpc": [
+    "https://rpc-testnet-dataseed.lerax.org",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Lerax",
+    "symbol": "LERAX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://lerax.org/",
+  "shortName": "LERAX",
+  "chainId": 8125,
+  "networkId": 8125,
+  "icon": "https://testnet.leraxscan.com/assets/configs/network_icon.svg",
+  "explorers": [{
+    "name": "Leraxscan Testnet",
+    "url": "https://testnet.leraxscan.com/",
+    "icon": "https://testnet.leraxscan.com/assets/configs/network_icon.svg",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Add Lerax Testnet to Chainlist

website: https://lerax.org/
rpc: https://rpc-testnet-dataseed.lerax.org
explorer: https://testnet.leraxscan.com/
native currency: LERAX (18 decimals)
icon: https://testnet.leraxscan.com/assets/configs/network_icon.svg