### PR TITLE
Add Japan Open Chain Mainnet

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -23,6 +23,7 @@ export default {
   "61": "ethereumclassic",
   "66": "okexchain",
   "70": "hoo",
+  "81": "joc",
   "82": "meter",
   "87": "nova network",
   "88": "tomochain",


### PR DESCRIPTION
As previously [PR](https://github.com/DefiLlama/chainlist/pull/875), we missed the Defilama listed. Now Japan Open Chain is already listed on [DefiLlama](https://defillama.com/chain/joc) 