### PR TITLE
Create chainlist-tensora.js

### DIFF
--- a/constants/additionalChainRegistry/~/chainlist-tensora.js
+++ b/constants/additionalChainRegistry/~/chainlist-tensora.js
@@ -1,4 +1,4 @@
-export default {
+export const data ={
   "name": "Tensora",
   "chain": "Tensora",
   "rpc": [


### PR DESCRIPTION
Adding Tensora L2 to Chainlist

Chain Information
- Chain Name: Tensora
- Chain ID: 44444444
- Type: OP Stack L2 Rollup
- L1: BSC Mainnet (Chain 56)

RPC Information

RPC Provider: Self-hosted infrastructure

Service Provider Website: https://tensora.sh
Privacy Policy: https://docs.tensora.sh/privacy

Why This RPC Should Be Added

Tensora is a new OP Stack Layer 2 rollup settling to BSC, designed for decentralized AI services. The RPC endpoint is self-hosted infrastructure running on dedicated hardware at 63.250.32.66.

Infrastructure Details:
- op-geth (execution engine) in archive mode
- op-node (rollup consensus) with sequencer enabled
- Nginx reverse proxy with CORS enabled
- SSL certificate (to be added via Let's Encrypt)

L1 Contracts Deployed:
- OptimismPortal: 0x4f559F30f5eB88D635FDe1548C4267DB8FaB0351
- L1StandardBridge: 0xd21060559c9beb54fC07aFd6151aDf6cFCDDCAeB
- SystemConfig: 0x416C42991d05b31E9A6dC209e91AD22b79D87Ae6

All contracts verified on BSCScan.

Note: This is a new chain launch. The RPC is provided at the end of the array as a fallback option.