### PR TITLE
feat: add NetX Mainnet (287) and NetX Testnet (587) RPCs

### DIFF
--- a/constants/additionalChainRegistry/chainid-287.js
+++ b/constants/additionalChainRegistry/chainid-287.js
@@ -1,0 +1,28 @@
+export const data = {
+  "name": "NetX Mainnet",
+  "chain": "NETX",
+  "rpc": [
+    "https://rpc.netxscan.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NETX",
+    "symbol": "NETX",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://netxscan.io/",
+  "shortName": "netx",
+  "chainId": 287,
+  "networkId": 287,
+  "explorers": [
+    {
+      "name": "NetXScan",
+      "url": "https://netxscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+};

--- a/constants/additionalChainRegistry/chainid-587.js
+++ b/constants/additionalChainRegistry/chainid-587.js
@@ -1,0 +1,28 @@
+export const data = {
+  "name": "NetX Testnet",
+  "chain": "NETX",
+  "rpc": [
+    "https://test-rpc.netxscan.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NETX",
+    "symbol": "NETX",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://test.netxscan.io/",
+  "shortName": "netx-testnet",
+  "chainId": 587,
+  "networkId": 587,
+  "explorers": [
+    {
+      "name": "NetXScan Testnet",
+      "url": "https://test.netxscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+};

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3307,12 +3307,12 @@ export const extraRpcs = {
   },
   287: {
     rpcs: [
-      "https://rpc.tsccan.io",
+      "https://rpc.netxscan.io",
     ],
   },
   587: {
     rpcs: [
-      "https://test-rpc.tsccan.io",
+      "https://test-rpc.netxscan.io",
     ],
   },
   288: {

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3305,6 +3305,16 @@ export const extraRpcs = {
       },
     ],
   },
+  287: {
+    rpcs: [
+      "https://rpc.tsccan.io",
+    ],
+  },
+  587: {
+    rpcs: [
+      "https://test-rpc.tsccan.io",
+    ],
+  },
   288: {
     rpcs: [
       "https://mainnet.boba.network/",


### PR DESCRIPTION
## Summary

Add RPC endpoints for the NetX network to `extraRpcs.js`:

- **NetX Mainnet** (Chain ID `287`): `https://rpc.tsccan.io`
- **NetX Testnet** (Chain ID `587`): `https://test-rpc.tsccan.io`

Corresponding chain definitions have been submitted to [ethereum-lists/chains#8190](https://github.com/ethereum-lists/chains/pull/8190).