### PR TITLE
feat: add Infinite Improbability Drive mainnet and testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-421018.js
+++ b/constants/additionalChainRegistry/chainid-421018.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Infinite Improbability Drive",
+  "chain": "INFINITE",
+  "rpc": [
+    "https://evm-rpc.infinitedrive.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Improbability",
+    "symbol": "42",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://infinitedrive.xyz",
+  "shortName": "infinite",
+  "chainId": 421018,
+  "networkId": 421018,
+  "icon": "infinite",
+  "explorers": [{
+    "name": "Infinite Drive Explorer",
+    "url": "https://scan.infinitedrive.xyz",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-421018001.js
+++ b/constants/additionalChainRegistry/chainid-421018001.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Infinite Improbability Drive Testnet",
+  "chain": "INFINITE",
+  "rpc": [
+    "https://evm-rpc-testnet.infinitedrive.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TestImprobability",
+    "symbol": "TEST42",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://infinitedrive.xyz",
+  "shortName": "infinite-testnet",
+  "chainId": 421018001,
+  "networkId": 421018001,
+  "icon": "infinite",
+  "explorers": [{
+    "name": "Infinite Drive Explorer - Testnet",
+    "url": "https://testnet-scan.infinitedrive.xyz",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
This PR adds Infinite Improbability Drive mainnet (chainId 421018) and testnet (chainId 421018001) to the additional chain registry, including RPC endpoints, block explorer URLs, and native currency metadata.

A separate PR will be opened in the icons repository to add the chain icon under the name infinite.

- Add chainid-421018.js (mainnet)
- Add chainid-421018001.js (testnet)


--- Information required by the Chainlist team ---

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://infinitedrive.xyz

#### Provide a link to your privacy policy:
https://infinitedrive.xyz/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
n/a

Your RPC should always be added at the end of the array.