### PR TITLE
Add CAPX Mainnet and Testnet (Chain IDs 757 and 756)

### DIFF
--- a/constants/additionalChainRegistry/chainid-756.js
+++ b/constants/additionalChainRegistry/chainid-756.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "CAPX Testnet",
+  "chain": "CAPX",
+  "rpc": [
+    "https://capx-testnet-c1.rpc.caldera.xyz/http",
+    "wss://capx-testnet-c1.rpc.caldera.xyz/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CAPX",
+    "symbol": "CAPX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.capx.ai/",
+  "shortName": "capx-testnet",
+  "chainId": 756,
+  "networkId": 756,
+  "icon": "capx",
+  "explorers": [{
+    "name": "blockscout",
+    "url": "https://testnet.capxscan.com",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-757.js
+++ b/constants/additionalChainRegistry/chainid-757.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "CAPX",
+  "chain": "CAPX",
+  "rpc": [
+    "https://capx-mainnet.calderachain.xyz/http",
+    "wss://capx-mainnet.calderachain.xyz/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CAPX",
+    "symbol": "CAPX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.capx.ai/",
+  "shortName": "capx",
+  "chainId": 757,
+  "networkId": 757,
+  "icon": "capx",
+  "explorers": [{
+    "name": "blockscout",
+    "url": "https://capxscan.com",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
This PR adds CAPX Mainnet and Testnet to chainlist. Both networks are EVM-compatible Layer 2 chains (Arbitrum Orbit rollups) built on Capx's infrastructure for AI agent deployment and tokenization.

**Website:** https://www.capx.ai/
**Native Currency:** CAPX (18 decimals)
**Features:** EIP155, EIP1559

## CAPX Mainnet (Chain ID: 757)
- **RPC URLs:** 
  - https://capx-mainnet.calderachain.xyz/http
  - wss://capx-mainnet.calderachain.xyz/ws

## CAPX Testnet (Chain ID: 756)
- **RPC URLs:**
  - https://capx-testnet-c1.rpc.caldera.xyz/http
  - wss://capx-testnet-c1.rpc.caldera.xyz/ws

---

**Note:** This PR adds new chain configurations following the structure outlined in the [README](https://github.com/DefiLlama/chainlist#add-a-chain). 

**Privacy Policy:** https://docs.capx.ai/