### PR TITLE
Add bloxroute hyperliquid endpoint

### DIFF
--- a/constants/additionalChainRegistry/chainid-999.js
+++ b/constants/additionalChainRegistry/chainid-999.js
@@ -9,7 +9,8 @@ export const data = {
       "https://hyperliquid.drpc.org",
       "wss://hyperliquid.drpc.org",
       "https://rpc.hyperlend.finance",
-      "https://hyperliquid.api.onfinality.io/evm/public"
+      "https://hyperliquid.api.onfinality.io/evm/public",
+      "https://hyperliquid.rpc.blxrbdn.com"
     ],
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "faucets": [],


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://bloxroute.com/

#### Provide a link to your privacy policy:

Our privacy policy is already listed in extraRpcs.js

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.