### PR TITLE
add: Bitmeta Chain (BMC) – chainId 1199

### DIFF
--- a/constants/additionalChainRegistry/chainid-1199.js
+++ b/constants/additionalChainRegistry/chainid-1199.js
@@ -1,9 +1,10 @@
-export default {
+export const data ={
   "chainId": 1199,
   "name": "BMC Chain",
   "shortName": "bmc",
   "chain": "BMC",
   "networkId": 1199,
+  "chainId": 1199,
   "infoURL": "https://bmcscan.io",
   "rpc": ["https://mainnet-rpc.bmcscan.io"],
   "nativeCurrency": {


### PR DESCRIPTION
### BMC Chain 

**Chain Details:**
- **Chain Name:** BMC Chain
- **Chain ID:** 1199
- **Short Name:** bmc
- **Network ID:** 1199
- **Native Currency:** Bitmeta Coin (BMC), 18 decimals
- **RPC URL:** https://mainnet-rpc.bmcscan.io
- **Explorer URL:** https://bmcscan.io
- **Info URL:** https://bmcscan.io
- **Features:** EVM Compatible, MetaMask Supported
- **Logo URL:** https://raw.githubusercontent.com/King11919/BMC-Chain/main/bmc-logo.png