### PR TITLE
Update link to RPC and explorer on Ethiq (30303) and Testethiq (853211)

### DIFF
--- a/constants/additionalChainRegistry/chainid-30303.js
+++ b/constants/additionalChainRegistry/chainid-30303.js
@@ -27,7 +27,7 @@ export const data = {
   "explorers": [
     {
       "name": "Ethiq Blockscout",
-      "url": "https://explorer.ethiq.haqq.network",
+      "url": "https://explorer.ethiq.network",
       "icon": "blockscout",
       "standard": "EIP3091"
     }

--- a/constants/additionalChainRegistry/chainid-853211.js
+++ b/constants/additionalChainRegistry/chainid-853211.js
@@ -2,8 +2,8 @@ export const data = {
   "name": "HAQQ Testethiq (L2 Sepolia Testnet)",
   "chain": "ETH",
   "rpc": [
-    "https://rpc.testethiq.haqq.network",
-    "wss://rpc.testethiq.haqq.network"
+    "https://rpc.testnet.ethiq.network",
+    "wss://rpc.testnet.ethiq.network"
   ],
   "faucets": [
   ],
@@ -18,7 +18,7 @@ export const data = {
     { "name": "EIP2930" },
     { "name": "EIP4844" }
   ],
-  "infoURL": "https://www.haqq.network",
+  "infoURL": "https://ethiq.network",
   "shortName": "haqq-testethiq",
   "chainId": 853211,
   "networkId": 853211,
@@ -27,7 +27,7 @@ export const data = {
   "explorers": [
     {
       "name": "HAQQ Testethiq Blockscout",
-      "url": "https://explorer.testethiq.haqq.network",
+      "url": "https://explorer.testnet.ethiq.network",
       "icon": "blockscout",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
We moved RPC and explorer to the main domain of the network.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://ethiq.network

#### Provide a link to your privacy policy:
None

#### If the RPC has none of the above and you still think it should be added, please explain why:
Updated the addresses of the main RPC and explorer networks after migrating to a new domain. No policy changes