### PR TITLE
Update 0G testnet chainId & RPCs (16601)

### DIFF
--- a/constants/additionalChainRegistry/chainid-16601.js
+++ b/constants/additionalChainRegistry/chainid-16601.js
@@ -1,0 +1,31 @@
+export const data = {
+  "name": "0G-Galileo-Testnet",
+  "chain": "0G",
+  "rpc": [
+    "https://evmrpc-testnet.0g.ai"
+  ],
+  "faucets": [
+    "https://faucet.0g.ai"
+  ],
+  "nativeCurrency": {
+    "name": "OG",
+    "symbol": "OG",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://0g.ai",
+  "shortName": "0g-galileo",
+  "chainId": 16601,
+  "networkId": 16601,
+  "testnet": true,
+  "explorers": [
+    {
+      "name": "0G Chain Explorer",
+      "url": "https://chainscan-galileo.0g.ai",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7145,41 +7145,23 @@ export const extraRpcs = {
     ],
   },
 
-  16600: {
+  16601: {
     rpcs: [
       "https://evmrpc-testnet.0g.ai",
-      "https://0g-json-rpc-public.originstake.com",
-      "https://og-testnet-jsonrpc.blockhub.id",
       {
-        url: "https://0g-json-rpc-public.originstake.com",
+        url: "https://evmrpc-testnet.0g.ai",
         tracking: "none",
-        trackingDetails: privacyStatement.originstake,
+        trackingDetails: privacyStatement.default,
       },
       {
-        url: "https://og-testnet-evm.itrocket.net",
+        url: "https://16601.rpc.thirdweb.com/",
         tracking: "none",
-        trackingDetails: privacyStatement.itrocket,
+        trackingDetails: privacyStatement.thirdweb,
       },
       {
-        url: "https://lightnode-json-rpc-0g.grandvalleys.com",
-        tracking: "none",
-        trackingDetails: privacyStatement.GrandValley,
-      },
-      {
-        url: "https://rpc.ankr.com/0g_newton",
+        url: "https://rpc.ankr.com/0g_galileo_testnet_evm",
         tracking: "none",
         trackingDetails: privacyStatement.ankr,
-      },
-      "https://0g-evm-rpc.murphynode.net",
-      {
-        url: "https://0g-newton-testnet.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
-      },
-      {
-        url: "wss://0g-newton-testnet.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
       },
     ],
   },


### PR DESCRIPTION
Update extraRpcs.js to modify RPC entries for chainId 16601 previously chainId 16600, replacing outdated URLs 


Link the service provider's website (the company/protocol/individual providing the RPC):

- [0G Site](https://0g.ai) 
- [Testnet Details](https://docs.0g.ai/developer-hub/testnet/testnet-overview)
