### PR TITLE
feat: add MSC chain 5577 to additionalChainRegistry

### DIFF
--- a/constants/additionalChainRegistry/chainid-5577.js
+++ b/constants/additionalChainRegistry/chainid-5577.js
@@ -1,0 +1,19 @@
+﻿export const chain5577 = {
+  "name": "MSC Blockchain",
+  "chain": "MSC",
+  "rpc": [
+    "https://rpc.taaqo.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MSC Token",
+    "symbol": "MSC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://taaqo.com",
+  "shortName": "msc",
+  "chainId": 5577,
+  "networkId": 5577,
+  "explorers": []
+}


### PR DESCRIPTION
Official Response for MSC Blockchain (ID 5577)
Link the service provider's website: https://taaqo.com

Provide a link to your privacy policy: https://taaqo.com/privacy (Note: If this link doesn't work yet, use: "We are currently finalizing our formal privacy policy page, but we confirm that this RPC does not log user IP addresses.")

If the RPC has none of the above, please explain why: "This is the official primary RPC for the MSC Blockchain. It is a new Layer 2 network (Chain ID 5577), and this endpoint is the essential gateway for users to connect their wallets and interact with the ecosystem."