### PR TITLE
Please Add Tatum Flare RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3399,6 +3399,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.ankr,
       },
+      {
+        url: "https://flare-mainnet.gateway.tatum.io/",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   15: {


### PR DESCRIPTION
Please Add Tatum Flare RPC endpoint and remove the old endpoints - https://01-vinthill-003-02.rpc.tatum.io/ext/bc/C/rpc , https://01-gravelines-003-01.rpc.tatum.io/ext/bc/C/rpc

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://tatum.io/chain/flare

#### Provide a link to your privacy policy:
https://tatum.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.