### PR TITLE
feat(chain): add RoonChain Testnet (chainId 13145201)

### DIFF
--- a/constants/additionalChainRegistry/chainid-13145201.js
+++ b/constants/additionalChainRegistry/chainid-13145201.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "RoonChain Testnet",
+  "chain": "ROON",
+  "icon": "roonchain",
+  "rpc": ["https://testnet-rpc.roonchain.com"],
+  "faucets": [],
+  "nativeCurrency": { 
+    "name": "ROON", 
+    "symbol": "ROON", 
+    "decimals": 18 
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://roonchain.com",
+  "shortName": "roonchain",
+  "chainId": 13145201,
+  "networkId": 13145201,
+  "explorers": [{
+    "name": "RoonChain Testnet explorer",
+    "url": "https://testnets.roonchain.com",
+    "icon": "roonchain",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Link the service provider's website (the company/protocol/individual providing the RPC):
https://roonchain.com/
Public endpoint: https://testnet-rpc.roonchain.com

Provide a link to your privacy policy:
None yet.

If the RPC has none of the above and you still think it should be added, please explain why:
This is the official public RPC operated by the RoonChain team for the RoonChain Testnet (chainId 13145201).
It supports standard Ethereum JSON-RPC methods, CORS is enabled for browser usage, and rate-limits/abuse protection are in place. A formal privacy policy will be published and linked once available.