### PR TITLE
Add Quantum Blockchain (QBC) RPC — Chain ID 3303

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9656,6 +9656,16 @@ export const extraRpcs = {
       },
     ],
   },
+  3303: {
+    rpcs: [
+      {
+        url: "https://qbc.network/rpc",
+        tracking: "none",
+        trackingDetails:
+          "Quantum Blockchain does not collect or store any user information transmitted via the RPC endpoint.",
+      },
+    ],
+  },
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
## Add RPC for Quantum Blockchain

| Field | Value |
|-------|-------|
| **Chain ID** | 3303 |
| **RPC URL** | https://qbc.network/rpc |
| **Tracking** | none |

Corresponding chain definition PR: https://github.com/ethereum-lists/chains/pull/8128

### Verification
```bash
curl -s -X POST https://qbc.network/rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# Returns: {"jsonrpc":"2.0","result":"0xce7","id":1}
```