### PR TITLE
Update extraRpcs.js | Oasys

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -6469,11 +6469,6 @@ export const extraRpcs = {
   248: {
     rpcs: [
       "https://rpc.mainnet.oasys.games",
-      {
-        url: "https://oasys.blockpi.network/v1/rpc/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.blockpi,
-      },
       "wss://ws.mainnet.oasys.games/",
       {
         url: "https://oasys.api.pocket.network",


### PR DESCRIPTION
Due to the expiration of our contract with BlockPI, we will be submitting a pull request to remove the RPC URL. Thank you.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.oasys.games/
https://docs.oasys.games/docs/staking/rpc-endpoint/1-1-rpc-endpoint#mainnet

#### Provide a link to your privacy policy:
https://drive.google.com/file/d/1UIdHJOOn7DsvvxuGOe7mUzB8O7syT3OH/view?usp=drive_link