### PR TITLE
Update R0AR Chain icon (mainnet 193939 + testnet 11166111) to IPFS

### DIFF
--- a/constants/additionalChainRegistry/chainid-11166111.js
+++ b/constants/additionalChainRegistry/chainid-11166111.js
@@ -1,0 +1,34 @@
+export default {
+  "name": "R0AR Testnet",
+  "chain": "R0AR",
+  "rpc": [
+    "https://testnet.rpc-r0ar.io"
+  ],
+  "faucets": [
+    "https://testnet.r0arfaucet.io"
+  ],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://r0ar.io",
+  "shortName": "r0art",
+  "chainId": 11166111,
+  "networkId": 11166111,
+  "icon": {
+    "url": "ipfs://bafkreidkjnapgtiklxnefhflatxs72t6knhft6ma7oaqkbfebr67uouyke",
+    "format": "png",
+    "width": 512,
+    "height": 512
+  },
+  "explorers": [
+    {
+      "name": "R0ARscan (testnet)",
+      "url": "https://testnet.r0arscan.io",
+      "icon": "r0ar",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-11166111.js
+++ b/constants/additionalChainRegistry/chainid-11166111.js
@@ -1,4 +1,4 @@
-export default {
+export const data ={
   "name": "R0AR Testnet",
   "chain": "R0AR",
   "rpc": [

--- a/constants/additionalChainRegistry/chainid-193939.js
+++ b/constants/additionalChainRegistry/chainid-193939.js
@@ -1,0 +1,32 @@
+export default {
+  "name": "R0AR Chain",
+  "chain": "R0AR",
+  "rpc": [
+    "https://rpc-r0ar.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://r0ar.io",
+  "shortName": "r0ar",
+  "chainId": 193939,
+  "networkId": 193939,
+  "icon": {
+    "url": "ipfs://bafkreidkjnapgtiklxnefhflatxs72t6knhft6ma7oaqkbfebr67uouyke",
+    "format": "png",
+    "width": 512,
+    "height": 512
+  },
+  "explorers": [
+    {
+      "name": "R0ARscan",
+      "url": "https://r0arscan.io",
+      "icon": "r0ar",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-193939.js
+++ b/constants/additionalChainRegistry/chainid-193939.js
@@ -1,4 +1,4 @@
-export default {
+export const data ={
   "name": "R0AR Chain",
   "chain": "R0AR",
   "rpc": [


### PR DESCRIPTION
This PR adds/updates overrides for R0AR Chain mainnet (chainId 193939) and R0AR Testnet (chainId 11166111) to include the new IPFS-hosted icon:

ipfs://bafkreidkjnapgtiklxnefhflatxs72t6knhft6ma7oaqkbfebr67uouyke
- format: SVG, 512x512

Both entries include EIP155/EIP1559 features and explorers.