### PR TITLE
Fix: Add chainSlug for chains not in TVL API (fixes QELT and other chains)

### DIFF
--- a/utils/fetch.js
+++ b/utils/fetch.js
@@ -52,7 +52,7 @@ export function populateChain(chain, chainTvls) {
     const defiChain = chainTvls.find((c) => c.name.toLowerCase() === chainSlug);
 
     return defiChain === undefined
-      ? chain
+      ? { ...chain, chainSlug }
       : {
           ...chain,
           tvl: defiChain.tvl,


### PR DESCRIPTION
## Problem

Chains that exist in `chainIds.js` but are NOT in DefiLlama's TVL API (like QELT chains 770/771) do not get the `chainSlug` field added to their JSON. This causes:

1. **❌ Icons don't display** - Icon URL construction requires `chainSlug`:
   ```javascript
   const icon = chain.chainSlug ? 
     `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : 
     "/unknown-logo.png";
   ```

2. **❌ RPC health checks may fail** - Chain objects are incomplete/malformed

## Root Cause

In `utils/fetch.js`, the `populateChain()` function only adds `chainSlug` when the chain is found in the TVL API:

```javascript
if (chainSlug !== undefined) {
  const defiChain = chainTvls.find((c) => c.name.toLowerCase() === chainSlug);
  
  return defiChain === undefined
    ? chain  // ← BUG: Returns WITHOUT chainSlug!
    : {
        ...chain,
        tvl: defiChain.tvl,
        chainSlug,  // ← Only added if in TVL API
      };
}
```

## Solution

Add `chainSlug` even when chain is not in TVL API:

```javascript
return defiChain === undefined
  ? { ...chain, chainSlug }  // ← FIX: Always add chainSlug
  : {
      ...chain,
      tvl: defiChain.tvl,
      chainSlug,
    };
```

## Verification

**Before (QELT - BROKEN):**
```json
{
  "chainId": 770,
  "name": "QELT Mainnet",
  "icon": "qelt",
  "rpc": [...]  // ← Missing chainSlug
}
```

**After (QELT - FIXED):**
```json
{
  "chainId": 770,
  "name": "QELT Mainnet",
  "icon": "qelt",
  "chainSlug": "qelt",  // ← Now present!
  "rpc": [...]
}
```

**Palm (WORKING - for comparison):**
```json
{
  "chainId": 11297108109,
  "name": "Palm",
  "icon": "palm",
  "chainSlug": "palm",  // ← Has chainSlug
  "rpc": [...]
}
```

## Impact

This fix ensures ALL chains in `chainIds.js` get proper `chainSlug` field, regardless of TVL API status. This will fix:
- ✅ QELT Mainnet (770) 
- ✅ QELT Testnet (771)
- ✅ Any other chains with chainIds mapping but no TVL data

## Testing

- Verified QELT RPCs respond correctly to `eth_getBlockByNumber`
- Verified CORS headers are properly configured
- Verified SSL certificates are valid
- Issue is purely frontend - missing `chainSlug` field breaks icon display logic