### PR TITLE
Add LuxePorts Network (LXP) RPC endpoints - Chain ID 1122

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9326,7 +9326,31 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.Cosmostation
       }
     ]
-  }
+  },
+  1122: {
+    rpcs: [
+      {
+        url: "https://rpc.luxeports.com",
+        tracking: "none",
+        trackingDetails: "LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.",
+      },
+      {
+        url: "https://erpc.luxeports.com",
+        tracking: "none",
+        trackingDetails: "LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.",
+      },
+      {
+        url: "wss://rpc.luxeports.com/ws",
+        tracking: "none",
+        trackingDetails: "LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.",
+      },
+      {
+        url: "wss://erpc.luxeports.com/ws",
+        tracking: "none",
+        trackingDetails: "LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.",
+      },
+    ],
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
## Summary
Adding RPC endpoints for **LuxePorts Network (LXP)** - Chain ID 1122

## Network Details
| Parameter | Value |
|-----------|-------|
| Chain ID | 1122 |
| Network Name | LuxePorts Network |
| Symbol | LXP |
| Block Explorer | https://explorer.luxeports.com |

## RPC Endpoints Added
- `https://rpc.luxeports.com` (HTTP)
- `https://erpc.luxeports.com` (HTTP)
- `wss://rpc.luxeports.com/ws` (WebSocket)
- `wss://erpc.luxeports.com/ws` (WebSocket)

## Privacy
LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.

## About LuxePorts
LuxePorts is an enterprise-grade EVM-compatible blockchain built on XDPoS (Delegated Proof of Stake) consensus mechanism, offering:
- ~2 second block times
- Low gas fees
- Enterprise-grade security
- Smart contract support

## Verification
- [x] Chain is already registered in ethereum-lists/chains
- [x] RPC endpoints are live and working
- [x] Privacy policy included