### PR TITLE
Add litvm liteforge testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-4441.js
+++ b/constants/additionalChainRegistry/chainid-4441.js
@@ -1,24 +1,22 @@
 export const data = {
-    "name": "LitVM Liteforge Testnet",
-    "chain": "Liteforge",
-    "rpc": [
-      "https://liteforge.rpc.caldera.xyz/http"
-    ],
-    "features": [{ "name": "EIP155" }],
-    "faucets": [],
-    "nativeCurrency": {
-      "name": "zkLTC",
-      "symbol": "zkLTC",
-      "decimals": 18
+  name: "LitVM Liteforge Testnet",
+  chain: "Liteforge",
+  rpc: ["https://liteforge.rpc.caldera.xyz/http"],
+  features: [{ name: "EIP155" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "zkLTC",
+    symbol: "zkLTC",
+    decimals: 18,
+  },
+  shortName: "liteforge",
+  chainId: 4441,
+  networkId: 4441,
+  explorers: [
+    {
+      name: "Liteforge Explorer",
+      url: "https://liteforge.explorer.caldera.xyz",
+      standard: "EIP3091",
     },
-    "shortName": "liteforge",
-    "chainId": 4441,
-    "networkId": 4441,
-    "explorers": [
-      {
-        "name": "Liteforge Explorer",
-        "url": "https://liteforge.explorer.caldera.xyz",
-        "standard": "EIP3091"
-      }
-    ]
-  }
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-4441.js
+++ b/constants/additionalChainRegistry/chainid-4441.js
@@ -1,0 +1,24 @@
+export const data = {
+    "name": "LitVM Liteforge Testnet",
+    "chain": "Liteforge",
+    "rpc": [
+      "https://liteforge.rpc.caldera.xyz/http"
+    ],
+    "features": [{ "name": "EIP155" }],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "zkLTC",
+      "symbol": "zkLTC",
+      "decimals": 18
+    },
+    "shortName": "liteforge",
+    "chainId": 4441,
+    "networkId": 4441,
+    "explorers": [
+      {
+        "name": "Liteforge Explorer",
+        "url": "https://liteforge.explorer.caldera.xyz",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
Link the service provider's website (the company/protocol/individual providing the RPC):
  https://caldera.xyz/

  Provide a link to your privacy policy:
  https://caldera.xyz/privacy

  If the RPC has none of the above and you still think it should be added, please explain why:
  This PR adds a new chain entry (LitVM Liteforge Testnet, chainId 4441) to the additional chain registry, not just an RPC
  to an existing chain. The RPC endpoint is provided by Caldera, a rollup deployment platform.