### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/validate-chain-files.yml
+++ b/.github/workflows/validate-chain-files.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 100
 


### PR DESCRIPTION
Updates actions/checkout@v3 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0