### PR TITLE
Add TBURN Mainnet (Chain ID 5800) to Chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-5800.js
+++ b/constants/additionalChainRegistry/chainid-5800.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "TBURN Mainnet",
+  "chain": "TBURN",
+  "icon": "tburn",
+  "rpc": [
+    "https://tburn.io/rpc"
+  ],
+  "faucets": [
+    "https://tburn.io/faucet"
+  ],
+  "nativeCurrency": {
+    "name": "TBURN",
+    "symbol": "TBURN",
+    "decimals": 18
+  },
+  "infoURL": "https://tburn.io",
+  "shortName": "tburn",
+  "chainId": 5800,
+  "networkId": 5800,
+  "icon": "tburn",
+  "explorers": [{
+    "name": "TBURNScan",
+    "url": "https://tburn.io/scan",
+    "icon": "tburn",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Add support for TBURN Mainnet
- Chain ID: 5800
- RPC: https://tburn.io/rpc
- Explorer: https://tburn.io/scan
- Native Currency: TBURN

This PR adds the mainnet configuration for TBURN blockchain.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://tburn.io


#### Provide a link to your privacy policy: https://tburn.io/legal/privacy-policy


#### If the RPC has none of the above and you still think it should be added, please explain why: https://tburn.io/rpc is the official TBURN mainnet RPC endpoint

Your RPC should always be added at the end of the array.