### PR TITLE
Add GenLayer Testnets (Chain ID 4221)

### DIFF
--- a/constants/additionalChainRegistry/chainid-4221.js
+++ b/constants/additionalChainRegistry/chainid-4221.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "GenLayer Testnets",
+    "chain": "GenLayer",
+    "rpc": [
+      "https://zksync-os-testnet-genlayer.zksync.dev"
+    ],
+    "faucets": [
+      "https://testnet-faucet.genlayer.foundation/"
+    ],
+    "nativeCurrency": {
+      "name": "GEN Token",
+      "symbol": "GEN",
+      "decimals": 18
+    },
+    "infoURL": "https://www.genlayer.com",
+    "shortName": "genlayer-testnets",
+    "chainId": 4221,
+    "networkId": 4221,
+    "explorers": [
+      {
+        "name": "GenLayer Testnets Explorer",
+        "url": "https://zksync-os-testnet-genlayer.explorer.zksync.dev",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
## Summary
- Adds GenLayer Testnets chain (Chain ID 4221) to the chain registry
- GenLayer is a ZKsync-based testnet for intelligent contracts powered by AI/LLM validators
- RPC: `https://zksync-os-testnet-genlayer.zksync.dev`
- Explorer: `https://zksync-os-testnet-genlayer.explorer.zksync.dev`
- Native currency: GEN (18 decimals)
- Faucet: `https://testnet-faucet.genlayer.foundation/`

## Test plan
- [ ] Verify chain ID 4221 is not already registered
- [ ] Verify RPC endpoint responds to JSON-RPC calls
- [ ] Verify explorer URL loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)