### PR TITLE
Create chainid-16166.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-16166.js
+++ b/constants/additionalChainRegistry/chainid-16166.js
@@ -1,0 +1,31 @@
+{
+  "name": "Cypherium Mainnet",
+  "chain": "CPH",
+  "rpc": [
+    "https://pubnodes.cypherium.io/rpc",
+    "https://make-cph-great-again.community"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Cypherium",
+    "symbol": "CPH",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://www.cypherium.io/",
+  "shortName": "cph",
+  "chainId": 16166,
+  "networkId": 16166,
+  "icon": "Cypherium",
+  "explorers": [
+    {
+      "name": "cypherium.tryethernal",
+      "url": "https://cypherium.tryethernal.com/",
+      "icon": "cypherium.tryethernal",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Add an additional public RPC endpoint for Cypherium Mainnet　icon

### Changes

- Added new RPC endpoint:
  - https://make-cph-great-again.community

### Verification

The RPC endpoint has been tested and is working correctly.

Example:

```bash
curl -X POST https://make-cph-great-again.community \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'