### PR TITLE
Add EGoldChain Mainnet (Chain ID: 1932)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1932.js
+++ b/constants/additionalChainRegistry/chainid-1932.js
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   "name": "EGoldChain Mainnet",
   "chain": "EGold",
   "rpc": [


### PR DESCRIPTION
## Add EGoldChain Mainnet

Adding EGoldChain Mainnet to chainlist.

### Chain Details:
- **Chain ID:** 1932
- **Network ID:** 1932
- **Chain Name:** EGoldChain Mainnet
- **Short Name:** egold
- **Native Currency:** EGold (XAU)
- **Decimals:** 18
- **RPC:** https://rpc.goldscan.gold
- **Explorer:** https://goldscan.gold
- **Website:** https://webgold.gold/

### Features:
- EIP155 compatible
- EIP1559 support
- QBFT consensus
- 2 second block time

### Checklist:
- [x] Added file to constants/additionalChainRegistry/
- [x] File named chainid-1932.js
- [x] All required fields included
- [x] RPC endpoint is accessible
- [x] Explorer is working