### PR TITLE
Update HPP Mainnet/Sepolia icon and add HPP Sepolia to chainIds

### DIFF
--- a/constants/additionalChainRegistry/chainid-181228.js
+++ b/constants/additionalChainRegistry/chainid-181228.js
@@ -15,7 +15,7 @@ export const data = {
   "shortName": "hpp-sepolia",
   "chainId": 181228,
   "networkId": 181228,
-  "icon": "ethereum",
+  "icon": "https://ipfs.io/ipfs/QmX5MTCNX4wKb7B9pK6UH7oHGcWj5m8XywhzXqLA7gtVAJ",
   "explorers": [{
     "name": "HPP Sepolia Explorer",
     "url": "https://sepolia-explorer.hpp.io",

--- a/constants/additionalChainRegistry/chainid-190415.js
+++ b/constants/additionalChainRegistry/chainid-190415.js
@@ -15,7 +15,7 @@ export const data = {
   "shortName": "hpp-mainnet",
   "chainId": 190415,
   "networkId": 190415,
-  "icon": "ethereum",
+  "icon": "https://ipfs.io/ipfs/QmX5MTCNX4wKb7B9pK6UH7oHGcWj5m8XywhzXqLA7gtVAJ",
   "explorers": [{
     "name": "HPP Mainnet Explorer",
     "url": "https://explorer.hpp.io",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -259,6 +259,7 @@ export default {
   "111188": "real",
   "153153": "odyssey",
   "167000": "taiko",
+  "181228": "hpp",
   "190415": "hpp",
   "200901": "bitlayer",
   "222222": "hydradx",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -259,7 +259,6 @@ export default {
   "111188": "real",
   "153153": "odyssey",
   "167000": "taiko",
-  "181228": "hpp-testnet",
   "190415": "hpp",
   "200901": "bitlayer",
   "222222": "hydradx",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -259,7 +259,7 @@ export default {
   "111188": "real",
   "153153": "odyssey",
   "167000": "taiko",
-  "181228": "hpp",
+  "181228": "hpp-testnet",
   "190415": "hpp",
   "200901": "bitlayer",
   "222222": "hydradx",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.hpp.io

Provide a link to your privacy policy:
No policy exists.

If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.


## Summary
- Update icon for HPP Mainnet (190415) and HPP Sepolia (181228) from `ethereum` to HPP's own icon via IPFS
- Add HPP Sepolia (181228) to `chainIds.js` as `hpp-testnet`

## Changes
- `constants/additionalChainRegistry/chainid-190415.js` — icon → IPFS URL
- `constants/additionalChainRegistry/chainid-181228.js` — icon → IPFS URL
- `constants/chainIds.js` — added `"181228": "hpp-testnet"`