### PR TITLE
Add extra RPC endpoint for QL1 (chainId 766)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8913,11 +8913,20 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.grove,
       },
       {
-        url: "wss://xrplevm-testnet.buildintheshade.com",
+       url: "wss://xrplevm-testnet.buildintheshade.com",
         tracking: "limited",
         trackingDetails: privacyStatement.grove,
       },
     ]
+  },
+  766: {
+    rpcs: [
+       {
+        url: "https://evm-rpc-ql1.foxxone.one",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+       },
+    ],
   },
 };
 


### PR DESCRIPTION
#### Link the service provider's website:
https://foxxone.one

#### Provide a link to your privacy policy:
This is a community-run, non-commercial RPC operated by FoxxOne. There is no formal privacy policy, but the endpoint does not perform analytics, tracking, fingerprinting, or data collection. Only minimal server-side logs are kept for abuse prevention and debugging (IP, timestamp, request path).

#### If the RPC has none of the above and you still think it should be added, please explain why: This RPC improves redundancy, reliability, and decentralization for the QL1 ecosystem (chainId 766). It is operated independently by a long-standing QL1 community validator (FoxxOne) and provides a stable alternative to the main RPC.

The endpoint:
• is fully synced on QL1 mainnet (eth_chainId = 0x2fe) • supports standard JSON-RPC methods (eth_blockNumber, eth_getBlockByNumber, etc.) • is publicly accessible over HTTPS
• requires no API key
• performs no tracking or data collection

This entry has been added at the end of the rpcs array for chainId 766 as requested.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.