### PR TITLE
Add dRPC Hyperliquid RPC endpoint (chainId 999)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8586,6 +8586,22 @@ export const extraRpcs = {
     websiteDead: false,
     rpcWorking: true,
   },
+  999: {
+    rpcs: [
+      {
+        url: "https://rpc.hyperliquid.xyz/evm",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
+      {
+        url: "https://hyperliquid.drpc.org",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      }
+    ],
+    websiteDead: false,
+    rpcWorking: true,
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://drpc.org


#### Provide a link to your privacy policy: https://drpc.org/privacy-policy


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.