### PR TITLE
feat: add STO Chain mainnet (1306) and testnet (1999)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1306.js
+++ b/constants/additionalChainRegistry/chainid-1306.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "STO Chain",
+  "chain": "STOC",
+  "rpc": [
+    "https://evm-stoc-mainnet.stochainscan.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "STOC",
+    "symbol": "STOC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://www.stochain.io/",
+  "shortName": "stoc",
+  "chainId": 1306,
+  "networkId": 1306,
+  "icon": "stoc",
+  "explorers": [
+    {
+      "name": "STO Chain Explorer",
+      "url": "https://stochainscan.io/en",
+      "standard": "none"
+    }
+  ],
+  "status": "active"
+};

--- a/constants/additionalChainRegistry/chainid-1999.js
+++ b/constants/additionalChainRegistry/chainid-1999.js
@@ -1,0 +1,29 @@
+export const data = {
+  "name": "STO Chain Testnet",
+  "chain": "TSTOC",
+  "rpc": [
+    "https://evm-stoc-testnet.stochainscan.io"
+  ],
+  "faucets": [
+    "https://testnet.stochainscan.io/en/request-faucet"
+  ],
+  "nativeCurrency": {
+    "name": "TSTOC",
+    "symbol": "TSTOC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://www.stochain.io/",
+  "shortName": "tstoc",
+  "chainId": 1999,
+  "networkId": 1999,
+  "icon": "stoc",
+  "explorers": [
+    {
+      "name": "STO Chain Testnet Explorer",
+      "url": "https://testnet.stochainscan.io/en",
+      "standard": "none"
+    }
+  ],
+  "status": "active"
+};

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -118,6 +118,7 @@ export default {
   "1234": "step",
   "1284": "moonbeam",
   "1285": "moonriver",
+  "1306": "stoc",
   "1329": "sei",
   "1424": "perennial",
   "1514": "sty",


### PR DESCRIPTION
## Adding STO Chain Mainnet & Testnet

**STO Chain** is a Cosmos SDK blockchain with full EVM compatibility (powered by Cosmos EVM) designed for securities tokenization (STO - Security Token Offering).

### Chain Details

#### Mainnet

| Field | Value |
|-------|-------|
| Chain ID | 1306 |
| Name | STO Chain |
| Symbol | STOC |
| Decimals | 18 |
| RPC | https://evm-stoc-mainnet.stochainscan.io |
| Explorer | https://stochainscan.io/en |
| Website | https://www.stochain.io/ |
| Status | Active (Mainnet) |

#### Testnet

| Field | Value |
|-------|-------|
| Chain ID | 1999 |
| Name | STO Chain Testnet |
| Symbol | TSTOC |
| Decimals | 18 |
| RPC | https://evm-stoc-testnet.stochainscan.io |
| Explorer | https://testnet.stochainscan.io/en |
| Faucet | https://testnet.stochainscan.io/en/request-faucet |
| Status | Active (Testnet) |

### Features
- EIP-155 (replay protection)
- Cosmos SDK v0.53 + CometBFT consensus
- Cosmos EVM - full Ethereum Virtual Machine compatibility
- IBC (Inter-Blockchain Communication) enabled
- Custom token module for securities tokenization

### Technical Details
- **Consensus**: CometBFT (BFT-based Proof of Stake)
- **Block Time**: ~5 seconds
- **Coin Type**: 118 (Cosmos standard)
- **Dual denomination**: `ustoc` (Cosmos, 6 decimals) ↔ `astoc` (EVM, 18 decimals)
- **Built with**: Cosmos SDK v0.53.4 + Cosmos EVM

### Links
- **Website**: https://www.stochain.io/
- **Explorer (Mainnet)**: https://stochainscan.io/en
- **Explorer (Testnet)**: https://testnet.stochainscan.io/en
- **Faucet (Testnet)**: https://testnet.stochainscan.io/en/request-faucet

#### Link the service provider's website:
https://www.stochain.io/

#### Provide a link to your privacy policy:
https://www.stochain.io/other/privacy.php

#### If the RPC has none of the above and you still think it should be added, please explain why:
STO Chain is a live Cosmos SDK blockchain with EVM compatibility for securities tokenization. Mainnet has been active since 2025. Both mainnet and testnet RPCs are publicly accessible.