### PR TITLE
add: Celeschain (Cles) - chainid 22225

### DIFF
--- a/constants/additionalChainRegistry/chainid-22225.js
+++ b/constants/additionalChainRegistry/chainid-22225.js
@@ -20,9 +20,10 @@ export const data = {
     "explorers": [
       {
         "name": "Celes Testnet Explorer",
-        "url": "https://testnet-explore.celeschain.org",
+        "url": "https://testnet-explorer.celeschain.org",
         "icon": "celes",
         "standard": "EIP3091"
       }
     ]
   }
+  


### PR DESCRIPTION
This pull request adds Celes Chain to the chain list, including complete network metadata such as chain ID, RPC endpoint, native currency details, and block explorer configuration. This ensures full compatibility with wallets, dApps, and EVM-based tooling.

Added Chain Metadata

Chain Name: Celes Testnet

Symbol: CLES

Native Currency: CLES (18 decimals)

Chain ID: 22225

Network ID: 22225

RPC URL: https://rpc-testnet.celeschain.org 
                wss://rpc-testnet.celeschain.org

Explorer: https://testnet-explorer.celeschain.org

Info URL: https://celeschain.org