### PR TITLE
Add Igra (38833) to chainIds for icon support

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -220,6 +220,7 @@ export default {
   "33139": "apechain",
   "34443": "mode",
   "35441": "q_protocol",
+  "38833": "igra",
   "39797": "energi",
   "41455": "aleph_zero_evm",
   "41923": "edu chain",


### PR DESCRIPTION
Add Igra Mainnet (chain ID 38833) to chainIds.js so the chain icon renders on chainlist.org.

Igra was added to additionalChainRegistry in PR #2535. This adds the chainIds mapping needed for the icon CDN.

- Website: https://igralabs.com
- Chain ID: 38833