### PR TITLE
Add Intuition Testnet (Chain ID: 13579)

### DIFF
--- a/constants/additionalChainRegistry/chainid-13579.js
+++ b/constants/additionalChainRegistry/chainid-13579.js
@@ -1,0 +1,26 @@
+{
+  "name": "Intuition Testnet",
+  "chain": "INTUITION",
+  "rpc": [
+    "https://testnet.rpc.intuition.systems"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Testnet TRUST",
+    "symbol": "TTRUST",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://intuition.systems",
+  "shortName": "intuition-testnet",
+  "chainId": 13579,
+  "networkId": 13579,
+  "icon": "intuition",
+  "explorers": [{
+    "name": "IntuitionScan (Testnet)",
+    "url": "https://testnet.explorer.intuition.systems",
+    "icon": "intuitionscan",
+    "standard": "EIP3091"
+  }],
+  "testnet": true
+}


### PR DESCRIPTION
## Add Intuition Testnet (Chain ID: 13579)

This PR adds Intuition Testnet to the chain registry.

### Details:
- **Chain ID**: 13579
- **Network**: Intuition Testnet
- **RPC URL**: https://testnet.rpc.intuition.systems
- **Explorer**: https://testnet.explorer.intuition.systems
- **Native Currency**: TTRUST (Testnet TRUST)
- **Decimals**: 18

### Service Provider:
- **Website**: https://intuition.systems

### Source:
Based on official configuration from: https://github.com/intuition-box/nft/commit/435a1bebba75110bd69b489239de5250a1b7ad9d

### Verification:
- ✅ Chain ID is unique (13579)
- ✅ RPC endpoint is accessible
- ✅ Explorer URL is valid
- ✅ JSON structure follows chainlist standards