### PR TITLE
Add Phala Network RPC (Chain ID 2035)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -7715,6 +7715,9 @@ export const extraRpcs = {
   78600: {
     rpcs: ["https://rpc-vanguard.vanarchain.com"],
   },
+  2035: {
+    rpcs: ["https://rpc.phala.network"],
+  },
   2040: {
     rpcs: ["https://rpc.vanarchain.com"],
   },


### PR DESCRIPTION
## Summary
- Add extra RPC endpoint for Phala Network (Chain ID 2035)
- RPC: https://rpc.phala.network

## Test plan
- [x] Verify RPC endpoint is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)