### PR TITLE
Add NeutronX Mainnet (Chain ID 2070)

### DIFF
--- a/constants/additionalChainRegistry/chainid-2070.js
+++ b/constants/additionalChainRegistry/chainid-2070.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "NeutronX Mainnet",
+  "chain": "NTX",
+  "icon": "neutronx",
+  "rpc": ["https://rpc.neutronchain.io"],
+  "features": [{ "name": "EIP155" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NeutronX",
+    "symbol": "NTX",
+    "decimals": 18
+  },
+  "infoURL": "https://neutronx.com",
+  "shortName": "ntx",
+  "chainId": 2070,
+  "networkId": 2070,
+  "explorers": [
+    {
+      "name": "NeutronX Explorer",
+      "url": "https://explorer.neutronchain.io"
+    }
+  ]
+}


### PR DESCRIPTION
## New Chain: NeutronX Mainnet

| Field | Value |
|-------|-------|
| **Chain ID** | 2070 |
| **Name** | NeutronX Mainnet |
| **Symbol** | NTX |
| **RPC** | https://rpc.neutronchain.io |
| **Explorer** | https://explorer.neutronchain.io |
| **Website** | https://neutronx.com |
| **Consensus** | Clique PoA, 2s blocks |

Chain is live and producing blocks. Explorer (Blockscout) is operational.