### PR TITLE
New RPC link in Bc Hyper Mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8126,6 +8126,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.bctech,
       },
+      {
+        url: "https://datahub-asia02.bchscan.io/",
+        tracking: "none",
+        trackingDetails: privacyStatement.bctech,
+      },
     ],
   },
   42070: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://www.versatizecoin.com/


#### Provide a link to your privacy policy: https://www.versatizecoin.com/#/PrivacyPolicy


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.