### PR TITLE
Add chain definitions for Linea (59144), Fraxtal (252), and Blast (81…

### DIFF
--- a/constants/additionalChainRegistry/chainid-252.js
+++ b/constants/additionalChainRegistry/chainid-252.js
@@ -1,0 +1,31 @@
+module.exports = {
+  name: "Fraxtal",
+  chain: "ETH",
+  rpc: [
+    "https://rpc.frax.com",
+    "https://fraxtal.drpc.org"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Frax Ether",
+    symbol: "frxETH",
+    decimals: 18,
+  },
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  infoURL: "https://frax.com/fraxtal",
+  shortName: "fraxtal",
+  chainId: 252,
+  networkId: 252,
+  icon: "fraxtal",
+  explorers: [
+    {
+      name: "Fraxscan",
+      url: "https://fraxscan.com",
+      icon: "fraxscan",
+      standard: "EIP3091"
+    }
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-59144.js
+++ b/constants/additionalChainRegistry/chainid-59144.js
@@ -1,0 +1,31 @@
+module.exports = {
+  name: "Linea",
+  chain: "ETH",
+  rpc: [
+    "https://rpc.linea.build",
+    "https://mainnet-rpc.linea.build"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  infoURL: "https://linea.build",
+  shortName: "linea",
+  chainId: 59144,
+  networkId: 59144,
+  icon: "linea",
+  explorers: [
+    {
+      name: "LineaScan",
+      url: "https://lineascan.build",
+      icon: "lineascan",
+      standard: "EIP3091"
+    }
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-81457.js
+++ b/constants/additionalChainRegistry/chainid-81457.js
@@ -1,0 +1,30 @@
+module.exports = {
+  name: "Blast",
+  chain: "ETH",
+  rpc: [
+    "https://rpc.blast.io"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  infoURL: "https://blast.io",
+  shortName: "blast",
+  chainId: 81457,
+  networkId: 81457,
+  icon: "blast",
+  explorers: [
+    {
+      name: "Blastscan",
+      url: "https://blastscan.io",
+      icon: "blastscan",
+      standard: "EIP3091"
+    }
+  ],
+};


### PR DESCRIPTION
Adds chain files for Linea, Fraxtal, and Blast with RPC endpoints, explorers, and L2 parent metadata.
Tested locally with lint and Node import.