### PR TITLE
Add Arc Network (chainId:5042002) to Chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-5042002.js
+++ b/constants/additionalChainRegistry/chainid-5042002.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "Arc Testnet",
+  "chain": "arc-testnet",
+  "rpc": ["https://rpc.testnet.arc.network"],
+  "faucets": ["https://faucet.circle.com/"],
+  "nativeCurrency": {
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": 6
+  },
+  "infoURL": "https://www.arc.network/",
+  "shortName": "arc-testnet",
+  "chainId": 5042002,
+  "networkId": 5042002,
+  "icon": "arc",
+  "explorers": [
+    {
+      "name": "Arc Testnet Explorer",
+      "url": "https://testnet.arcscan.app/",
+      "icon": "arc",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Arc Network to the additionalChainRegistry with official RPC endpoints and explorer.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

#### Provide a link to your privacy policy:

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.