### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3897,6 +3897,7 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
+      "https://rpc.gigatheminter.com",
       "https://rpc-pulsechain.g4mm4.io",
       "https://evex.cloud/pulserpc",
       "wss://evex.cloud/pulsews",


### PR DESCRIPTION
### PR Description:

## Description
Adding new public RPC endpoints for PulseChain network.

## Endpoints Added
- HTTPS: `https://rpc.gigatheminter.com`

## Infrastructure Details
- **Provider**: GigaTheMinter
- **Location**:  US (New York)
- **Rate Limits**: 100 req/sec per IP (burst 200)
- **Features**:
  - ✅ Cloudflare DDoS Protection
  - ✅ SSL/TLS encryption
  - ✅ WebSocket subscriptions supported
  - ✅ Full node  
  - ✅ 99.9% target

## Contact
-Tele: t.me/giga_doge
- Domain: gigatheminter.com

---
✅ I confirm these endpoints are publicly accessible
✅ I confirm these endpoints have appropriate rate limiting
✅ I confirm these endpoints are production-ready