### PR TITLE
Dinari Financial Network - Chain ID:202110

### DIFF
--- a/constants/additionalChainRegistry/chainid-179205.js
+++ b/constants/additionalChainRegistry/chainid-179205.js
@@ -1,6 +1,6 @@
 export const data = {
-    "name": "Dinari Paper Network",
-    "chain": "DPN",
+    "name": "Dinari Financial Network Paper",
+    "chain": "DFNP",
     "rpc": [
       "https://subnets.avax.network/dfnpaper/testnet/rpc",
     ],
@@ -10,7 +10,10 @@ export const data = {
       "symbol": "DGAS",
       "decimals": 18
     },
-    "features": [{ "name": "EIP155" }],
+    "features": [
+      { "name": "EIP155" },
+      { "name": "EIP1559" }
+    ],
     "infoURL": "https://dinari.com",
     "shortName": "dpn",
     "chainId": 179205,

--- a/constants/additionalChainRegistry/chainid-202110.js
+++ b/constants/additionalChainRegistry/chainid-202110.js
@@ -10,7 +10,10 @@ export const data = {
       "symbol": "DGAS",
       "decimals": 18
     },
-    "features": [{ "name": "EIP155" }],
+    "features": [
+      { "name": "EIP155" },
+      { "name": "EIP1559" }
+    ],
     "infoURL": "https://dinari.com",
     "shortName": "dfn",
     "chainId": 202110,


### PR DESCRIPTION
The Dinari Financial Network is an L1 chain supporting the transaction of tokenized equities. 

This PR includes an entry for main net (202110) and test net (179205). 

Link the service provider's website (the company/protocol/individual providing the RPC):

Company: https://dinari.com
Hosting provider: https://www.avacloud.io/

Provide a link to your privacy policy:
https://dinari.com/privacy