### PR TITLE
ICBX Network New RPC Created extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8471,7 +8471,8 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc1-mainnet.icbnetwork.info",
       "https://rpc2-mainnet.icbnetwork.info",
-      "https://main1.rpc-icb-network.io/",
+      "https://main1.rpc-icb-network.io",
+      "https://main2.rpc-icb-network.io",
     ],
   },
   2632500: {


### PR DESCRIPTION
Network Name :- ICB Network
Chain ID :- 73115(0x11d9b)
Currency : ICBX

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):

Service Company = ICBX Network ( icb.network )
Chain Type :- Layer 1 EVM

Provide a link to your privacy policy:

https://docs.icb.network/legal-docs/privacy-policy

We have created the new RPC. 

http://main2.rpc-icb-network.io


  73115: {
    rpcs: [
      "https://rpc1-mainnet.icbnetwork.info",
      "https://rpc2-mainnet.icbnetwork.info",
      "https://main1.rpc-icb-network.io/",
       "https://main2.rpc-icb-network.io",

    ]



