### PR TITLE
Add PropTech Mainnet (Chain ID: 88788)

### DIFF
--- a/constants/additionalChainRegistry/chainid-88788.js
+++ b/constants/additionalChainRegistry/chainid-88788.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "PropTech Mainnet",
+  chain: "PTEK",
+  rpc: ["https://mainnet.ptekcoin.com"],
+  faucets: [],
+  nativeCurrency: {
+    name: "PropTech Token",
+    symbol: "PTEK",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://ptekcoin.com",
+  shortName: "ptek",
+  chainId: 88788,
+  networkId: 88788,
+  icon: "ptek",
+  explorers: [
+    {
+      name: "PropTech Blockchain Explorer",
+      url: "https://explorer.ptekcoin.com",
+      icon: "ptek",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
# Add PropTech Mainnet (Chain ID: 88788)

## Chain Details
- **Chain Name:** PropTech Mainnet
- **Chain ID:** 88788
- **Native Currency:** PTEK (PropTech Token)
- **RPC Endpoint:** https://mainnet.ptekcoin.com
- **Explorer:** https://explorer.ptekcoin.com
- **Website:** https://ptek.ai
- **Privacy Policy:** https://ptek.ai/wp-content/uploads/2026/01/PropTechSmart_PrivacyPolicy_2026.pdf

## RPC Information
- **Provider:** PropTech Smart
- **Privacy:** Full privacy policy available at the link above
- **Tracking:** No user data (IP, location, personal info) is logged or stored from RPC requests
- **Network Status:** Live with 5.65M+ blocks, 20k+ wallet addresses, 2.9M+ transactions

## Files Added
- `constants/additionalChainRegistry/chainid-88788.js`

## Verification
- [x] Chain ID is unique (88788)
- [x] RPC endpoint is publicly accessible
- [x] Explorer is working (https://explorer.ptekcoin.com)
- [x] Native currency details are correct (PTEK, 18 decimals)
- [x] Features include EIP155 and EIP1559 (confirmed in genesis.json)
- [x] Website is live (https://ptek.ai)
- [x] Privacy policy is provided

## Additional Context
PropTech Mainnet is an EVM-compatible blockchain with all major forks enabled from genesis (London, Berlin, Istanbul, etc.). The network is actively mined and growing.