### PR TITLE
Add ArmaChain Testnet (Chain ID 2028)

### DIFF
--- a/constants/additionalChainRegistry/chainid-2028.js
+++ b/constants/additionalChainRegistry/chainid-2028.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "ArmaChain Testnet",
+  "chain": "ArmaChain",
+  "icon": "armachain",
+  "rpc": [
+    "https://rpc.armascan.io"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": ["https://armafaucet.io"],
+  "nativeCurrency": {
+    "name": "Testnet ARMA",
+    "symbol": "tARMA",
+    "decimals": 18
+  },
+  "infoURL": "https://armadex.io",
+  "shortName": "arma-testnet",
+  "chainId": 2028,
+  "networkId": 2028,
+  "explorers": [
+    {
+      "name": "ArmaScan",
+      "url": "https://armascan.io",
+      "icon": "armachain",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4762,6 +4762,9 @@ export const extraRpcs = {
   2025: {
     rpcs: ["https://mainnet.rangersprotocol.com/api/jsonrpc"],
   },
+  2028: {
+    rpcs: ["https://rpc.armascan.io"],
+  },
   2077: {
     rpcs: ["http://rpc.qkacoin.org:8548"],
   },


### PR DESCRIPTION
Adding ArmaChain Testnet as a new chain to chainlist.

**Chain Details:**
- Chain ID: 2028
- Native Currency: tARMA (18 decimals)
- RPC: https://rpc.armascan.io
- Explorer: https://armascan.io (EIP3091)
- Faucet: https://armafaucet.io
- Features: EIP155, EIP1559

**Link the service provider's website:**
https://armadex.io

**If the RPC has none of the above and you still think it should be added, please explain why:**
This is the official RPC endpoint for ArmaChain Testnet, operated by the ArmaChain team. We are adding a new chain registry entry along with the RPC.
