### PR TITLE
Fix Alpen Testnet II RPC and faucet URLs

### DIFF
--- a/constants/additionalChainRegistry/chainid-8150.js
+++ b/constants/additionalChainRegistry/chainid-8150.js
@@ -2,9 +2,9 @@ export const data = {
   "name": "Alpen Testnet II",
   "chain": "Alpen",
   "rpc": [
-    "https://rpc.pectra-testnet.alpenlabs.io",
+    "https://rpc.testnet.alpenlabs.io",
   ],
-  "faucets": ["https://faucet.pectra-testnet.alpenlabs.io/"],
+  "faucets": ["https://faucet.testnet.alpenlabs.io/"],
   "nativeCurrency": {
     "name": "Signet BTC",
     "symbol": "sBTC",
@@ -18,7 +18,7 @@ export const data = {
     "icon": "https://avatars.githubusercontent.com/u/113091135",
   "explorers": [{
     "name": "Alpen Testnet Explorer",
-    "url": "https://explorer.pectra-testnet.alpenlabs.io",
+    "url": "https://explorer.testnet.alpenlabs.io",
     "icon": "",
     "standard": "EIP3091"
   }]


### PR DESCRIPTION
Fxing the rpc, faucet and explorer links to reflect current status of Alpen endpoints

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
N/A

#### Provide a link to your privacy policy:
N/A

#### If the RPC has none of the above and you still think it should be added, please explain why:
The endpoints at https://*.pectra-testnet.alpenlabs.io have been disabled and don't work anymore; the canonical ones are https://*.testnet.alpenlabs.io

Adding this change to Chainlist to avoid technical issues to wallets using this repo as reference.

Your RPC should always be added at the end of the array.