### PR TITLE
feat(chains): agregar FST Smart Chain chainId 2034

### DIFF
--- a/_data/chains/eip155-2034.json
+++ b/_data/chains/eip155-2034.json
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "FST Smart Chain",
   "chain": "FST",
   "network": "mainnet",


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://fenixst.io

#### Provide a link to your privacy policy:

https://fenixst.io/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

FST Smart Chain is an EVM-compatible blockchain with chainId 2034 and this is the official public RPC endpoint operated by the core team. It is required so that wallets and dapps can easily connect to the network via Chainlist using the canonical RPC and explorer (https://fstscan.fenixst.io).