### PR TITLE
Add Fanatico L1 blockchain (Chain ID: 11111111111)

### DIFF
--- a/constants/additionalChainRegistry/chainid-11111111111.js
+++ b/constants/additionalChainRegistry/chainid-11111111111.js
@@ -1,0 +1,29 @@
+export const data = {
+    "name": "Fanatico",
+    "chain": "FCO",
+    "icon": "https://d37ow1hrtyzl5c.cloudfront.net/icons/fanatico_logo.svg",
+    "rpc": [
+      "https://rpc.fanati.co"
+    ],
+    "features": [
+      { "name": "EIP155" },
+      { "name": "EIP1559" }
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Fanatico",
+      "symbol": "FCO",
+      "decimals": 18
+    },
+    "infoURL": "https://chain.fanati.co",
+    "shortName": "fco",
+    "chainId": 11111111111,
+    "networkId": 11111111111,
+    "explorers": [
+      {
+        "name": "Fanatico Explorer",
+        "url": "https://explorer.fanati.co",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
## Summary

Adding Fanatico, an EVM-compatible Layer 1 blockchain.

## Chain Details

| Property | Value |
|----------|-------|
| Name | Fanatico |
| Chain ID | 11111111111 |
| Symbol | FCO |
| Decimals | 18 |
| RPC URL | https://rpc.fanati.co |
| Block Explorer | https://explorer.fanati.co |
| Chain Info | https://chain.fanati.co |

## Features

- EIP-155 (Replay attack protection)
- EIP-1559 (Dynamic fee transactions)
- Full EVM compatibility
- ~2 second block time

## Verification

- RPC endpoint is publicly accessible via HTTPS
- Block explorer is live and indexing blocks
- Chain info website provides connection details