### PR TITLE
fix: add missing semicolon to KultChain config (fixes build)

### DIFF
--- a/constants/additionalChainRegistry/chainid-220312.js
+++ b/constants/additionalChainRegistry/chainid-220312.js
@@ -23,4 +23,4 @@ export const data = {
     "icon": "blockscout",
     "standard": "EIP3091"
   }]
-}
+};


### PR DESCRIPTION
  ## Fix broken Cloudflare build

  PR #2019 broke the build due to missing semicolon in the ESM export.

  ### Changes:
  - Add missing semicolon at the end of `chainid-220312.js`
  - Changes `}` to `};` to properly close the ESM export