### PR TITLE
Add Galactica Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-843843.js
+++ b/constants/additionalChainRegistry/chainid-843843.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "Galactica Testnet",
+  chain: "GNET",
+  rpc: ["https://galactica-cassiopeia.g.alchemy.com/public"],
+  faucets: ["https://faucet-cassiopeia.galactica.com"],
+  nativeCurrency: {
+    name: "Gnet",
+    symbol: "GNET",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://galactica.com",
+  shortName: "galactica-testnet",
+  chainId: 843843,
+  networkId: 843843,
+  icon: "https://galactica-com.s3.eu-central-1.amazonaws.com/icon_galactica.png",
+  explorers: [
+    {
+      name: "Blockscout",
+      url: "https://galactica-cassiopeia.explorer.alchemy.com",
+      icon: "blockscout",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds Galactica Testnet (chainId 843843) to Chainlist.

- website: https://galactica.com (Link to privacy policy in footer)
- explorer: https://galactica-cassiopeia.explorer.alchemy.com
- native currency: GNET (18 decimals)
- icon: https://galactica-com.s3.eu-central-1.amazonaws.com/icon_galactica.png
- rpc: https://galactica-cassiopeia.g.alchemy.com/public

