### PR TITLE
feat: update iTani Network Chain (1229800785) - add node RPC and explorers

### DIFF
--- a/constants/additionalChainRegistry/chainid-1229800785.js
+++ b/constants/additionalChainRegistry/chainid-1229800785.js
@@ -3,6 +3,7 @@ export const data = {
   "chain": "ITN",
   "icon": "itani",
   "rpc": [
+    "https://node.itaninetworkchain.com/jsonrpc",
     "https://relay.itaninetworkchain.com/jsonrpc"
   ],
   "features": [
@@ -23,9 +24,15 @@ export const data = {
   "explorers": [
     {
       "name": "iTani Explorer",
+      "url": "https://node.itaninetworkchain.com",
+      "icon": "itani",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "iTani Explorer (Relay)",
       "url": "https://relay.itaninetworkchain.com",
       "icon": "itani",
       "standard": "EIP3091"
     }
   ]
-}
+};


### PR DESCRIPTION
## Summary
Update iTani Network Chain (Chain ID: 1229800785) entry with additional RPC endpoint and explorer entries.

## Changes
- Added primary node RPC endpoint: \https://node.itaninetworkchain.com/jsonrpc\
- Added node explorer entry with EIP-3091 standard
- Added relay explorer entry with EIP-3091 standard
- Minor formatting fix (trailing semicolon)

## Chain Details
| Field | Value |
|-------|-------|
| Name | iTani Network Chain |
| Chain ID | 1229800785 (0x494D4551) |
| Symbol | ITANI |
| Decimals | 18 |
| Consensus | ISSP (Proof of Stake) |

## RPC Endpoints
- \https://node.itaninetworkchain.com/jsonrpc\ (primary node)
- \https://relay.itaninetworkchain.com/jsonrpc\ (relay)

## Explorer
- https://node.itaninetworkchain.com/explorer (EIP-3091)
- https://relay.itaninetworkchain.com/explorer (EIP-3091)

## Verification
Both endpoints respond to \th_chainId\ with \