### PR TITLE
Add Moca Chain Testnet/Mainnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-222888.js
+++ b/constants/additionalChainRegistry/chainid-222888.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "Moca Chain Testnet",
+    "chain": "Moca Chain",
+    "rpc": [
+      "https://testnet-rpc.mocachain.org",
+    ],
+    "faucets": [
+        "https://testnet-scan.mocachain.org/faucet"
+    ],
+    "nativeCurrency": {
+      "name": "MOCA",
+      "symbol": "MOCA",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://mocachain.org",
+    "shortName": "MOCA",
+    "chainId": 222888,
+    "networkId": 222888,
+    "icon": "moca",
+    "explorers": [{
+      "name": "Moca Chain Scan",
+      "url": "https://testnet-scan.mocachain.org",
+      "icon": "moca",
+      "standard": "EIP3091"
+    }]
+}

--- a/constants/additionalChainRegistry/chainid-222888.js
+++ b/constants/additionalChainRegistry/chainid-222888.js
@@ -14,7 +14,7 @@ export const data = {
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "infoURL": "https://mocachain.org",
-    "shortName": "MOCA",
+    "shortName": "mocat",
     "chainId": 222888,
     "networkId": 222888,
     "icon": "moca",

--- a/constants/additionalChainRegistry/chainid-2288.js
+++ b/constants/additionalChainRegistry/chainid-2288.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "Moca Chain Mainnet",
+    "chain": "Moca Chain",
+    "rpc": [
+      "https://rpc.mocachain.org",
+    ],
+    "faucets": [
+        "https://scan.mocachain.org/faucet"
+    ],
+    "nativeCurrency": {
+      "name": "MOCA",
+      "symbol": "MOCA",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://mocachain.org",
+    "shortName": "MOCA",
+    "chainId": 2288,
+    "networkId": 2288,
+    "icon": "moca",
+    "explorers": [{
+      "name": "Moca Chain Scan",
+      "url": "https://scan.mocachain.org",
+      "icon": "moca",
+      "standard": "EIP3091"
+    }]
+}

--- a/constants/additionalChainRegistry/chainid-2288.js
+++ b/constants/additionalChainRegistry/chainid-2288.js
@@ -14,7 +14,7 @@ export const data = {
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "infoURL": "https://mocachain.org",
-    "shortName": "MOCA",
+    "shortName": "moca",
     "chainId": 2288,
     "networkId": 2288,
     "icon": "moca",


### PR DESCRIPTION
Add Moca Chain Testnet/Mainnet

https://github.com/ethereum-lists/chains/pull/7641  is live

icons "moca" {
    "url": "ipfs://QmNqJnEL2Aj7pLKYnJwRnWGZFwUWTsvfZm8CofA8ztvD6J",
    "width": 512,
    "height": 512,
    "format": "png"
  }
is already used in https://github.com/ethereum-lists/chains/blob/master/_data/icons/moca.json that we committed before