### PR TITLE
Fix shortName for Panchain Mainnet (chainId: 7890)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7890.js
+++ b/constants/additionalChainRegistry/chainid-7890.js
@@ -12,7 +12,7 @@ export const data = {
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://panchain.io",
-  "shortName": "pcn",
+  "shortName": "pc",
   "chainId": 7890,
   "networkId": 7890,
   "explorers": [{


### PR DESCRIPTION
Fixed shortName from "pcn" to "pc" to correctly 
match the native currency symbol for Panchain Mainnet.