### PR TITLE
Add XYBERCHAIN Testnet (chainId 9194)

### DIFF
--- a/constants/additionalChainRegistry/chainid-9194.js
+++ b/constants/additionalChainRegistry/chainid-9194.js
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   "name": "Xyberchain Testnet",
   "chain": "XYB",
   "rpc": [


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.xyberchain.network/

#### Provide a link to your privacy policy:
https://www.xyberchain.network/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
The RPC is fully managed by the XYBERCHAIN team and provides secure, reliable access to the XYBERCHAIN Testnet (chainId 9194).  
It is publicly accessible for developers and users to interact with the testnet, supporting contract deployment, token testing, and transaction queries.  
All requests follow our privacy policy: https://www.xyberchain.network/privacy
(rpc https://xyberchain-rpc.xyz/)
Your RPC should always be added at the end of the array.