### PR TITLE
Add dRPC NodeCloud RPC endpoint for Arc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8818,7 +8818,8 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
     ],
-}}
+  },
+};
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 


### PR DESCRIPTION
This PR adds dRPC NodeCloud’s HTTP and WSS endpoints for the Arc network.

Endpoints:
- HTTPS: https://arc.drpc.org
- WSS: wss://arc.drpc.org

Webpage: https://drpc.org/chainlist/arc

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://drpc.org

#### Provide a link to your privacy policy:

https://drpc.org/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.