### PR TITLE
Please Add Tatum Plume Mainnet RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8951,6 +8951,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://plume-mainnet.gateway.tatum.io/",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   747474: {


### PR DESCRIPTION
Please Add Tatum Plume Mainnet RPC endpoint

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://tatum.io/chain/plume


#### Provide a link to your privacy policy: https://tatum.io/terms-of-use


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.