### PR TITLE
Add VinuChain mainnet (207) and testnet (206)

### DIFF
--- a/constants/additionalChainRegistry/chainid-206.js
+++ b/constants/additionalChainRegistry/chainid-206.js
@@ -1,0 +1,31 @@
+export const data = {
+    "name": "VinuChain Testnet",
+    "chain": "VC",
+    "icon": "vinuchain",
+    "rpc": [
+      "https://testnet-rpc.vinuchain.org",
+      "https://vinufoundation-rpc.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "VinuChain",
+      "symbol": "VC",
+      "decimals": 18
+    },
+    "infoURL": "https://vinuchain.org",
+    "shortName": "vc-testnet",
+    "chainId": 206,
+    "networkId": 206,
+    "explorers": [
+      {
+        "name": "VinuExplorer Testnet",
+        "url": "https://testnet.vinuexplorer.org",
+        "standard": "EIP3091"
+      },
+      {
+        "name": "VinuScan Testnet",
+        "url": "https://testnet.vinuscan.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/additionalChainRegistry/chainid-207.js
+++ b/constants/additionalChainRegistry/chainid-207.js
@@ -1,0 +1,31 @@
+export const data = {
+    "name": "VinuChain",
+    "chain": "VC",
+    "icon": "vinuchain",
+    "rpc": [
+      "https://rpc.vinuchain.org",
+      "https://vinuchain-rpc.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "VinuChain",
+      "symbol": "VC",
+      "decimals": 18
+    },
+    "infoURL": "https://vinuchain.org",
+    "shortName": "vc",
+    "chainId": 207,
+    "networkId": 207,
+    "explorers": [
+      {
+        "name": "VinuExplorer",
+        "url": "https://vinuexplorer.org",
+        "standard": "EIP3091"
+      },
+      {
+        "name": "VinuScan",
+        "url": "https://mainnet.vinuscan.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -53,6 +53,7 @@ export default {
   "199": "bittorrent",
   "200": "xdaiarb",
   "204": "op_bnb",
+  "206": "vinuchain testnet",
   "207": "vinuchain",
   "225": "lachain",
   "228": "mind network",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -53,7 +53,6 @@ export default {
   "199": "bittorrent",
   "200": "xdaiarb",
   "204": "op_bnb",
-  "206": "vinuchain testnet",
   "207": "vinuchain",
   "225": "lachain",
   "228": "mind network",


### PR DESCRIPTION
Adds chain registry entries for VinuChain.

### VinuChain Mainnet (Chain ID: 207)
- RPCs: `https://rpc.vinuchain.org`, `https://vinuchain-rpc.com`
- Explorers: https://vinuexplorer.org, https://mainnet.vinuscan.com
- Currency: VC (18 decimals)
- Website: https://vinuchain.org

### VinuChain Testnet (Chain ID: 206)
- RPCs: `https://testnet-rpc.vinuchain.org`, `https://vinufoundation-rpc.com`
- Explorers: https://testnet.vinuexplorer.org, https://testnet.vinuscan.com
- Currency: VC (18 decimals)

Icon PR: DefiLlama/icons#2354