### PR TITLE
Add MANTRA testnet description

### DIFF
--- a/constants/additionalChainRegistry/chainid-5887.js
+++ b/constants/additionalChainRegistry/chainid-5887.js
@@ -1,0 +1,29 @@
+export const data = {
+  "name": "MANTRACHAIN Testnet",
+  "chain": "Dukong",
+  "icon": "om",
+  "rpc": [
+    "https://evm.dukong.mantrachain.io",
+    "wss://evm.dukong.mantrachain.io/ws"
+  ],
+  "faucets": [
+    "https://faucet.dukong.mantrachain.io"
+  ],
+  "nativeCurrency": {
+    "name": "OM",
+    "symbol": "OM",
+    "decimals": 18
+  },
+  "infoURL": "https://mantrachain.io",
+  "shortName": "dukong",
+  "chainId": 5887,
+  "networkId": 5887,
+  "explorers": [
+    {
+      "name": "Dukong Explorer",
+      "url": "http://mantrascan.io",
+      "standard": "none",
+      "icon": "om"
+    }
+  ]
+}


### PR DESCRIPTION
Adds MANTRA Testnet (chainId 5887) to Chainlist.

website: https://www.mantrachain.io/ ([Privacy policy](https://www.mantrachain.io/legal/privacy-policy))
explorer: https://mantrascan.io/dukong
native currency: OM (18 decimals)
rpc: https://evm.dukong.mantrachain.io