### PR TITLE
Add Fastnode's public endpoint for Atleta Mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -203,6 +203,8 @@ const privacyStatement = {
     "When you use our services or visit our websites, we may log your device’s IP address for debugging and security reasons. We may retain this information for up to twelve months",
   MBF:
     "MBF does not use user accounts and does not intentionally collect personally identifying information. When you access our RPC endpoints, the only data we may process are the requesting IP address and the requested method name. We use this limited data solely for operating the service—for example, rate limiting, abuse and DDoS mitigation, debugging, uptime monitoring, and reliability analytics.",
+  fastnode:
+    "Fastnode temporarily logs request metadata (IP address, method, headers, timestamps, status, latency) for rate-limiting, security, DDoS protection and debugging. We do not correlate logs with on-chain wallet addresses, use them to front-run transactions, or sell personal data."
 };
 
 export const extraRpcs = {
@@ -1509,6 +1511,11 @@ export const extraRpcs = {
         url: "https://rpc.ankr.com/atleta_mainnet",
         tracking: "none",
         trackingDetails: privacyStatement.ankr,
+      },
+      {
+        url: "https://public-atla-mainnet.fastnode.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.fastnode,
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
fastnode.io

#### Provide a link to your privacy policy:
In commit 

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.