### PR TITLE
Add Atleta 2440 RPC 

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -201,6 +201,8 @@ const privacyStatement = {
     "We do not collect or store personal request data or request origins. To ensure the functionality of our services, such as load balancing and DDoS protection",
   PulseChainRpc:
     "When you use our services or visit our websites, we may log your device’s IP address for debugging and security reasons. We may retain this information for up to twelve months"
+  Hightower:
+    "We may collect publicly available blockchain information in order to provide our services. This can include wallet addresses, transaction IDs, timestamps, amounts and fees, and transaction status (e.g., completed, pending, or failed)."
 };
 
 export const extraRpcs = {
@@ -8443,6 +8445,20 @@ export const extraRpcs = {
         url: "wss://hemi-testnet.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    ],
+  },
+  2440: {
+    rpcs: [
+      {
+        url: "https://rpc.atleta.at.htw.tech",
+        tracking: "none",
+        trackingDetails: privacyStatement.Hightower,
+      },
+      {
+        url: "wss://rpc.atleta.at.htw.tech",
+        tracking: "none",
+        trackingDetails: privacyStatement.Hightower,
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.