### PR TITLE
Add HyperX chain (888)

### DIFF
--- a/constants/additionalChainRegistry/chainid-888.js
+++ b/constants/additionalChainRegistry/chainid-888.js
@@ -1,0 +1,27 @@
+export default {
+  "name": "HyperX",
+  "chain": "HPX",
+  "rpc": [
+    "https://rpc.hyperx.technology"
+  ],
+  "faucets": [
+    "https://faucet.hyperx.technology"
+  ],
+  "nativeCurrency": {
+    "name": "HPX",
+    "symbol": "HPX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://hyperx.technology",
+  "shortName": "hpx",
+  "chainId": 888,
+  "networkId": 888,
+  "explorers": [
+    {
+      "name": "HyperX Explorer",
+      "url": "https://scan.hyperx.technology",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Link the service provider's website:
https://hyperx.technology/
Provide a link to your privacy policy:
N/A - This is a new chain submission, not an RPC addition.
If the RPC has none of the above and you still think it should be added, please explain why:
This PR adds a new EVM chain (HyperX, chain ID 888), not an RPC to an existing chain.