### PR TITLE
add: xo chain testnet (chainId 1000101)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1000101.js
+++ b/constants/additionalChainRegistry/chainid-1000101.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "XO Chain Testnet",
+  "chain": "XO",
+  "rpc": [
+    "https://testnet-rpc-1.xo.market"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "XO Token",
+    "symbol": "XO",
+    "decimals": 18
+  },
+  "infoURL": "https://xo.market",
+  "shortName": "xo",
+  "chainId": 1000101,
+  "networkId": 1000101,
+  "icon": "xo",
+  "explorers": [
+    {
+      "name": "xo explorer",
+      "url": "https://explorer-testnet.xo.market",
+      "icon": "xo",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
This PR adds the **XO Chain Testnet** to ChainList `chainId 1000101`.  
**XO Chain Testnet** is an **EVM-compatible network** powering **XO Market’s conviction markets**, where people trade their beliefs and permissionlessly create markets using LS-LMSR adaptive liquidity, across any topic, with transparent and efficient resolution.

### Network Details
- **Chain Name:** XO Chain Testnet  
- **Chain ID:** 1000101  
- **RPC:** `https://testnet-rpc-1.xo.market`  
- **Explorer:** `https://explorer-testnet.xo.market`  
- **Native Token:** XO (18 decimals)  
- **Info URL and Service Provider:** [https://xo.market](https://xo.market)

