### PR TITLE
Update chainid-721529 (name,RPC)

### DIFF
--- a/constants/additionalChainRegistry/chainid-721529
+++ b/constants/additionalChainRegistry/chainid-721529
@@ -1,0 +1,25 @@
+{
+  "name": "OIL Mainnet",
+  "chain": "OIL",
+  "rpc": [
+    "https://mainnet-rpc.oilscan.net",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Oil",
+    "symbol": "OIL",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "",
+  "shortName": "oil",
+  "chainId": 721529,
+  "networkId": 721529,
+  "icon": "oilchain",
+  "explorers": [{
+    "name": "OilScan",
+    "url": "https://oilscan.net",
+    "icon": "oilscan",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Dear ChainList Team,

We previously submitted a request to change the name of this network but did not receive a response. To resolve the matter, we have now submitted a new request through the company’s official email.

As context, we initially introduced this chain under the name ERAM, but as part of our public launch and in full alignment with our whitepaper and international branding strategy, we have rebranded it to OIL Smart Chain. This change is limited to the name and domain—our technical infrastructure remains unchanged. The purpose of this move is to ensure consistency across the ecosystem and to communicate a clear and reliable message to our users, investors, and global partners.

We kindly request your assistance in reviewing and processing this change at your earliest convenience.

Best regards,Oil Smart Chain Team