### PR TITLE
Now nodes provider

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -153,7 +153,7 @@ const privacyStatement = {
   graffiti:
     "Regarding RPC (remote procedure call) data, we do not collect request data or request origin. We temporarily record request method names and IP addresses for 7 days to ensure service functionality like load balancing and DDoS protection. All data is automatically deleted after 7 days, except for RPC request amounts, which are recorded for accounting and billing purposes for a longer period.https://graffiti.farm/privacy-policy/",
   nownodes:
-    "NOWNodes provides free public RPC endpoints! You do not need an API key to get node access. Learn more: https://nownodes.io/public-endpoints",
+    "NOWNodes provides free public RPC endpoints! You do not need an API key to get node access. Learn more: https://nownodes.io/public-endpoints. For our complete privacy policy, please visit https://nownodes.io/assets/data/privacy-pol.pdf",
 };
 
 export const extraRpcs = {


### PR DESCRIPTION

NOWNodes is an ultimate blockchain infra provider that lets users get access to full and archive nodes.
NOWNodes offers multiple interface options including Tendermint, Blockbook, Index and more; available on both mainnets and testnets, depending on the blockchain.
The service provides a high-quality infrastructure that is quick, cost-effective, and reliable.
Node Access: NOWNodes gives users access to 110+ Networks. Because it is important for us to be mentioned in this list!

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://nownodes.io/

#### Provide a link to your privacy policy:

https://nownodes.io/assets/data/privacy-pol.pdf

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.