### PR TITLE
add Arbitrum RPC via Ankr (NodeInfra)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1669,6 +1669,11 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.nodies,
       },
       {
+  url: "https://rpc.ankr.com/arbitrum/c4cc6a8c87ec30258076de433ab2cf3d834228aae3fc4d76087873e4fea11635",
+  tracking: "yes",
+  trackingDetails: privacyStatement.ankr,
+},
+      {
         url: "https://arb-mainnet.g.alchemy.com/v2/demo",
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,


### PR DESCRIPTION
Adds an Ankr-backed Arbitrum RPC endpoint for NodeInfra testing and visibility.

This PR adds an additional Arbitrum One (Mainnet) RPC endpoint powered by Ankr.

The endpoint is used for testing, benchmarking, and public availability via Chainlist, with no custom logging or modification layer on top.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://www.ankr.com/

#### Provide a link to your privacy policy:
https://www.ankr.com/privacy-policy/

#### If the RPC has none of the above and you still think it should be added, please explain why: Not applicable – the service provider and privacy policy are provided.

Additional notes:
- The RPC endpoint is added at the end of the array, following repository guidelines.
- The endpoint relies entirely on Ankr infrastructure and policies.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.