### PR TITLE
 Update OPN Chain Mainnet (chainId 222) native currency name from OPN to IOPN

### DIFF
--- a/constants/additionalChainRegistry/chainid-222.js
+++ b/constants/additionalChainRegistry/chainid-222.js
@@ -1,6 +1,6 @@
 export const data = {
     "name": "OPN Chain Mainnet",
-    "chain": "OPN",
+    "chain": "IOPN",
     "rpc": [
       "https://mainnet-rpc.iopn.tech",
       "https://mainnet-rpc2.iopn.tech",
@@ -11,20 +11,20 @@ export const data = {
     ],
     "faucets": [],
     "nativeCurrency": {
-      "name": "OPN",
-      "symbol": "OPN",
+      "name": "IOPN",
+      "symbol": "IOPN",
       "decimals": 18
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }, {"name": "EIP7702"}],
     "infoURL": "https://chain.iopn.io",
-    "shortName": "opn",
+    "shortName": "iopn",
     "chainId": 222,
     "networkId": 222,
-    "icon": "opn",
+    "icon": "iopn",
     "explorers": [{
-      "name": "OPN Explorer",
+      "name": "OPNScan",
       "url": "https://opnscan.io",
-      "icon": "opn",
+      "icon": "iopn",
       "standard": "none"
     }]
   }


### PR DESCRIPTION
---

Updates the chain configuration for OPN Chain Mainnet (chainId: 222) to reflect the native currency rename from OPN to IOPN.

**Changes:**

- `chain`: `OPN` → `IOPN`
- `nativeCurrency.name`: `OPN` → `IOPN`
- `nativeCurrency.symbol`: `OPN` → `IOPN`
- `shortName`: `opn` → `iopn`
- `icon`: `opn` → `iopn`
- `explorers[0].name`: `OPN Explorer` → `OPNScan`
- `explorers[0].icon`: `opn` → `iopn`

**No changes to:**
- RPC endpoints
- chainId / networkId
- `infoURL`
- Explorer URL (`https://opnscan.io`)

**Type of change:** Chain metadata update — native currency renamed from OPN to IOPN

---