### PR TITLE
Add NitroGraph Testnet (Chain ID: 200024)

### DIFF
--- a/constants/additionalChainRegistry/chainid-200024.js
+++ b/constants/additionalChainRegistry/chainid-200024.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "NitroGraph Testnet",
+    "chain": "NOS",
+    "rpc": [
+      "https://rpc-testnet.nitrograph.foundation",
+    ],
+    "faucets": [
+        "https://faucet-testnet.nitrograph.foundation"
+    ],
+    "nativeCurrency": {
+      "name": "Nitro",
+      "symbol": "NOS",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://nitrograph.com",
+    "shortName": "NOS",
+    "chainId": 200024,
+    "networkId": 200024,
+    "icon": "https://github.com/nitrographtech/ng-assets/blob/main/logos/nitro_token_red.png",
+    "explorers": [{
+      "name": "nitroscan",
+      "url": "https://explorer-testnet.nitrograph.foundation",
+      "icon": "nitroscan",
+      "standard": "EIP3091"
+    }]
+}


### PR DESCRIPTION
## Add NitroGraph Testnet

This PR adds the NitroGraph Testnet to the chainlist registry.

### Chain Details:
- **Chain ID**: 200024
- **Network Name**: NitroGraph Testnet
- **Native Currency**: NOS (Nitro)
- **RPC Endpoint**: https://rpc-testnet.nitrograph.foundation
- **Explorer**: https://explorer-testnet.nitrograph.foundation
- **Faucet**: https://faucet-testnet.nitrograph.foundation
- **Website**: https://nitrograph.com

### Features:
- EIP155 support
- EIP1559 support
- EIP3091 compliant explorer

### Testing:
- ✅ RPC endpoint is accessible and functional
- ✅ Explorer is live and working
- ✅ Faucet is operational for testnet tokens
- ✅ Configuration follows chainlist standards

The testnet is stable and ready for public use.