### PR TITLE
feat: Add Dilithium3 Testnet (Chain ID 30939) RPC with privacy statement

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -229,6 +229,8 @@ const privacyStatement = {
     "We do not collect or store any PII, including IP addresses or wallet information. Temporary logs for rate limiting are purged within 24 hours. https://www.cosmostation.io/service_en?target=privacy",
   GlobalStake:
     "GlobalStake, LLC and its affiliates are committed to protecting your privacy in accordance with applicable data protection laws. We may share information with affiliates, service providers, and partners as needed to deliver services and comply with legal requirements. By using our services, you agree to the terms of our privacy practices. Full policy: https://globalstake.io/privacy-policy/",
+  dilithium3:
+    "Dilithium3 RPC does not store or track any user data including IP addresses, wallet addresses, or transaction metadata. All data needed to process requests is ephemeral and not logged. Our quantum-resistant blockchain uses NIST FIPS 203/204/205 compliant post-quantum cryptography. No analytics, tracking cookies, or third-party services are used. https://dilithium3.com/privacy",
 };
 
 
@@ -9531,6 +9533,20 @@ export const extraRpcs = {
         url: "wss://erpc.luxeports.com/ws",
         tracking: "none",
         trackingDetails: "LuxePorts does not collect or store any user information (IP addresses, locations, etc.) through the RPC. All data transmitted is solely for blockchain transactions.",
+      },
+    ],
+  },
+  30939: {
+    rpcs: [
+      {
+        url: "https://rpc-testnet.dilithium3.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.dilithium3,
+      },
+      {
+        url: "wss://ws-testnet.dilithium3.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.dilithium3,
       },
     ],
   },


### PR DESCRIPTION
## Description
Adds Dilithium3 Testnet (Chain ID 30939) RPC endpoints with privacy tracking statement to `extraRpcs.js`.

## Chain Details
- **Name**: Dilithium3 Testnet
- **Chain ID**: 30939
- **Symbol**: DLT
- **RPC**: https://rpc-testnet.dilithium3.com
- **WSS**: wss://ws-testnet.dilithium3.com
- **Explorer**: https://explorer-testnet.dilithium3.com

## Privacy Policy
Dilithium3 RPC does not store or track any user data. All request processing is ephemeral with no logging of IP addresses, wallet addresses, or transaction metadata. Our infrastructure uses NIST FIPS 203/204/205 compliant post-quantum cryptography (ML-DSA-65 / Dilithium3).

**Tracking**: `none`

## Reference
- Chain already merged in [ethereum-lists/chains#7912](https://github.com/ethereum-lists/chains/pull/7912)
- Privacy policy: https://dilithium3.com/privacy