### PR TITLE
Update CX Chain RPC URLs in extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9056,12 +9056,12 @@ export const extraRpcs = {
   737373: {
     rpcs: [
       {
-        url: "https://katana-testnet.drpc.org",
+        url: "https://subnets.avax.network/cx/mainnet/rpc",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
       {
-        url: "wss://katana-testnet.drpc.org",
+        url: "wss://mainnet-cx-yfa61.avax.network/ext/bc/25xjR3fvh7aXkxs36n1xRc3wLUAuqnS1wBxJD1BC4z3y6mHsEV/ws?token=f538541aa85c54fd5e1bae54881851f39c538dbd1ae9f4ef23b280ec5b87b51f",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },


### PR DESCRIPTION


#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://www.cxchain.xyz/

#### Provide a link to your privacy policy:

https://cx-chain-docs.vercel.app/

#### If the RPC has none of the above and you still think it should be added, please explain why:

Our CX Chain network with chainid 737373 had uncorrected rpcs, because the data of another network was specified in this file

Your RPC should always be added at the end of the array.