### PR TITLE
add plasma rpc to chainID 9745

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8849,6 +8849,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://plasma.blockpi.network/v1/rpc/create_your_free_key",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
     ],
     websiteDead: false,
     rpcWorking: true,


### PR DESCRIPTION
Hello, we provide free Plasma RPC services, but users need to register and create their own keys. Therefore, the endpoint we intend to add is https://plasma.blockpi.network/v1/rpc/create_your_free_key
website: https://blockpi.io/