### PR TITLE
Add MON CHAIN (chainId 19901)

### DIFF
--- a/constants/additionalChainRegistry/chainid-19901.js
+++ b/constants/additionalChainRegistry/chainid-19901.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "MON CHAIN",
+  "chain": "MON",
+  "rpc": [
+    "https://rpc.monlite.online"
+  ],
+  "features": [{ "name": "EIP155" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Monetae",
+    "symbol": "MON",
+    "decimals": 18
+  },
+  "infoURL": "https://monlite.online",
+  "shortName": "mon",
+  "chainId": 19901,
+  "networkId": 19901,
+  "explorers": [
+    {
+      "name": "MON CHAIN Explorer",
+      "url": "https://scan.monlite.online"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds MON CHAIN to the chain registry.

**Chain Details:**
- Chain Name: MON CHAIN
- Chain ID: 19901
- Symbol: MON
- RPC: https://rpc.monlite.online
- Explorer: https://scan.monlite.online

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://monlite.online

#### Provide a link to your privacy policy:
[Please provide the privacy policy URL for MON CHAIN/Monlite if available]

#### If the RPC has none of the above and you still think it should be added, please explain why:
[Only fill this out if you don't have a privacy policy - otherwise leave blank]

**Files Changed:**
- Added `constants/additionalChainRegistry/chainid-19901.js` with chain configuration
- Updated `constants/extraRpcs.js` to include the RPC endpoint (added at the end of the array)