### PR TITLE
Add OPN Chain Testnet to Chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-984.js
+++ b/constants/additionalChainRegistry/chainid-984.js
@@ -1,0 +1,28 @@
+export const data = {
+    "name": "OPN Chain Testnet",
+    "chain": "IOPN",
+    "rpc": [
+      "https://testnet-rpc.iopn.tech",
+      "https://testnet-rpc2.iopn.tech",
+      "wss://testnet-rpc.iopn.tech/ws",
+      "wss://testnet-rpc2.iopn.tech/ws"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "IOPN",
+      "symbol": "IOPN",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }, {"name": "EIP7702"}],
+    "infoURL": "https://chain.iopn.io",
+    "shortName": "iopn",
+    "chainId": 984,
+    "networkId": 984,
+    "icon": "iopn",
+    "explorers": [{
+      "name": "OPNScan Testnet",
+      "url": "https://testnet.iopn.tech",
+      "icon": "iopn",
+      "standard": "none"
+    }]
+  }


### PR DESCRIPTION
This PR adds a new chain entry for **OPN Chain Testnet** with:

- **Chain ID:** 984
- **Network ID:** 984
- **Native token:** IOPN
- **RPC endpoints:** HTTPS and WSS
- **Explorer:** https://testnet.iopn.tech
- **Info URL:** https://chain.iopn.io
- **Features:** EIP155, EIP1559, EIP7702