### PR TITLE
Add bloxroute base endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5195,6 +5195,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.grove,
       },
+      {
+        url: "https://base-rpc.blxrbdn.com",
+        tracking: "yes",
+        trackingDetails: privacyStatement.bloxroute,
+      },
     ],
   },
   11235: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://bloxroute.com/

#### Provide a link to your privacy policy:
Our privacy policy is already listed in extraRpcs.js

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.