### PR TITLE
add notes network

### DIFF
--- a/constants/additionalChainRegistry/chainid-2643.json
+++ b/constants/additionalChainRegistry/chainid-2643.json
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "Notes Network Mainnet",
   "chain": "NOTES",
   "rpc": ["https://rpc-mainnet.noschain.org"],


### PR DESCRIPTION
Add Notes Network (chainId 2643)

This PR adds the Notes Network Mainnet to Chainlist.

Chain ID: 2643
RPC: https://rpc-mainnet.noschain.org
Explorer: https://nosscan.noschain.org
Native currency: KTO (decimals: 11)