### PR TITLE
Add Entropy Chain registry data

### DIFF
--- a/constants/additionalChainRegistry/chainid-19911.js
+++ b/constants/additionalChainRegistry/chainid-19911.js
@@ -6,8 +6,8 @@ export const data = {
   ],
   faucets: [],
   nativeCurrency: {
-    name: "KGF.e",
-    symbol: "KGF.e",
+    name: "KGFe",
+    symbol: "KGFe",
     decimals: 18
   },
   infoURL: "https://entropychain.live",


### PR DESCRIPTION
This pull request adds Entropy Chain to the chain list, including complete network metadata such as chain ID, RPC endpoint, native currency details, and block explorer configuration. This ensures full compatibility with wallets, dApps, and EVM-based tooling.

Added Chain Metadata

Chain Name: Entropy Chain

Symbol: KGFe

Native Currency: KGFe (18 decimals)

Chain ID: 19911

Network ID: 19911

RPC URL: https://rpc-mainnet.entropychain.live

Explorer: https://scan.entropychain.live
(EIP-3091 compliant)

Info URL: https://entropychain.live

