### PR TITLE
Add ChainIDs 292, 4611 and 4612 for HashSphere

### DIFF
--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -1,0 +1,17 @@
+{
+    "name": "HashSphere",
+    "chain": "HashSphere",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "hbar",
+      "symbol": "HBAR",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://hashgraph.com",
+    "shortName": "hbar",
+    "chainId": 292,
+    "networkId": 292,
+    "explorers": []
+  }

--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -1,7 +1,7 @@
 {
     "name": "HashSphere",
     "chain": "HashSphere",
-    "rpc": [],
+    "rpc": ["http://rpc-292.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
       "name": "hbar",

--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -1,6 +1,6 @@
 {
-    "name": "HashSphere",
-    "chain": "HashSphere",
+    "name": "HashSphere Private Network 292",
+    "chain": "HashSphere-292",
     "rpc": ["http://rpc-292.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
@@ -10,7 +10,7 @@
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "infoURL": "https://hashgraph.com",
-    "shortName": "hbar",
+    "shortName": "hsp-292",
     "chainId": 292,
     "networkId": 292,
     "explorers": []

--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -13,5 +13,11 @@
     "shortName": "hsp-292",
     "chainId": 292,
     "networkId": 292,
-    "explorers": []
+    "explorers": [
+      {
+        "name": "HashSphere Explorer 292",
+        "url": "http://explorer-292.champagnesphere.net",
+        "standard": "none"
+      }
+    ]
   }

--- a/constants/additionalChainRegistry/chainid-292.js
+++ b/constants/additionalChainRegistry/chainid-292.js
@@ -1,4 +1,4 @@
-{
+export const data = {
     "name": "HashSphere Private Network 292",
     "chain": "HashSphere-292",
     "rpc": ["http://rpc-292.champagnesphere.net/"],

--- a/constants/additionalChainRegistry/chainid-4611.js
+++ b/constants/additionalChainRegistry/chainid-4611.js
@@ -1,0 +1,17 @@
+{
+    "name": "HashSphere-4611",
+    "chain": "HashSphere",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "hbar",
+      "symbol": "HBAR",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://hashgraph.com",
+    "shortName": "hbar-4611",
+    "chainId": 4611,
+    "networkId": 4611,
+    "explorers": []
+  }

--- a/constants/additionalChainRegistry/chainid-4611.js
+++ b/constants/additionalChainRegistry/chainid-4611.js
@@ -1,6 +1,6 @@
 {
-    "name": "HashSphere-4611",
-    "chain": "HashSphere",
+    "name": "HashSphere Private Network 4611",
+    "chain": "hsphere-private-4611",
     "rpc": ["http://rpc-4611.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
@@ -10,7 +10,7 @@
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "infoURL": "https://hashgraph.com",
-    "shortName": "hbar-4611",
+    "shortName": "hsp-4611",
     "chainId": 4611,
     "networkId": 4611,
     "explorers": []

--- a/constants/additionalChainRegistry/chainid-4611.js
+++ b/constants/additionalChainRegistry/chainid-4611.js
@@ -1,7 +1,7 @@
 {
     "name": "HashSphere-4611",
     "chain": "HashSphere",
-    "rpc": [],
+    "rpc": ["http://rpc-4611.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
       "name": "hbar",

--- a/constants/additionalChainRegistry/chainid-4611.js
+++ b/constants/additionalChainRegistry/chainid-4611.js
@@ -13,5 +13,11 @@
     "shortName": "hsp-4611",
     "chainId": 4611,
     "networkId": 4611,
-    "explorers": []
+    "explorers": [
+      {
+        "name": "HashSphere Explorer 4611",
+        "url": "http://explorer-4611.champagnesphere.net",
+        "standard": "none"
+      }
+    ]
   }

--- a/constants/additionalChainRegistry/chainid-4611.js
+++ b/constants/additionalChainRegistry/chainid-4611.js
@@ -1,4 +1,4 @@
-{
+export const data = {
     "name": "HashSphere Private Network 4611",
     "chain": "hsphere-private-4611",
     "rpc": ["http://rpc-4611.champagnesphere.net/"],

--- a/constants/additionalChainRegistry/chainid-4612.js
+++ b/constants/additionalChainRegistry/chainid-4612.js
@@ -1,7 +1,7 @@
 {
     "name": "HashSphere-4612",
     "chain": "HashSphere",
-    "rpc": [],
+    "rpc": ["http://rpc-4612.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
       "name": "hbar",

--- a/constants/additionalChainRegistry/chainid-4612.js
+++ b/constants/additionalChainRegistry/chainid-4612.js
@@ -1,6 +1,6 @@
 {
-    "name": "HashSphere-4612",
-    "chain": "HashSphere",
+    "name": "HashSphere Private Network 4612",
+    "chain": "hsphere-private-4612",
     "rpc": ["http://rpc-4612.champagnesphere.net/"],
     "faucets": [],
     "nativeCurrency": {
@@ -10,7 +10,7 @@
     },
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
     "infoURL": "https://hashgraph.com",
-    "shortName": "hbar-4612",
+    "shortName": "hsp-4612",
     "chainId": 4612,
     "networkId": 4612,
     "explorers": []

--- a/constants/additionalChainRegistry/chainid-4612.js
+++ b/constants/additionalChainRegistry/chainid-4612.js
@@ -1,0 +1,17 @@
+{
+    "name": "HashSphere-4612",
+    "chain": "HashSphere",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "hbar",
+      "symbol": "HBAR",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://hashgraph.com",
+    "shortName": "hbar-4612",
+    "chainId": 4612,
+    "networkId": 4612,
+    "explorers": []
+  }

--- a/constants/additionalChainRegistry/chainid-4612.js
+++ b/constants/additionalChainRegistry/chainid-4612.js
@@ -13,5 +13,11 @@
     "shortName": "hsp-4612",
     "chainId": 4612,
     "networkId": 4612,
-    "explorers": []
+    "explorers": [
+      {
+        "name": "HashSphere Explorer 4612",
+        "url": "http://explorer-4612.champagnesphere.net",
+        "standard": "none"
+      }
+    ]
   }

--- a/constants/additionalChainRegistry/chainid-4612.js
+++ b/constants/additionalChainRegistry/chainid-4612.js
@@ -1,4 +1,4 @@
-{
+export const data = {
     "name": "HashSphere Private Network 4612",
     "chain": "hsphere-private-4612",
     "rpc": ["http://rpc-4612.champagnesphere.net/"],


### PR DESCRIPTION
Reserves chain IDs 292, 4611 (0x1203), and 4612 (0x1204) for HashSphere.

[HashSphere](https://www.hashgraph.com/hashsphere) is a private blockchain product by Hashgraph. These networks are currently private, but are being registered now in anticipation of potentially becoming public in the future. Placeholder RPC endpoints have been included to satisfy submission requirements.

- `chainid-292.js` — HashSphere (previously submitted, resubmitting with RPC)
- `chainid-4611.js` — HashSphere-4611
- `chainid-4612.js` — HashSphere-4612