### PR TITLE
add onfinality's hyperliquid rpc endpoint

### DIFF
--- a/constants/additionalChainRegistry/chainid-999.js
+++ b/constants/additionalChainRegistry/chainid-999.js
@@ -8,7 +8,8 @@ export const data = {
       "https://hyperliquid-json-rpc.stakely.io",
       "https://hyperliquid.drpc.org",
       "wss://hyperliquid.drpc.org",
-      "https://rpc.hyperlend.finance"
+      "https://rpc.hyperlend.finance",
+      "https://hyperliquid.api.onfinality.io/evm/public"
     ],
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "faucets": [],

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3114,11 +3114,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://okt-chain.api.onfinality.io/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.onfinality,
-      },
-      {
         url: "https://1rpc.io/oktc",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://onfinality.io/

#### Provide a link to your privacy policy:
https://onfinality.io/en/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.