### PR TITLE
feat: add CChain (2500) RPC endpoints

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -584,6 +584,12 @@ export const extraRpcs = {
   1975: {
     rpcs: ["https://rpc.onuschain.io"],
   },
+  2500: {
+    rpcs: [
+      "https://rpc.cchain.cc",
+      "wss://wss.cchain.cc"
+    ],
+  },
   2517: {
     rpcs: [
       "https://svp-dataseed1-testnet.svpchain.org",


### PR DESCRIPTION
Added production-ready HTTPS and WSS RPC nodes for CChain mainnet.

#### Link the service provider's website:
https://cchain.cc

#### Provide a link to your privacy policy:
N/A (Official project RPC with no user tracking).

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the official RPC endpoint for CChain (Chain ID: 2500). We have also submitted the metadata registration to the official ethereum-lists/chains repository: https://github.com/ethereum-lists/chains/pull/8125.

Our RPC nodes are production-ready, support CORS, and have been added to the end of the array as requested.