### PR TITLE
Add Brevis ProverNet Testnet [Chain ID: 999983] 

### DIFF
--- a/constants/additionalChainRegistry/chainid-999983.js
+++ b/constants/additionalChainRegistry/chainid-999983.js
@@ -12,7 +12,7 @@ export const data = {
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://brevis.network/",
-  "shortName": "brevis-network-testnet",
+  "shortName": "brevis-provernet-testnet",
   "chainId": 999983,
   "networkId": 999983,
   "explorers": [{


### PR DESCRIPTION
Brevis Prover Network Testnet
Chain ID: 999983
https://brevis.network/