### PR TITLE
add Polygon RPC via Ankr (NodeInfra)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -582,6 +582,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.omnia,
       },
+      {
+  url: "https://rpc.ankr.com/polygon/c4cc6a8c87ec30258076de433ab2cf3d834228aae3fc4d76087873e4fea11635",
+  tracking: "yes",
+  trackingDetails: privacyStatement.ankr,
+},
       "https://polygontestapi.terminet.io/rpc",
       {
         url: "https://polygon-testnet.public.blastapi.io",


### PR DESCRIPTION
Adds an Ankr-backed Polygon RPC endpoint for NodeInfra testing and visibility.

This PR adds an additional Polygon Mainnet RPC endpoint powered by Ankr.

The endpoint is used for testing, benchmarking, and public availability via Chainlist, with no custom logging or modification layer on top.

Link the service provider's website (the company/protocol/individual providing the RPC): https://www.ankr.com/

Provide a link to your privacy policy:
https://www.ankr.com/privacy-policy/

If the RPC has none of the above and you still think it should be added, please explain why: Not applicable – the service provider and privacy policy are provided.

Additional notes:
The RPC endpoint is added at the end of the array, following repository guidelines. The endpoint relies entirely on Ankr infrastructure and policies.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.