### PR TITLE
Fix: Update Somnia Mainnet RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8822,7 +8822,7 @@ export const extraRpcs = {
     rpcWorking: true,
   },
   5031: {
-    rpcs: ["https://rpc.somnia.network", "https://somnia-json-rpc.stakely.io", "https://somnia-rpc.publicnode.com"],
+    rpcs: ["https://somnia-json-rpc.stakely.io", "https://somnia-rpc.publicnode.com"],
   },
   9745: {
     rpcs: [


### PR DESCRIPTION
I have removed an RPC url path that does not exist: `https://rpc.somnia.network`