### PR TITLE
Add INRI CHAIN (chainId 3777)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3777.js
+++ b/constants/additionalChainRegistry/chainid-3777.js
@@ -1,0 +1,22 @@
+export default {
+  name: "INRI CHAIN",
+  chain: "INRI",
+  rpc: ["https://rpc.inri.life"],
+  faucets: [],
+  nativeCurrency: {
+    name: "INRI",
+    symbol: "INRI",
+    decimals: 18,
+  },
+  infoURL: "https://inri.life",
+  shortName: "inri",
+  chainId: 3777,
+  networkId: 3777,
+  explorers: [
+    {
+      name: "INRI Explorer",
+      url: "https://explorer.inri.life",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds INRI CHAIN mainnet.

- ChainId: 3777
- RPC: https://rpc.inri.life
- Explorer: https://explorer.inri.life
