### PR TITLE
Create chainid-511.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-511.js
+++ b/constants/additionalChainRegistry/chainid-511.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "FyroChain Mainnet",
   "chain": "FYRO",
   "rpc": [


### PR DESCRIPTION
Add FyroChain Mainnet (Chain ID: 511)

New EVM-compatible Layer 1 blockchain.

- Chain ID: 511
- RPC: https://rpc.fyrochain.org
- Explorer: https://fyrochain.org
- Symbol: FYRO
- Max Supply: 21,000,000 FYRO