### PR TITLE
Add BitBadges Mainnet (50024) and Testnet (50025)

### DIFF
--- a/constants/additionalChainRegistry/chainid-50024.js
+++ b/constants/additionalChainRegistry/chainid-50024.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "BitBadges",
+  "chain": "BitBadges",
+  "rpc": [
+    "https://evm-rpc.bitbadges.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BitBadges",
+    "symbol": "BADGE",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://bitbadges.io",
+  "shortName": "bitbadges",
+  "chainId": 50024,
+  "networkId": 50024,
+  "explorers": [
+    {
+      "name": "BitBadges Explorer",
+      "url": "https://evm.explorer.bitbadges.io",
+      "standard": "EIP3091"
+    }
+  ]
+}
+

--- a/constants/additionalChainRegistry/chainid-50025.js
+++ b/constants/additionalChainRegistry/chainid-50025.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "BitBadges Testnet",
+  "chain": "BitBadges",
+  "rpc": [
+    "https://evm-rpc-testnet.bitbadges.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BitBadges",
+    "symbol": "BADGE",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://bitbadges.io",
+  "shortName": "bitbadges-testnet",
+  "chainId": 50025,
+  "networkId": 50025,
+  "explorers": [
+    {
+      "name": "BitBadges Testnet Explorer",
+      "url": "https://evm-testnet.explorer.bitbadges.io",
+      "standard": "EIP3091"
+    }
+  ]
+}
+


### PR DESCRIPTION
This PR adds BitBadges chain support for both mainnet and testnet.

## Chain Details
- **Mainnet Chain ID**: 50024
- **Testnet Chain ID**: 50025
- EVM-compatible chain built on Cosmos SDK

## Files Added
- constants/additionalChainRegistry/chainid-50024.js (mainnet)
- constants/additionalChainRegistry/chainid-50025.js (testnet)

## Links
- Documentation: https://docs.bitbadges.io
- EVM Explorer: https://evm.explorer.bitbadges.io
- Website: https://bitbadges.io

## Features
- EIP-155 support (replay protection)
- EIP-3091 compliant explorer (Blockscout)
- Self-hosted RPC endpoints