### PR TITLE
Add Qubitcoin chain (Chain ID: 3303)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3303.js
+++ b/constants/additionalChainRegistry/chainid-3303.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "Qubitcoin",
+  "chain": "QBC",
+  "rpc": [
+    "https://qbc.network/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Qubitcoin",
+    "symbol": "QBC",
+    "decimals": 8
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://qbc.network",
+  "shortName": "qbc",
+  "chainId": 3303,
+  "networkId": 3303,
+  "explorers": [
+    {
+      "name": "Qubitcoin Explorer",
+      "url": "https://qbc.network/explorer",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+};


### PR DESCRIPTION
## Adding new chain: Qubitcoin (Chain ID 3303)

| Property | Value |
|----------|-------|
| Chain Name | Qubitcoin |
| Chain ID | 3303 |
| Currency | QBC (8 decimals) |
| RPC | https://qbc.network/rpc |
| Block Explorer | https://qbc.network/explorer |
| Website | https://qbc.network |

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://qbc.network

#### Provide a link to your privacy policy:
N/A — self-hosted, open-source node. No user data is collected or stored.

#### If the RPC has none of the above and you still think it should be added, please explain why:
Qubitcoin is a live mainnet blockchain (Chain ID 3303) with active validators, block production, and a working block explorer. The RPC endpoint is publicly accessible at https://qbc.network/rpc.