### PR TITLE
Remove peaq.therpc.io RPC endpoint from chain ID 3338

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1950,7 +1950,7 @@ export const extraRpcs = {
       },
     ],
   },
-  5611 : {
+  5611: {
     rpcs: [
       {
         url: "https://opbnb-testnet.therpc.io",
@@ -2636,15 +2636,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.therpc,
       }
     ],
-  },
-  3338: {
-    rpcs: [
-      {
-        url: "https://peaq.therpc.io",
-        tracking: "limited",
-        trackingDetails: privacyStatement.therpc,
-      }
-    ]
   },
   10200: {
     rpcs: [
@@ -8435,7 +8426,7 @@ export const extraRpcs = {
       },
     ],
   },
-    743111: {
+  743111: {
     rpcs: [
       {
         url: "https://hemi-testnet.drpc.org",


### PR DESCRIPTION
### Remove peaq.therpc.io RPC endpoint from chain ID 3338

**Summary**
This PR removes the https://peaq.therpc.io RPC endpoint from chain ID 3338 in the constants/extraRpcs.js file.

**Reason for Removal**
We are removing this RPC endpoint as part of our ongoing effort to maintain only trusted and verified RPC endpoints on chainlist.org. This ensures users have access to reliable and secure RPC services.

**Changes Made**
Removed the entire chain ID 3338 entry containing the peaq.therpc.io endpoint
No other references to this endpoint were found in the codebase

**Impact**
Users will no longer see this RPC endpoint as an option for chain ID 3338
The change maintains the integrity of our trusted RPC endpoint list