### PR TITLE
Add Tron Classic (chainId 30485) registry and extra RPC

### DIFF
--- a/constants/additionalChainRegistry/chainid-30485.js
+++ b/constants/additionalChainRegistry/chainid-30485.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Tron Classic",
+  chain: "TRXC",
+  rpc: ["https://rpc.tronclassicscan.org:8545"],
+  faucets: [],
+  nativeCurrency: {
+    name: "Tron Classic",
+    symbol: "TRXC",
+    decimals: 6,
+  },
+  features: [{ name: "EIP155" }],
+  infoURL: "https://trxclassic.com",
+  shortName: "trxc",
+  chainId: 30485,
+  networkId: 30485,
+  explorers: [
+    {
+      name: "TronClassicScan",
+      url: "https://tronclassicscan.org",
+      standard: "EIP3091",
+    },
+  ],
+};

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9642,6 +9642,16 @@ export const extraRpcs = {
       },
     ],
   },
+  30485: {
+    rpcs: [
+      {
+        url: "https://rpc.tronclassicscan.org:8545",
+        tracking: "limited",
+        trackingDetails:
+          "TronClassicScan public RPC may log IP addresses and request metadata for rate limiting, security, and service reliability.",
+      },
+    ],
+  },
   677: {
     rpcs: [
       {


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://trxclassic.com  
https://tronclassicscan.org

#### Provide a link to your privacy policy:

No standalone privacy policy URL is published yet.

#### If the RPC has none of the above and you still think it should be added, please explain why:

Public JSON-RPC for Tron Classic mainnet (chainId 30485), operated alongside TronClassicScan. Needed for wallets and dapps to connect. The entry uses `tracking: "limited"` and `trackingDetails` to describe possible IP and request metadata logging for rate limiting and reliability until a formal privacy page is published.