### PR TITLE
add HyperCluster 838838

### DIFF
--- a/constants/additionalChainRegistry/chainid-838838.js
+++ b/constants/additionalChainRegistry/chainid-838838.js
@@ -12,7 +12,7 @@ export const data = {
     "decimals": 18
   },
   "infoURL": "https://hypercluster.org/",
-  "shortName": "HyperCluster",
+  "shortName": "hypercluster",
   "chainId": 838838,
   "networkId": 838838,
   "explorers": [


### PR DESCRIPTION
Link the service provider's website (the company/protocol/individual providing the RPC):
https://hypercluster.org/

Provide a link to your privacy policy:
https://hypercluster.org/privacy

his is the official RPC endpoint for HyperCluster mainnet (chain ID 838838), a Besu QBFT-based network. This is our first submission to chainlist as a new chain.