### PR TITLE
Add BTB Chain Mainnet (Chain ID 509)

### DIFF
--- a/constants/additionalChainRegistry/chainid-509.js
+++ b/constants/additionalChainRegistry/chainid-509.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "BTB Chain Mainnet",
+  "chain": "BTB",
+  "rpc": [
+    "https://btb-dataseed.btbchain.org",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BitTap Chain Token",
+    "symbol": "BTB",
+    "decimals": 18
+  },
+  "infoURL": "https://www.btbchain.org/",
+  "shortName": "btb",
+  "chainId": 509,
+  "networkId": 509,
+  "explorers": [
+    {
+      "name": "BTB Chain Explorer",
+      "url": "https://btb-explorer.btbchain.org",
+      "standard": "EIP3091"
+    }
+  ],
+  "chainSlug": "btb",
+  "isTestnet": false
+}


### PR DESCRIPTION
Added BTB Chain Mainnet configuration

- Chain ID: 509
- RPC: https://btb-dataseed.btbchain.org
- Symbol: BTB
- Explorer: https://btb-explorer.btbchain.org