### PR TITLE
Added onfinality plasma endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9068,6 +9068,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://plasma.api.onfinality.io/public",
+        tracking: "limited",
+        trackingDetails: privacyStatement.onfinality,
+      },
     ],
     websiteDead: false,
     rpcWorking: true,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):
https://plasma.api.onfinality.io/public

Provide a link to your privacy policy:
https://onfinality.io/en/privacy

If the RPC has none of the above and you still think it should be added, please explain why:
Your RPC should always be added at the end of the array.