### PR TITLE
feat(ethereal-testnet-0): added ethereal-testnet-0

### DIFF
--- a/constants/additionalChainRegistry/chainid-13374202.js
+++ b/constants/additionalChainRegistry/chainid-13374202.js
@@ -1,0 +1,28 @@
+export const data = {
+  "name": "Ethereal Testnet",
+  "title": "Ethereal Testnet",
+  "chain": "Ethereal",
+  "rpc": [
+    "https://rpc.etherealtest.net",
+    "https://rpc-ethereal-testnet-0.t.conduit.xyz"
+  ],
+  "icon": "etherealtestnet",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "USDe",
+    "symbol": "USDe",
+    "decimals": 18
+  },
+  "infoURL": "https://www.ethereal.trade/",
+  "shortName": "ethereal-testnet-0",
+  "chainId": 13374202,
+  "networkId": 13374202,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.etherealtest.net",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
The same network as in https://github.com/DefiLlama/chainlist/pull/1916, but without deletion of the previous ethereal testnet.