### PR TITLE
feat: update chainid-5887.js with new icon and currency names

### DIFF
--- a/constants/additionalChainRegistry/chainid-5887.js
+++ b/constants/additionalChainRegistry/chainid-5887.js
@@ -20,6 +20,12 @@ export const data = {
   "networkId": 5887,
   "explorers": [
     {
+      "name": "Dukong Blockscout Explorer",
+      "url": "https://explorer.dukong.io",
+      "standard": "EIP3091",
+      "icon": "mantra"
+    },
+    {
       "name": "Dukong Explorer",
       "url": "http://mantrascan.io/dukong",
       "standard": "none",


### PR DESCRIPTION
update MANTRA Testnet (chainId 5887) to Chainlist.

website: https://www.mantrachain.io/ ([Privacy policy](https://www.mantrachain.io/legal/privacy-policy))
explorer: https://mantrascan.io/dukong
native currency: MANTRA (18 decimals)
rpc: https://evm.dukong.mantrachain.io/