### PR TITLE
feat: add KultChain to chainIds mapping

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -215,6 +215,7 @@ export default {
   "153153": "odyssey",
   "167000": "taiko",
   "200901": "bitlayer",
+  "220312": "kultchain",
   "222222": "hydradx",
   "256256": "cmp",
   "322202": "parex",


### PR DESCRIPTION
  Add missing chainId mapping for KultChain (220312).

  KultChain was added in PR #2019 but the chainIds.js mapping was missing.
  This PR adds the entry "220312": "kultchain" in the correct numerical
  order.