### PR TITLE
Add ETO Network (Chain ID 69420)

### DIFF
--- a/constants/additionalChainRegistry/chainid-69420.js
+++ b/constants/additionalChainRegistry/chainid-69420.js
@@ -1,0 +1,34 @@
+// File: constants/additionalChainRegistry/chainid-69420.js
+// This file should be added to the DefiLlama/chainlist repository
+
+export default {
+  "name": "ETO Network",
+  "chain": "ETO",
+  "rpc": [
+    "https://eto.ash.center/rpc",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "DRI",
+    "symbol": "DRI",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://eto.ash.center",
+  "shortName": "eto",
+  "chainId": 69420,
+  "networkId": 69420,
+  "icon": "ethereum",
+  "explorers": [
+    {
+      "name": "ETO Explorer",
+      "url": "https://eto.ash.center",
+      "icon": "ethereum",
+      "standard": "EIP3091"
+    }
+  ]
+};
+


### PR DESCRIPTION
This PR adds ETO Network (Chain ID 69420) to Chainlist.

**Chain Details:**
- Chain ID: 69420
- Network ID: 69420
- Name: ETO Network
- Native Currency: DRI (18 decimals)
- RPC: https://eto.ash.center/rpc
- EVM Compatible: Yes
- Features: EIP155, EIP1559

**Verification:**
- RPC endpoint is publicly accessible
- Chain is EVM-compatible
- Network is operational (100k+ blocks)

This will allow users to add ETO Network to MetaMask and other wallets via Chainlist.