### PR TITLE
Add ethereum mainnet stakely json-rpc lb to rpc list

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -27,7 +27,7 @@ const privacyStatement = {
   cloudflare:
     "Just as when you visit and interact with most websites and services delivered via the Internet, when you visit our Websites, including the Cloudflare Community Forum, we gather certain information and store it in log files. This information may include but is not limited to Internet Protocol (IP) addresses, system configuration information, URLs of referring pages, and locale and language preferences. https://www.cloudflare.com/privacypolicy/",
   blastapi:
-
+    "All the information in our logs (log data) can only be accessed for the last 7 days at any certain time, and it is completely purged after 14 days. We do not store any user information for longer periods of time or with any other purposes than investigating potential errors and service failures. https://blastapi.io/privacy-policy",
   bitstack:
     "Information about your computer hardware and software may be automatically collected by BitStack. This information can include: your IP address, browser type, domain names, access times and referring website addresses. https://bitstack.com/#/privacy",
   pokt: "What We Do Not Collect: User's IP address, request origin, request data. https://www.blog.pokt.network/rpc-logging-practices/",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
-Main website: https://stakely.io/

Ethereum JSON-RPC load balancer: https://stakely.io/web3-api-load-balancer/ethereum?type=json-rpc

Provide a link to your privacy policy:
If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.