### PR TITLE
Add Bridgeless Mainnet network

### DIFF
--- a/constants/additionalChainRegistry/chainid-13441.js
+++ b/constants/additionalChainRegistry/chainid-13441.js
@@ -1,0 +1,22 @@
+export const data = {
+  "name": "Bridgeless Mainnet",
+  "chain": "BRIDGELESS",
+  "rpc": [
+    "https://eth-rpc.node0.mainnet.bridgeless.com"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Bridge",
+    "symbol": "BRIDGE",
+    "decimals": 18
+  },
+  "infoURL": "https://bridgeless.com",
+  "shortName": "bridgeless",
+  "chainId": 13441,
+  "networkId": 13441,
+  "explorers": [{
+    "name": "bridgeless",
+    "url": "https://explorer.mainnet.bridgeless.com/",
+  }]
+}


### PR DESCRIPTION
Add Bridgeless Mainnet network (chainId 13441) to Chainlist

website: https://bridgeless.com/
rpc: https://eth-rpc.node0.mainnet.bridgeless.com 
explorer: https://explorer.mainnet.bridgeless.com
native currency: BRIDGE (18 decimals)
