### PR TITLE
feat: added stakely story json rpc, removed evmos and somnia json rpc

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5061,11 +5061,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
       "https://eth.bd.evmos.org:8545/",
-      {
-        url: "https://evmos-json-rpc.stakely.io",
-        tracking: "none",
-        trackingDetails: privacyStatement.Stakely,
-      },
       "https://jsonrpc-evmos-ia.cosmosia.notional.ventures",
       "https://json-rpc.evmos.blockhunters.org",
       "https://evmos-json-rpc.agoranodes.com",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

-Main website: https://stakely.io/

Story JSON-RPC load balancer: https://stakely.io/web3-api-load-balancer/story?type=json-rpc

Also removed stakely rpc for Somnia (chainId: 5031) and Evmos (chainId: 9001)
#### Provide a link to your privacy policy:

https://stakely.io/policies/privacy-policy#rpc-load-balancer

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.