### PR TITLE
remove https://evmos.api.onfinality.io/public api from list

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5102,11 +5102,6 @@ export const extraRpcs = {
       },
       "https://jsonrpc-evmos.goldenratiostaking.net",
       {
-        url: "https://evmos.api.onfinality.io/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.onfinality,
-      },
-      {
         url: "https://evmos-jsonrpc.cyphercore.io",
         tracking: "yes",
         trackingDetails: privacyStatement.cyphercore,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.