### PR TITLE
Add AETRON Mainnet (Chain ID 3355)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3355.js
+++ b/constants/additionalChainRegistry/chainid-3355.js
@@ -1,0 +1,16 @@
+export const data = {
+  name: "AETRON Mainnet",
+  chain: "AETRON",
+  rpc: ["https://entrypoint-mainnet.aetron.ai/"],
+  faucets: [],
+  nativeCurrency: {
+    name: "AETRON",
+    symbol: "AET",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://aetron.io",
+  shortName: "aet",
+  chainId: 3355,
+  networkId: 3355,
+};


### PR DESCRIPTION
Add AETRON Mainnet chain

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://aetron.io

#### Provide a link to your privacy policy:
Privacy policy is in development. This is the official RPC endpoint operated by the AETRON team.

#### If the RPC has none of the above and you still think it should be added, please explain why:

This PR adds the AETRON Mainnet chain. AETRON is an EVM-compatible network built on Substrate with Frontier. The RPC is operated by the core team.