### PR TITLE
Add Dolphinet RPCs for mainnet and testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9308,6 +9308,23 @@ export const extraRpcs = {
       },
     ],
   },
+   // Dolphinet 主网
+  1520: {
+    rpcs: [
+      { url: "https://rpc.dolphinode.world", tracking: "none" },
+      { url: "wss://wss.dolphinode.world", tracking: "none" },
+      { url: "https://rpc-dev01.dolphinode.world", tracking: "none" },
+      { url: "wss://wss-dev01.dolphinode.world", tracking: "none" },
+    ],
+  },
+
+  // Dolphinet Testnet
+  1519: {
+    rpcs: [
+      { url: "https://rpc-testnet.dolphinode.world", tracking: "none" },
+      { url: "wss://wss-testnet.dolphinode.world", tracking: "none" },
+    ],
+  },
   2523: {
     rpcs: [
       {


### PR DESCRIPTION
Added RPC configurations for Dolphinet mainnet and testnet.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.