### PR TITLE
feat: add ZKsync Prividium Mainnet (chain ID 30716)

### DIFF
--- a/constants/additionalChainRegistry/chainid-30716.js
+++ b/constants/additionalChainRegistry/chainid-30716.js
@@ -1,0 +1,17 @@
+export const data = {
+  "name": "ZKsync Prividium Mainnet",
+  "chain": "ZKsync Prividium",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.zksync.io",
+  "shortName": "zksync-prividium-mainnet",
+  "chainId": 30716,
+  "networkId": 30716,
+  "explorers": []
+}


### PR DESCRIPTION
## Summary

- Add ZKsync Prividium Mainnet to the chainlist
- This chain is deployed with the ZK Stack
- Chain ID: 30716
- Chain is not public, but want to make sure the Chain ID does not get used. If there are any issues with that let us know. 