### PR TITLE
Add BNX Smart Chain (chainId 7777)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7777.js
+++ b/constants/additionalChainRegistry/chainid-7777.js
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   name: "BNX Smart Chain",
   chain: "BNX",
   rpc: [


### PR DESCRIPTION
## BNX Smart Chain

BNX Smart Chain is an EVM-compatible blockchain network.

### Network Details
- Name: BNX Smart Chain
- Chain ID: 7777
- Symbol: BNX
- RPC URL: http://217.76.56.234:8545
- Explorer: http://217.76.56.234:4000
- Website: https://betnetx.xyz

### RPC Provider
The RPC endpoint is operated by the BNX Smart Chain team.

### Privacy Policy
https://betnetx.xyz/privacy

### Reason for inclusion
BNX Smart Chain is designed for Web3 and DeFi applications and should be listed in ChainList to allow users to easily connect via MetaMask and other wallets.
