### PR TITLE
Fix QELT mainnet and testnet: Add chainIds mapping and update icon format

### DIFF
--- a/constants/additionalChainRegistry/chainid-770.js
+++ b/constants/additionalChainRegistry/chainid-770.js
@@ -20,11 +20,11 @@ export const data = {
   "shortName": "qelt",
   "chainId": 770,
   "networkId": 770,
-  "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+  "icon": "qelt",
   "explorers": [{
     "name": "QELTScan",
     "url": "https://qeltscan.ai",
-    "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+    "icon": "qelt",
     "standard": "EIP3091"
   }]
 }

--- a/constants/additionalChainRegistry/chainid-771.js
+++ b/constants/additionalChainRegistry/chainid-771.js
@@ -17,11 +17,11 @@ export const data = {
   "shortName": "qelt-testnet",
   "chainId": 771,
   "networkId": 771,
-  "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+  "icon": "qelt",
   "explorers": [{
     "name": "QELTScan Testnet",
     "url": "https://testnet.qeltscan.ai",
-    "icon": "https://i.postimg.cc/DzvDjBrT/Q-mark-Blue.png",
+    "icon": "qelt",
     "standard": "EIP3091"
   }]
 }

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -259,6 +259,8 @@ export default {
   "167000": "taiko",
   "190415": "hpp",
   "200901": "bitlayer",
+  "770": "qelt",
+  "771": "qelt-testnet",
   "222222": "hydradx",
   "256256": "cmp",
   "258432": "standx",


### PR DESCRIPTION
## Description

This PR fixes the issues preventing QELT mainnet (chain 770) and testnet (chain 771) from displaying correctly on chainlist.org.

## Issues Fixed

1. **RPC servers showing as dead** - Added missing chainIds.js entries that map chain IDs to their slugs
2. **Logo not displaying** - Changed icon format from full URLs to slug format ("qelt") for proper integration with the chainlist icon system

## Changes Made

- Added `"770": "qelt"` and `"771": "qelt-testnet"` to constants/chainIds.js
- Updated icon field in chainid-770.js from URL to slug format
- Updated icon field in chainid-771.js from URL to slug format

## Testing

- ✅ Verified RPC endpoints are responding correctly
- ✅ Confirmed block height retrieval works (testnet at block 0x6498b)
- ✅ All RPC endpoints tested:
  - https://mainnet.qelt.ai
  - https://testnet.qelt.ai
  - https://archive.qelt.ai
  - wss://ws.qelt.ai

## Additional Notes

- QELT is a Hyperledger Besu QBFT PoA blockchain
- All chains support EIP155 and EIP1559
- This is a follow-up to the initial QELT addition PR which was missing these critical configuration mappings