### PR TITLE
Add Riche Chain Testnet (45578)

### DIFF
--- a/constants/additionalChainRegistry/chainid-45578.js
+++ b/constants/additionalChainRegistry/chainid-45578.js
@@ -1,0 +1,28 @@
+export const data = {
+  "name": "Riche Chain Testnet",
+  "chain": "RIC",
+  "rpc": [
+    "https://rpcrichechain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Riche",
+    "symbol": "RIC",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://rpcrichechain.com",
+  "shortName": "ric-test",
+  "chainId": 45578,
+  "networkId": 45578,
+  "explorers": [
+    {
+      "name": "RicheScan",
+      "url": "https://richescan-testnet.com/",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): I am the individual founder and operator of this new public testnet. The project's official block explorer, which is already live, can be found at: https://richescan-testnet.com/.


#### Provide a link to your privacy policy: A formal privacy policy page is not yet available, as this is a newly launched independent testnet. However, the RPC endpoint (https://rpcrichechain.com) is a standard Hyperledger Besu implementation. It does not collect, store, or process any personal user data, beyond the standard operational logs necessary for node health and security (e.g., IP addresses for diagnostics or rate-limiting).


#### If the RPC has none of the above and you still think it should be added, please explain why: We are adding Riche Chain Testnet as it is a new, open, and persistent EVM-compatible testnet (PoA, EIP1559-enabled) built for developers. Our goal is to provide a stable and reliable platform for the community to test smart contracts and dApps. We are fully committed to maintaining this infrastructure for the long term.

Your RPC should always be added at the end of the array.