### PR TITLE
Added HAQQ Testethic L2 Testnet (Sepolia)

### DIFF
--- a/constants/additionalChainRegistry/chainid-853211.js
+++ b/constants/additionalChainRegistry/chainid-853211.js
@@ -1,6 +1,6 @@
 export const data = {
   "name": "HAQQ Testethic (L2 Sepolia Testnet)",
-  "chain": "HAQQ L2",
+  "chain": "ETH",
   "rpc": [
     "https://rpc.testethic.haqq.network",
     "wss://rpc.testethic.haqq.network"

--- a/constants/additionalChainRegistry/chainid-853211.js
+++ b/constants/additionalChainRegistry/chainid-853211.js
@@ -1,0 +1,44 @@
+export const data = {
+  "name": "HAQQ Testethic (L2 Sepolia Testnet)",
+  "chain": "HAQQ L2",
+  "rpc": [
+    "https://rpc.testethic.haqq.network",
+    "wss://rpc.testethic.haqq.network"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "ETH",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" },
+    { "name": "EIP2930" },
+    { "name": "EIP4844" }
+  ],
+  "infoURL": "https://www.haqq.network",
+  "shortName": "haqq-testethic",
+  "chainId": 853211,
+  "networkId": 853211,
+  "testnet": true,
+  "icon": "haqq",
+  "explorers": [
+    {
+      "name": "HAQQ Testethic Blockscout",
+      "url": "https://explorer.testethic.haqq.network",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [
+      {
+        "url": "https://shell.haqq.network/bridge"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds HAQQ Testethic (Chain ID: 853211), an OP Stack-based L2 testnet with parent chain Ethereum Sepolia, to ChainList.
