### PR TITLE
Update extraRpcs.js for Kite AI chain (Chainlist ID : 2366)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9690,6 +9690,16 @@ export const extraRpcs = {
       },
     ],
   },
+  2366: {
+  rpcs: [
+    {
+      url: "https://rpc.gokite.ai/",
+      tracking: "none",
+      trackingDetails:
+        "KiteAI RPC does not collect or store personal data from requests. Standard infrastructure-level logs may be used for monitoring and reliability.",
+    },
+  ],
+},
 };
 
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);


### PR DESCRIPTION
Request to update RPC details for Kite AI Chain - https://chainlist.org/chain/2366

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://gokite.ai/ 

#### Provide a link to your privacy policy: https://gokite.ai/privacy 

#### If the RPC has none of the above and you still think it should be added, please explain why:

This is the official public RPC endpoint operated by the Kite AI core team for the KiteAI mainnet (chainId 2366). It is publicly documented in Kite AI’s developer documentation and used by ecosystem developers, wallets, and infrastructure providers - https://docs.gokite.ai/kite-chain/1-getting-started/network-information 

Your RPC should always be added at the end of the array. Updated. 