### PR TITLE
Unipoly Chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 
 # others
 build.log
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ yarn-error.log*
 
 # others
 build.log
-/.vs

--- a/constants/additionalChainRegistry/chainid-47382916.js
+++ b/constants/additionalChainRegistry/chainid-47382916.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Unipoly Chain Mainnet",
+  "chain": "UNP",
+  "rpc": [
+    "https://rpc.unpchain.com",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Unipoly Coin",
+    "symbol": "UNP",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://unipoly.network",
+  "shortName": "unp",
+  "chainId": 47382916,
+  "networkId": 47382916,
+  "icon": "https://unipoly.network/favicon.ico",
+  "explorers": [{
+    "name": "UNP Chain Explorer",
+    "url": "https://explorer.unpchain.com",
+    "icon": "https://unipoly.network/favicon.ico",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Link the service provider's website (the company/protocol/individual providing the RPC):
https://unipoly.network
https://coinmarketcap.com/currencies/unipoly/
https://rpc.unpchain.com
https://explorer.unpchain.com

Provide a link to your privacy policy:
https://unipoly.network/en/chain/article/terms-conditions

If the RPC has none of the above and you still think it should be added, please explain why:
The RPC endpoint https://rpc.unpchain.com is the official public RPC for the Unipoly Chain Mainnet, operated and maintained by the Unipoly Core Development Team.
It is essential for dApp developers, wallets, and external services to connect to and interact with the UNP blockchain.
This RPC does not log or retain any personally identifiable information and exists solely to provide secure, reliable access to blockchain data and transaction submission for the Unipoly ecosystem.