### PR TITLE
chainid-{1404}.js

### DIFF
--- a/chainid-{1404}.js
+++ b/chainid-{1404}.js
@@ -1,0 +1,27 @@
+{
+  "name": "BlockDAG Mainnet",
+  "chain": "BDAG",
+  "rpc": [
+    "https://rpc.bdagscan.com/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BlockDAG",
+    "symbol": "BDAG",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" }
+  ],
+  "infoURL": "https://blockdag.network/",
+  "shortName": "bdag",
+  "chainId": 1404,
+  "networkId": 1404,
+  "explorers": [
+    {
+      "name": "bdagscan",
+      "url": "https://bdagscan.com/",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Blockdag Network not available in Metamask to sell tokens.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

RPC Details:

Network Name: BlockDAG Mainnet
RPC URL: https://rpc.bdagscan.com
Chain ID: 1404
Currency Symbol: BDAG
Block Explorer URL: https://bdagscan.com 

#### Provide a link to your privacy policy:



#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.