### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8823,6 +8823,18 @@ export const extraRpcs = {
       "https://eth.nodebridge.xyz/assetchaintestnet/exec/b903e07d-54ee-4c4d-bffb-8b073e8163fa",
     ],
   },
+    42429: {
+    rpcs: [
+      "https://tempo-testnet.drpc.org",
+      "wss://tempo-testnet.drpc.org",
+    ],
+  },
+      6281971: {
+    rpcs: [
+      "https://dogeos-testnet.drpc.org",
+      "wss://dogeos-testnet.drpc.org",
+    ],
+  },
   43111: {
     rpcs: [
       "https://rpc.hemi.network/rpc",


### PR DESCRIPTION
Added additional RPC endpoints for Tempo (42429) and DogeOS (6281971)

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.