### PR TITLE
Add ChainID 292 for HashSphere

### DIFF
--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -1,0 +1,17 @@
+{
+    "name": "HashSphere",
+    "chain": "HashSphere",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "hbar",
+      "symbol": "HBAR",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://hashgraph.com",
+    "shortName": "hbar",
+    "chainId": 292,
+    "networkId": 292,
+    "explorers": []
+  }


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.