### PR TITLE
Create Kudora 12000

### DIFF
--- a/constants/additionalChainRegistry/chainid-12000.js
+++ b/constants/additionalChainRegistry/chainid-12000.js
@@ -1,0 +1,18 @@
+export const data = {
+  name: "Kudora Mainnet",
+  chain: "KUD",
+  icon: "kudora",
+  rpc: ["https://rpc.kudora.org"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "Kudo",
+    symbol: "KUD",
+    decimals: 18,
+  },
+  infoURL: "https://kudora.org/",
+  shortName: "kud",
+  chainId: 12000,
+  networkId: 12000,
+  explorers: []
+};


### PR DESCRIPTION
Add Kudora Mainnet (chainId 12000), an EVM L1 on Cosmos SDK/Ethermint, native currency Kudo (KUD, 18 decimals). Thanks to the repo contributors for the excellent work and for reviewing this change. Maintainer: Kudora Labs : https://github.com/Kudora-Labs