### PR TITLE
fix: duplicate abstract mainnet values, sepolia abstract assignment

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8220,7 +8220,7 @@ export const extraRpcs = {
   295: {
     rpcs: ["https://hedera.linkpool.pro"],
   },
-  2741: {
+  11124: {
     rpcs: [
       {
         url: "https://abstract-sepolia.drpc.org",


### PR DESCRIPTION
Fixing the RPC assignment for Abstract Mainnet. The file has duplicate values for the same chain, which caused issues for automatic checks for a chain. More info: https://github.com/safe-global/safe-deployments/pull/1179#issuecomment-3190912620

Thank you.