### PR TITLE
Please Add Tatum Cronos RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1433,6 +1433,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.owlracle,
       },
+      {
+        url: "https://cro-mainnet.gateway.tatum.io/",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   338: {


### PR DESCRIPTION
Please Add Tatum Cronos RPC endpoint

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://tatum.io/chain/cronos

#### Provide a link to your privacy policy:
https://tatum.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.