### PR TITLE
Fix HairyLabs PulseChain RPC URL

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4124,7 +4124,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.pulsechainstats,
       },
       {
-        url: "https://rpc.hairylabs.io/rpc",
+        url: "https://rpc.hairylabs.io",
         tracking: "none",
         trackingDetails: privacyStatement.hairylabs,
       },


### PR DESCRIPTION
## Summary
Corrected the RPC endpoint URL for HairyLabs PulseChain node from `https://rpc.hairylabs.io/rpc` to `https://rpc.hairylabs.io` (removed incorrect `/rpc` suffix).

## Changes
- Updated PulseChain (Chain ID 369) RPC endpoint URL in `constants/extraRpcs.js`

## Verification
The endpoint is operational and serving PulseChain mainnet:
- Chain ID: 369 (0x171)
- Endpoint: https://rpc.hairylabs.io
- Health check: https://rpc.hairylabs.io/health
- Current block: 25,772,017+ (fully synced)

## Test Results
```bash
# Chain ID verification
curl -X POST https://rpc.hairylabs.io \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# Response: {"jsonrpc":"2.0","id":1,"result":"0x171"}

# Sync status
curl -X POST https://rpc.hairylabs.io \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'
# Response: {"jsonrpc":"2.0","id":1,"result":false}
```

## Additional Information
- Privacy policy already defined in `privacyStatement.hairylabs`
- Tracking: none
- No user data collected or stored
- Token-based rate limiting with automatic session purging