### PR TITLE
Create chainid-8125.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-8125.js
+++ b/constants/additionalChainRegistry/chainid-8125.js
@@ -12,7 +12,7 @@ export const data = {
   },
   "features": [{ "name": "EIP155" }],
   "infoURL": "https://lerax.org/",
-  "shortName": "LERAX",
+  "shortName": "lerax",
   "chainId": 8125,
   "networkId": 8125,
   "icon": "https://testnet.leraxscan.com/assets/configs/network_icon.svg",


### PR DESCRIPTION
Adds Lerax Chain Testnet (chainId 8125) to Chainlist.

website: https://lerax.org/
rpc: https://rpc-testnet-dataseed.lerax.org
explorer: https://testnet.leraxscan.com/
native currency: LERAX (18 decimals)
icon: https://testnet.leraxscan.com/assets/configs/network_icon.svg