### PR TITLE
Add HairyLabs Base RPC and fix privacy policy URL

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -99,7 +99,7 @@ const privacyStatement = {
   quicknode:
     "Information about your computer hardware and software may be automatically collected by QuickNode. This information can include such details as your IP address, browser type, domain names, access times and referring website addresses.https://www.quicknode.com/privacy",
   hairylabs:
-    "No user data is collected or stored. Token-based rate limiting uses temporary session identifiers that are automatically purged after inactivity. https://pulsechain.hairylabs.io",
+    "No user data is collected or stored. Token-based rate limiting uses temporary session identifiers that are automatically purged after inactivity. https://hairylabs.io",
   pulsechainstats:
     "PulseChainStats RPC does not store or track user information. We only temporarily log IP addresses for rate limiting and DDoS protection purposes. Logs are automatically deleted after 7 days. No wallet addresses or transaction data are correlated with IP addresses.",
   chainstack:
@@ -5382,6 +5382,11 @@ export const extraRpcs = {
         url: "wss://base.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://rpcbase.hairylabs.io/rpc",
+        tracking: "none",
+        trackingDetails: privacyStatement.hairylabs,
       },
     ],
   },


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://hairylabs.io

#### Provide a link to your privacy policy:
https://hairylabs.io

#### If the RPC has none of the above and you still think it should be added, please explain why:
Adding HairyLabs Base RPC endpoint (https://rpcbase.hairylabs.io/rpc) for Base chain (8453). Also fixing the privacy policy URL from the old pulsechain.hairylabs.io to hairylabs.io for the existing PulseChain RPC entry.

Your RPC should always be added at the end of the array.
