### PR TITLE
Add Amazonic Blockchain data to chainid-65.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-65.js
+++ b/constants/additionalChainRegistry/chainid-65.js
@@ -1,0 +1,22 @@
+export const data = {
+  "name": "Amazonic Blockchain",
+  "chain": "AMZG",
+  "rpc": ["https://rpc.amz1.com.br"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Amazonic Green",
+    "symbol": "AMZG",
+    "decimals": 18
+  },
+  "infoURL": "https://amazonicone.com.br",
+  "shortName": "amzg",
+  "chainId": 65,
+  "networkId": 65,
+  "icon": "https://amazonicone.com.br/wp-content/uploads/2025/10/800X800-1.png",
+  "explorers": [{
+    "name": "AMZ Scan",
+    "url": "https://amzexplorer.com",
+    "icon": "https://amazonicone.com.br/wp-content/uploads/2025/10/800X800-1.png",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adds support for Amazonic Blockchain (Amazonic One) — an EVM-compatible network built on a customized Waves core, offering full interoperability with MetaMask and Web3 applications. This integration enables seamless interaction with dApps and smart contracts through standard Ethereum RPC and signing protocols.

Network details:

Name: Amazonic Blockchain

Symbol: AMZG

Chain ID: 65

RPC: https://rpc.amz1.com.br

Explorer: AMZ Scan

Native Currency: Amazonic Green (AMZG, 18 decimals)

Official Website: amazonicone.com.br

Best regards, Diego Oris – @diegoorisderoa on Telegram)

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.