### PR TITLE
feat: add extra RPC for KultChain

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6647,6 +6647,11 @@ export const extraRpcs = {
       },
     ],
   },
+  220312: {
+    rpcs: [
+      "https://kultrpc.kultchain.com",
+    ],
+  },
   131313: {
     rpcs: [
       "https://testnode.dioneprotocol.com/ext/bc/D/rpc",


### PR DESCRIPTION
  Add additional RPC endpoint for KultChain (chainId 220312).

  New RPC: https://kultrpc.kultchain.com

  This provides users with an alternative endpoint for better reliability
  and redundancy.