### PR TITLE
Add JITO Public Network RPC endpoint

### DIFF
--- a/constants/additionalChainRegistry/chainid-149.js
+++ b/constants/additionalChainRegistry/chainid-149.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "JITO Public Network",
+  chain: "JITO",
+  rpc: [
+    "https://rpc.flowpe.io",
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "JITO",
+    symbol: "JITO",
+    decimals: 18
+  },
+  features: [{ name: "EIP155" }],
+  infoURL: "https://jito.flowpe.io",
+  shortName: "jito149",
+  chainId: 149,
+  networkId: 149,
+  explorers: [{
+    name: "jito-explorer",
+    url: "https://explorer.flowpe.io",
+    standard: "EIP3091"
+  }]
+}


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC): https://jito.flowpe.io

#### Provide a link to your privacy policy:
https://jito.flowpe.io/privacy.html

#### If the RPC has none of the above and you still think it should be added, please explain why: N/A

RPC endpoint:
- https://rpc.flowpe.io

Explorer:
- https://explorer.flowpe.io/explorer

Network:
- Name: JITO Public Network
- Chain ID: 149
- Symbol: JITO

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.