### PR TITLE
Add Igra Mainnet (chainId 38833) to additionalChainRegistry 

### DIFF
--- a/constants/additionalChainRegistry/chainid-38833.js
+++ b/constants/additionalChainRegistry/chainid-38833.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "Igra Mainnet",
+  chain: "Igra",
+  rpc: ["https://rpc.igralabs.com:8545"],
+  faucets: [],
+  nativeCurrency: {
+    name: "IKas",
+    symbol: "IKAS",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://igralabs.com",
+  shortName: "igra",
+  chainId: 38833,
+  networkId: 38833,
+  icon: "https://ipfs.io/ipfs/bafkreigamdso3uh3pabmjoci7yyomvrhg2ynocp6fbagbaufsu7wzkaahy",
+  explorers: [
+    {
+      name: "Igra Explorer",
+      url: "https://explorer.igralabs.com",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds constants/additionalChainRegistry/chainid-38833.js
                                                                                                                                                    
  Chain details:                                                                                                                                    
  - Name: Igra Mainnet
  - Chain ID: 38833
  - Native currency: IKas (IKAS, 18 decimals)
  - RPC: https://rpc.igralabs.com:8545
  - Explorer: https://explorer.igralabs.com (EIP-3091)
  - Features: EIP-155, EIP-1559

  Service provider:
  - Website: https://igralabs.com
  - Privacy policy: https://igralabs.com/privacy