### PR TITLE
Add PulseChainStats RPC endpoint for PulseChain (369)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -98,6 +98,8 @@ const privacyStatement = {
   zan: "ZAN Node Service generally does not store any kind of user information (e.g. IP address, location, requst location, request data, etc.) that transits through our RPCs except for one senario ——we may track your IP address when you are using our RPCs and will delete it immediately when you stoping using our RPCs. To learn more, please review our privacy policy at https://a.zan.top/static/Privacy-Policy.pdf",
   quicknode:
     "Information about your computer hardware and software may be automatically collected by QuickNode. This information can include such details as your IP address, browser type, domain names, access times and referring website addresses.https://www.quicknode.com/privacy",
+  pulsechainstats:
+    "PulseChainStats RPC does not store or track user information. We only temporarily log IP addresses for rate limiting and DDoS protection purposes. Logs are automatically deleted after 7 days. No wallet addresses or transaction data are correlated with IP addresses.",
   chainstack:
     "We process certain personal data to provide you with the core functionality of our Services. Specifically, when you are: Using the Chainstack Console, we process your name, surname, email address (your account identifier), organization name, IP address, all HTTP headers (most importantly User-Agent), cookies; Using the Chainstack Blockchain infrastructure, we process nodes' token stored in Chainstack Vault, IP address and HTTP headers, request body, API token in Chainstack Vault.https://chainstack.com/privacy/",
   shardeum:
@@ -3918,6 +3920,11 @@ export const extraRpcs = {
         url: "wss://ws.pulsechainrpc.com",
         tracking: "none",
         trackingDetails: privacyStatement.PulseChainRpc,
+      },
+      {
+        url: "https://rpc.pulsechainstats.com",
+        tracking: "limited",
+        trackingDetails: privacyStatement.pulsechainstats,
       },
     ],
   },


### PR DESCRIPTION
## Summary
  Adding a new community RPC endpoint for PulseChain (Chain ID 369)

  ## RPC Details
  - **URL**: https://rpc.pulsechainstats.com
  - **Provider**: PulseChainStats
  - **Location**: United States
  - **Features**:
    - Full PulseChain mainnet node
    - SSL/TLS encrypted (Let's Encrypt)
    - Cloudflare DDoS protection
    - Supports eth, net, web3, and txpool APIs

  ## Questions

  #### Link the service provider's website (the company/protocol/individual
  providing the RPC):
  https://pulsechainstats.com

  #### Provide a link to your privacy policy:
  Privacy statement included in the code submission:
  - No user tracking or data storage
  - IP addresses temporarily logged for rate limiting and DDoS protection only
  - Logs automatically deleted after 7 days
  - No correlation between wallet addresses and IP addresses

  #### If the RPC has none of the above and you still think it should be
  added, please explain why:
  N/A - Privacy policy is provided in the code submission.

  ## Testing
  RPC is fully operational and can be tested:
  ```bash
  curl -X POST https://rpc.pulsechainstats.com \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'

  Expected response: Current PulseChain block number

  Note

  RPC has been added at the end of the PulseChain (369) RPC array as
  requested.
  ```
