### PR TITLE
Add SPACE OS Testnet (Chain ID 800000)

### DIFF
--- a/constants/additionalChainRegistry/chainid-800000.js
+++ b/constants/additionalChainRegistry/chainid-800000.js
@@ -1,0 +1,29 @@
+export const data = {
+  "name": "SPACE OS Testnet",
+  "chain": "SPACE",
+  "icon": "spaceos",
+  "rpc": [
+    "https://testnet.evm.spaceos.com/"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [
+    "https://faucet.spaceos.com/"
+  ],
+  "nativeCurrency": {
+    "name": "SPACE",
+    "symbol": "SPACE",
+    "decimals": 18
+  },
+  "infoURL": "https://spaceos.com/",
+  "shortName": "spaceos-testnet",
+  "chainId": 800000,
+  "networkId": 800000,
+  "testnet": true,
+  "explorers": [
+    {
+      "name": "SPACE OS Explorer",
+      "url": "https://testnet.evm-explorer.spaceos.com/",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds **SPACE OS Testnet** to chainlist with Chain ID **800000**
- SPACE OS is an Antelope-based L1 with an EVM compatibility layer
- This is a testnet listing

## Chain Details

| Field | Value |
|-------|-------|
| Chain ID | 800000 |
| Network ID | 800000 |
| RPC | https://testnet.evm.spaceos.com/ |
| Explorer | https://testnet.evm-explorer.spaceos.com/ |
| Faucet | https://faucet.spaceos.com/ |
| Native Currency | SPACE (18 decimals) |
| Website | https://spaceos.com/ |
| Features | EIP155, EIP1559 |

## Files Changed

- `constants/additionalChainRegistry/chainid-800000.js` — chain registry entry