### PR TITLE
Add chain registry for chainid 38391207

### DIFF
--- a/constants/additionalChainRegistry/chainid-38391207.js
+++ b/constants/additionalChainRegistry/chainid-38391207.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "GLOBALCHAIN",
+  "chain": "GBDo",
+  "rpc": [
+    "https://rpc.brantley-global.com",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Global Dollar",
+    "symbol": "GBDo",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://brantley-global.com",
+  "shortName": "gbdo",
+  "chainId": 38391207,
+  "networkId": 38391207,
+  "icon": "gbdo",
+  "explorers": [{
+    "name": "globaldash",
+    "url": "https://brantley-global.com/dashboard",
+    "icon": "bg",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Add Brantley Global GLOBALCHAIN (chainId: 38391207)

Name: GLOBALCHAIN
Chain ID: 38391207
Short Name: gbdo
Network ID: 38391207
Native Currency: GBDo (18 decimals)
RPC: https://rpc.brantley-global.com/
Explorer: https://brantley-global.com/dashboard
Status: active
No parent chain (Layer 1)

EIP155
EIP1559
EIP1344
EIP2930
EIP2718

Chain icon: gbdo
    CID: bafybeig6kwquzuvdgnpvwgaaess2lsw6fhaen5ivzqeecax443naxbalmm
Explorer icon: bg
    CID: bafybeid2vnkiajyou6g2toeb4zqlfiqhwn2p3s45dftwqrpexhm46qf6uq