### PR TITLE
Add Gravity Longevity Testnet (chainId 7771625)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7771625.js
+++ b/constants/additionalChainRegistry/chainid-7771625.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "Gravity Longevity Testnet",
+  chain: "Gravity",
+  icon: "gravity",
+  rpc: ["https://rpc-testnet.gravity.xyz"],
+  faucets: ["https://faucet.gravity.xyz"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }, { name: "EIP1108" }],
+  nativeCurrency: {
+    name: "Gravity",
+    symbol: "G",
+    decimals: 18,
+  },
+  infoURL: "https://gravity.xyz",
+  shortName: "gravity-testnet",
+  chainId: 7771625,
+  networkId: 7771625,
+  explorers: [
+    {
+      name: "Gravity Testnet Explorer",
+      url: "https://explorer-testnet.gravity.xyz",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
### Summary
- Adds **Gravity Longevity Testnet** (L1) to `constants/additionalChainRegistry` as `chainid-7771625.js`

### Network details
- **Chain ID / Network ID:** 7771625
- **Native currency:** G (18 decimals)
- **RPC:** https://rpc-testnet.gravity.xyz
- **Explorer:** https://explorer-testnet.gravity.xyz
- **Faucet:** https://faucet.gravity.xyz
- **Docs:** https://docs.gravity.xyz/network/l1-longevity-testnet


### RPC provider website
https://gravity.xyz

