### PR TITLE
Add Dolphinet Mainnet to Chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-1520.js
+++ b/constants/additionalChainRegistry/chainid-1520.js
@@ -1,11 +1,16 @@
-module.exports = {
+export const data = {
   name: "Dolphinet Mainnet",
   chain: "DOL",
+  icon: "dolphinet",
   rpc: [
     "https://rpc.dolphinode.world",
     "wss://wss.dolphinode.world",
     "https://rpc-dev01.dolphinode.world",
     "wss://wss-dev01.dolphinode.world"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
   ],
   faucets: [],
   nativeCurrency: {
@@ -13,10 +18,6 @@ module.exports = {
     symbol: "DOL",
     decimals: 18
   },
-  features: [
-    { name: "EIP155" },
-    { name: "EIP1559" }
-  ],
   infoURL: "https://chain.dolphinode.world/",
   shortName: "dolphinet",
   chainId: 1520,
@@ -24,9 +25,7 @@ module.exports = {
   explorers: [
     {
       name: "blockscout",
-      url: "https://explorer.dolphinode.world/",
-      icon: "blockscout",
-      standard: "EIP3091"
+      url: "https://explorer.dolphinode.world/"
     }
   ]
 };


### PR DESCRIPTION
This PR adds Dolphinet Mainnet and Dolphinet Testnet to Chainlist, both supporting EIP155 and EIP1559 features.

Mainnet:
- ChainID: 1520
- RPC: 
  - https://rpc.dolphinode.world
  - wss://wss.dolphinode.world
  - https://rpc-dev01.dolphinode.world
  - wss://wss-dev01.dolphinode.world
- Explorer: https://explorer.dolphinode.world
- Native Token: DOL (18 decimals)
- Website: https://chain.dolphinode.world

Testnet:
- ChainID: 1519
- RPC: 
  - https://rpc-testnet.dolphinode.world
  - wss://wss-testnet.dolphinode.world
- Explorer: https://explorer-testnet.dolphinode.world
- Native Token: DOL (18 decimals)
- Website: https://explorer-testnet.dolphinode.world

Both chains support:
- EIP155
- EIP1559 (Dynamic transaction fee model)

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.