### PR TITLE
Add VirBiCoin (Chain ID 329)

### DIFF
--- a/constants/additionalChainRegistry/chainid-329.js
+++ b/constants/additionalChainRegistry/chainid-329.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "VirBiCoin",
+    "chain": "VBC",
+    "rpc": [
+        "https://rpc.digitalregion.jp"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "VBC",
+        "symbol": "VBC",
+        "decimals": 18
+    },
+    "infoURL": "https://vbc.digitalregion.jp",
+    "shortName": "virbicoin",
+    "chainId": 329,
+    "networkId": 329,
+    "icon": "vbc",
+    "explorers": [
+        {
+            "name": "VirBiCoin Explorer",
+            "url": "https://explorer.digitalregion.jp",
+            "icon": "vbc",
+            "standard": "EIP3091"
+        }
+    ]
+}


### PR DESCRIPTION
Add VirBiCoin (Chain ID 329)

This PR adds the VirBiCoin EVM-compatible main network to the Chainlist registry.

🔗 Chain Information
Name: VirBiCoin
Chain ID: 329
Network ID: 329
RPC URL: [https://rpc.digitalregion.jp/](https://rpc.digitalregion.jp/)
Currency: VBC
Status: Mainnet Active
Info URL: [https://vbc.digitalregion.jp/](https://vbc.digitalregion.jp/)
Icon: [https://bafkreihwi6alsxnjlox2tu3yg2ahbn3dqaltktgwip7fg73vr6yujvdy5y.ipfs.w3s.link](https://bafkreihwi6alsxnjlox2tu3yg2ahbn3dqaltktgwip7fg73vr6yujvdy5y.ipfs.w3s.link)
Explorer: [https://explorer.digitalregion.jp/](https://explorer.digitalregion.jp/)

📋 Registry Reference
Listed on [chainid.network](https://chainid.network/chain/329/)

Thanks!