### PR TITLE
Deprecate CoreDAO Testnet 1115 and Remove Deprecated RPC Endpoints

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4196,25 +4196,9 @@ export const extraRpcs = {
       },
     ],
   },
-  1115: {
-    rpcs: [
-      "https://rpc.test.btcs.network",
-      {
-        url: "https://core-testnet.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
-      },
-      {
-        url: "wss://core-testnet.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
-      },
-    ],
-  },
   1116: {
     rpcs: [
       "https://rpc.coredao.org",
-      "https://core.public.infstones.com",
       "wss://ws.coredao.org",
       {
         url: "https://1rpc.io/core",


### PR DESCRIPTION
This PR deprecates remaining references to **CoreDAO Testnet 1115** and removes mainnet **deprecated RPC endpoints**. Testnet 1115 is no longer recommended for development, and continued support may cause confusion, broken integrations, and inconsistent developer experience.

Reference : https://forum.coredao.org/t/core-testnet1-deprecation-notice-migrate-to-core-testnet2/865
