### PR TITLE
Add H2 Mainnet (2582) and H2 Lambda (25821)

### DIFF
--- a/constants/additionalChainRegistry/chainid-2582.js
+++ b/constants/additionalChainRegistry/chainid-2582.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "H2",
+  "chain": "H2",
+  "rpc": [
+    "https://rpc.h2chain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "H2",
+    "symbol": "H2",
+    "decimals": 18
+  },
+  "infoURL": "https://h2chain.io",
+  "shortName": "h2",
+  "chainId": 2582,
+  "networkId": 2582,
+  "icon": "https://h2inno.com/logo.svg",
+  "explorers": [
+    {
+      "name": "H2Scan",
+      "url": "https://h2scan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}
+

--- a/constants/additionalChainRegistry/chainid-25821.js
+++ b/constants/additionalChainRegistry/chainid-25821.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "H2 Lambda",
+  "chain": "H2",
+  "rpc": [
+    "https://rpc.h-1.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "H2",
+    "symbol": "H2",
+    "decimals": 18
+  },
+  "infoURL": "https://h2chain.io",
+  "shortName": "h2lambda",
+  "chainId": 25821,
+  "networkId": 25821,
+  "icon": "https://h2inno.com/logo.svg",
+  "explorers": [
+    {
+      "name": "H2Scan",
+      "url": "https://lambda.h2scan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}
+


### PR DESCRIPTION
   ## Summary
   This PR adds two new H2 networks to Chainlist:
   
   - **H2 Mainnet** (Chain ID: 2582)
     - RPC: https://rpc.h2chain.io
     - Explorer: https://h2scan.io
     - Website: https://h2inno.com
   
   - **H2 Lambda** (Chain ID: 25821)
     - RPC: https://rpc.h-1.io
     - Explorer: https://lambda.h2scan.io
     - Website: https://h2inno.com
   
   ## Details
   - Both networks use H2 as native currency (18 decimals)
   - Icon: https://h2inno.com/logo.svg
   - Both networks are mainnets (testnet: false)