### PR TITLE
remove deprecated public blockpi rpc "https://oasys.blockpi.network/v1/rpc/public" from list

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -8849,6 +8849,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://plasma.blockpi.network/v1/rpc/create_your_free_key",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
     ],
     websiteDead: false,
     rpcWorking: true,

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6302,11 +6302,6 @@ export const extraRpcs = {
   248: {
     rpcs: [
       "https://rpc.mainnet.oasys.games",
-      {
-        url: "https://oasys.blockpi.network/v1/rpc/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.blockpi,
-      },
       "wss://ws.mainnet.oasys.games/",
       {
         url: "https://oasys.api.pocket.network",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.