### PR TITLE
Fix: Update Denergy Explorer URL to the correct domain

### DIFF
--- a/constants/additionalChainRegistry/chainid-369369.js
+++ b/constants/additionalChainRegistry/chainid-369369.js
@@ -16,7 +16,7 @@ export const data = {
   explorers: [
     {
       name: "Denergy Explorer",
-      url: "https://explorer.d.energy",
+      url: "https://explorer.denergychain.com",
       icon: "denergy",
       standard: "EIP3091",
     },


### PR DESCRIPTION
### Description
This PR fixes the incorrect Explorer URL for Denergy - https://explorer.denergychain.com