### PR TITLE
feat: add fluent devnet (20993)

### DIFF
--- a/constants/additionalChainRegistry/chainid-20993.js
+++ b/constants/additionalChainRegistry/chainid-20993.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Fluent Devnet",
+  chain: "FLUENT",
+  rpc: ["https://rpc.devnet.fluent.xyz"],
+  faucets: ["https://testnet.fluent.xyz/dev-portal"],
+  nativeCurrency: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }, { name: "EIP4844" }],
+  infoURL: "https://www.fluent.xyz/",
+  shortName: "fluent-devnet",
+  chainId: 20993,
+  networkId: 20993,
+  explorers: [
+    {
+      name: "Fluent Devnet Explorer",
+      url: "https://devnet.fluentscan.xyz/",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Fix: Correct Fluent Devnet chain configuration
Fluent Devnet already [exists](https://chainlist.org/chain/20993) in Chainlist but was added through the previous data source with incorrect information. This PR fixes:

RPC URL
Chain name