### PR TITLE
Add Panchain Mainnet (chainId: 7890) to chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-7890.js
+++ b/constants/additionalChainRegistry/chainid-7890.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "Panchain Mainnet",
   "chain": "PC",
   "rpc": [


### PR DESCRIPTION
This PR adds Panchain Mainnet to the chainlist registry:
- Chain ID: 7890
- Network name: Panchain Mainnet
- Native currency: Pan Coin (PC)
- RPC: https://rpc.panchain.io
- Explorer: https://scan.panchain.io (Blockscout)
- Features: EIP155, EIP1559

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.