### PR TITLE
feat: add Dawn Mainnet (chain ID 30715)

### DIFF
--- a/constants/additionalChainRegistry/chainid-30715.js
+++ b/constants/additionalChainRegistry/chainid-30715.js
@@ -1,0 +1,17 @@
+export const data = {
+  "name": "Dawn Mainnet",
+  "chain": "Dawn",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ZKsync",
+    "symbol": "ZK",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.zksync.io",
+  "shortName": "dawn-mainnet",
+  "chainId": 30715,
+  "networkId": 30715,
+  "explorers": []
+}


### PR DESCRIPTION
## Summary

- Add Dawn Mainnet to the chainlist
- This chain is deployed with the ZK Stack
- Chain ID: 30715
- Chain is not public, but want to make sure the Chain ID does not get used. If there are any issues with that let us know. 