### PR TITLE
Add QELT blockchain mainnet and testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-770.js
+++ b/constants/additionalChainRegistry/chainid-770.js
@@ -1,0 +1,30 @@
+export const data = {
+  "name": "QELT Mainnet",
+  "chain": "QELT",
+  "rpc": [
+    "https://mainnet.qelt.ai",
+    "https://mainnet2.qelt.ai",
+    "https://mainnet3.qelt.ai",
+    "https://mainnet4.qelt.ai",
+    "https://mainnet5.qelt.ai",
+    "https://archivem.qelt.ai"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QELT",
+    "symbol": "QELT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://qelt.ai",
+  "shortName": "qelt",
+  "chainId": 770,
+  "networkId": 770,
+  "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+  "explorers": [{
+    "name": "QELTScan",
+    "url": "https://qeltscan.ai",
+    "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-771.js
+++ b/constants/additionalChainRegistry/chainid-771.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "QELT Testnet",
+  "chain": "QELT",
+  "rpc": [
+    "https://testnet.qelt.ai",
+    "https://archive.qelt.ai",
+    "wss://ws.qelt.ai"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QELT",
+    "symbol": "QELT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://qelt.ai",
+  "shortName": "qelt-testnet",
+  "chainId": 771,
+  "networkId": 771,
+  "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+  "explorers": [{
+    "name": "QELTScan Testnet",
+    "url": "https://testnet.qeltscan.ai",
+    "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
## Summary

This PR adds QELT blockchain mainnet and testnet configurations to Chainlist.

## Changes

### QELT Mainnet (Chain ID: 770)
- **Name**: QELT Mainnet
- **Native Currency**: QELT (18 decimals)
- **RPC Endpoints**: 6 endpoints including archive node
  - https://mainnet.qelt.ai (Primary validator)
  - https://mainnet2.qelt.ai (Secondary validator)
  - https://mainnet3.qelt.ai (Tertiary validator) 
  - https://mainnet4.qelt.ai (Fourth validator)
  - https://mainnet5.qelt.ai (Fifth validator)
  - https://archivem.qelt.ai (Archive node with full history)
- **Block Explorer**: https://qeltscan.ai
- **Features**: EIP155, EIP1559

### QELT Testnet (Chain ID: 771)
- **Name**: QELT Testnet
- **Native Currency**: QELT (18 decimals)
- **RPC Endpoints**: 3 endpoints including WebSocket
  - https://testnet.qelt.ai (Primary RPC)
  - https://archive.qelt.ai (Archive RPC with TRACE API)
  - wss://ws.qelt.ai (WebSocket for real-time events)
- **Block Explorer**: https://testnet.qeltscan.ai
- **Features**: EIP155, EIP1559

## Files Added

- `constants/additionalChainRegistry/chainid-770.js` - QELT Mainnet configuration
- `constants/additionalChainRegistry/chainid-771.js` - QELT Testnet configuration

Both configurations include proper logos, multiple RPC endpoints for redundancy, and standard blockchain features.