### PR TITLE
add dRPC RPC endpoints for MegaETH mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4813,6 +4813,16 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.GlobalStake,
       },
+      {
+        url: "https://megaeth.drpc.org",
+        tracking: "none",
+        trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "wss://megaeth.drpc.org",
+        tracking: "none",
+        trackingDetails: privacyStatement.drpc,
+      },
     ],
   },
   2612: {


### PR DESCRIPTION
Adds HTTPS and WSS dRPC RPC endpoints for MegaETH Mainnet (chainId 4326).

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.