### PR TITLE
Add Kalichain configuration for chain ID 6533

### DIFF
--- a/constants/additionalChainRegistry/chainid-6533.js
+++ b/constants/additionalChainRegistry/chainid-6533.js
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   name: "Kalichain",
   chain: "Kalichain",
   rpc: [


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://kalichain.com (Official Website)
Hosting provider: https://www.avacloud.io

#### Provide a link to your privacy policy:
https://www.avax.network/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the new official RPC for Kalichain following the migration to an Avalanche Subnet (ID 6533).