### PR TITLE
Add Mars Credit (110110) RPC endpoint

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9602,6 +9602,16 @@ export const extraRpcs = {
       },
     ],
   },
+  110110: {
+    rpcs: [
+      {
+        url: "https://rpc.marscredit.xyz",
+        tracking: "none",
+        trackingDetails:
+          "Mars Credit does not collect or store any user information (IP addresses, locations, etc.) transmitted via our RPC.",
+      },
+    ],
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
## Summary

Adds the public RPC endpoint for **Mars Credit** (chain ID `110110`) to `extraRpcs.js`.

- **Chain ID:** 110110
- **RPC:** `https://rpc.marscredit.xyz`
- **Tracking:** none

Mars Credit is a proof-of-work EVM chain. The chain is already registered in [ethereum-lists/chains](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-110110.json) (update PR pending at ethereum-lists/chains#8103).

### Verification

```bash
curl -X POST -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  https://rpc.marscredit.xyz
```

Returns: `{"jsonrpc":"2.0","id":1,"result":"0x1adfe"}` (110110 in hex)