### PR TITLE
Add Dolphinet Testnet chain data

### DIFF
--- a/constants/additionalChainRegistry/chainid-1519.js
+++ b/constants/additionalChainRegistry/chainid-1519.js
@@ -1,0 +1,29 @@
+export const data = {
+  name: "Dolphinet Testnet",
+  chain: "DOL",
+  icon: "dolphinet-testnet",
+  rpc: [
+    "https://rpc-testnet.dolphinode.world",
+    "wss://wss-testnet.dolphinode.world"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "DOL",
+    symbol: "DOL",
+    decimals: 18
+  },
+  infoURL: "https://explorer-testnet.dolphinode.world/",
+  shortName: "dolphinet-testnet",
+  chainId: 1519,
+  networkId: 1519,
+  explorers: [
+    {
+      name: "blockscout",
+      url: "https://explorer-testnet.dolphinode.world/"
+    }
+  ]
+};


### PR DESCRIPTION
Add Dolphinet Mainnet and Dolphinet Testnet to Chainlist

This PR adds Dolphinet Mainnet and Dolphinet Testnet to Chainlist, both supporting EIP155 and EIP1559 features.

Mainnet:
- ChainID: 1520
- RPC: 
  - https://rpc.dolphinode.world
  - wss://wss.dolphinode.world
  - https://rpc-dev01.dolphinode.world
  - wss://wss-dev01.dolphinode.world
- Explorer: https://explorer.dolphinode.world
- Native Token: DOL (18 decimals)
- Website: https://chain.dolphinode.world

Testnet:
- ChainID: 1519
- RPC: 
  - https://rpc-testnet.dolphinode.world
  - wss://wss-testnet.dolphinode.world
- Explorer: https://explorer-testnet.dolphinode.world
- Native Token: DOL (18 decimals)
- Website: https://explorer-testnet.dolphinode.world

Both chains support:
- EIP155
- EIP1559 (Dynamic transaction fee model)

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.