### PR TITLE
Add public RPC endpoints for Infinite and QL1

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9418,6 +9418,11 @@ export const extraRpcs = {
         url: "https://evm-rpc-ql1.foxxone.one",
         tracking: "none",
         trackingDetails: "No user tracking or data collection",
+      }, 
+      {
+        url: "https://evm-rpc-ql1.mschihuahua.org",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
       },
     ],
   },
@@ -9697,6 +9702,16 @@ export const extraRpcs = {
 },
 };
 
+  421018: {
+    rpcs: [
+      {
+        url: "https://evm-rpc-infinite.mschihuahua.org",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
+    ],
+  }
+};  
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 
 export default allExtraRpcs;


### PR DESCRIPTION
Add public RPC endpoints for Infinite and QL1

- Infinite (421018): https://evm-rpc-infinite.mschihuahua.org
- QL1 (766): https://evm-rpc-ql1.mschihuahua.org

#### Link the service provider's website:
https://mschihuahua.org

#### Provide a link to your privacy policy:
No user tracking or data collection. This is a self-hosted RPC node.

#### Additional notes:
- Endpoints tested:
  - eth_chainId ✔️
  - eth_blockNumber ✔️
- Self-hosted infrastructure
- HTTPS enabled
- Rate-limited via Nginx
- Stable production RPC