### PR TITLE
Add Alpha Chain to Chainlist (3111 & 511111)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3111.js
+++ b/constants/additionalChainRegistry/chainid-3111.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "Alpha Chain Mainnet",
+  "chain": "Alpha Chain",
+  "rpc": [
+    "https://rpc.goalpha.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://docs.alphatoken.com/AlphaChain/about-alpha-chain",
+  "shortName": "alpha",
+  "chainId": 3111,
+  "networkId": 3111,
+  "explorers": [{
+    "name": "Alpha Chain Scan",
+    "url": "https://scan.goalpha.org",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-511111.js
+++ b/constants/additionalChainRegistry/chainid-511111.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "Alpha Chain Testnet",
+  "chain": "Alpha Chain",
+  "rpc": [
+    "https://testnet-rpc.goalpha.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://docs.alphatoken.com/AlphaChain/about-alpha-chain",
+  "shortName": "alpha",
+  "chainId": 511111,
+  "networkId": 511111,
+  "explorers": [{
+    "name": "Alpha Chain Scan",
+    "url": "https://testnet-scan.goalpha.org",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

AlphaToken is the company behind Alpha Chain RPC Services.
https://docs.alphatoken.com/

#### Provide a link to your privacy policy:

https://docs.alphatoken.com/AlphaChain/rpc-privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.