### PR TITLE
Updated the name of chain from qie to qiev3 

### DIFF
--- a/constants/additionalChainRegistry/chainid-1990.js
+++ b/constants/additionalChainRegistry/chainid-1990.js
@@ -1,8 +1,9 @@
 export const data = {
-  "name": "QIE Mainnet",
-  "chain": "QIE",
+  "name": "QIEMainnet",
+  "chain": "QIEV3",
   "rpc": [
     "https://rpc1mainnet.qie.digital",
+    "https://rpc5mainnet.qie.digital",
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -12,10 +13,10 @@ export const data = {
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://www.qie.digital/",
-  "shortName": "QIE",
+  "shortName": "QIEV3",
   "chainId": 1990,
   "networkId": 1990,
-  "icon": "QIE",
+  "icon": "qiev3",
   "explorers": [{
     "name": "QIE mainnet explorer",
     "url": "https://mainnet.qie.digital/",


### PR DESCRIPTION


If you are adding a new RPC, please answer the following questions.
Link the service provider's website (the company/protocol/individual providing the RPC):

https://www.qie.digital/
Provide a link to your privacy policy:
If the RPC has none of the above and you still think it should be added, please explain why:

N/A – This RPC is provided by the official QIE network infrastructure and meets the required standards for mainnet connectivity.

Your RPC should always be added at the end of the array.
