### PR TITLE
Add Orbinum Mainnet (Chain ID 270) and Orbinum Testnet (Chain ID 2700)

### DIFF
--- a/constants/additionalChainRegistry/chainid-270.js
+++ b/constants/additionalChainRegistry/chainid-270.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "Orbinum",
+    "chain": "ORB",
+    "icon": "https://orbinum.network/isotipo-black.svg",
+    "rpc": [
+      "https://rpc.orbinum.io"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "ORB",
+      "symbol": "ORB",
+      "decimals": 18
+    },
+    "infoURL": "https://www.orbinum.network",
+    "shortName": "orbinum",
+    "chainId": 270,
+    "networkId": 270,
+    "explorers": [
+      {
+        "name": "Orbinum Privacy Explorer",
+        "url": "https://explorer.orbinum.network/",
+        "icon": "https://orbinum.network/isotipo-black.svg",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/additionalChainRegistry/chainid-2700.js
+++ b/constants/additionalChainRegistry/chainid-2700.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "Orbinum Testnet",
+    "chain": "ORB",
+    "icon": "https://orbinum.network/isotipo-black.svg",
+    "rpc": [
+      "https://testnet-rpc.orbinum.io"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "ORB",
+      "symbol": "ORB",
+      "decimals": 18
+    },
+    "infoURL": "https://www.orbinum.network",
+    "shortName": "orbinum",
+    "chainId": 2700,
+    "networkId": 2700,
+    "explorers": [
+      {
+        "name": "Orbinum Privacy Explorer",
+        "url": "https://testnet-explorer.orbinum.network/",
+        "icon": "https://orbinum.network/isotipo-black.svg",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
## Description

This PR adds two new EVM-compatible networks to the additional chain registry:

### Orbinum Mainnet (Chain ID: 270)
- **Name:** Orbinum
- **Chain:** ORB
- **Native Currency:** ORB (18 decimals)
- **RPC:** https://rpc.orbinum.io
- **Explorer:** https://explorer.orbinum.network/ (EIP-3091 compliant)
- **Info URL:** https://www.orbinum.network

### Orbinum Testnet (Chain ID: 2700)
- **Name:** Orbinum Testnet
- **Chain:** ORB
- **Native Currency:** ORB (18 decimals)
- **RPC:** https://testnet-rpc.orbinum.io
- **Explorer:** https://testnet-explorer.orbinum.network/ (EIP-3091 compliant)
- **Info URL:** https://www.orbinum.network