### PR TITLE
Add Ault Blockchain mainnet and testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-10904.js
+++ b/constants/additionalChainRegistry/chainid-10904.js
@@ -1,0 +1,18 @@
+module.exports = {
+  name: "Ault Blockchain Testnet",
+  chain: "AULT",
+  rpc: [],
+  faucets: [],
+  nativeCurrency: {
+    name: "Testnet AULT Token",
+    symbol: "AULT",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://aultblockchain.com",
+  shortName: "ault-testnet",
+  chainId: 10904,
+  networkId: 10904,
+  icon: "ault",
+  explorers: [],
+};

--- a/constants/additionalChainRegistry/chainid-904.js
+++ b/constants/additionalChainRegistry/chainid-904.js
@@ -1,0 +1,18 @@
+module.exports = {
+  name: "Ault Blockchain Mainnet",
+  chain: "AULT",
+  rpc: [],
+  faucets: [],
+  nativeCurrency: {
+    name: "AULT Token",
+    symbol: "AULT",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://aultblockchain.com",
+  shortName: "ault",
+  chainId: 904,
+  networkId: 904,
+  icon: "ault",
+  explorers: [],
+};


### PR DESCRIPTION
Adds Ault Blockchain mainnet (904) and testnet (10904).

RPC / explorer / faucet fields are currently left empty as they are TBD and will be added once officially available.


---------
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): N/A

#### Provide a link to your privacy policy: N/A

#### If the RPC has none of the above and you still think it should be added, please explain why: N/A

Your RPC should always be added at the end of the array.