### PR TITLE
Add BesaChain network configurations

### DIFF
--- a/constants/additionalChainRegistry/chainid-1444.js
+++ b/constants/additionalChainRegistry/chainid-1444.js
@@ -11,12 +11,12 @@ export const data = {
     symbol: "BESA",
     decimals: 18
   },
-  infoURL: "https://besachain.io",
+  infoURL: "https://besachain.com",
   shortName: "besa-l1",
   chainId: 1444,
   networkId: 1444,
   explorers: [],
   rpc: [
-    "https://rpc.besachain.io"
+    "https://rpc.besachain.com"
   ]
 };

--- a/constants/additionalChainRegistry/chainid-1444.js
+++ b/constants/additionalChainRegistry/chainid-1444.js
@@ -1,0 +1,22 @@
+export const data = {
+  name: "BesaChain L1",
+  chain: "BESA",
+  rpc: [
+    "https://rpc.besachain.io"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Besa",
+    symbol: "BESA",
+    decimals: 18
+  },
+  infoURL: "https://besachain.io",
+  shortName: "besa-l1",
+  chainId: 1444,
+  networkId: 1444,
+  explorers: []
+};

--- a/constants/additionalChainRegistry/chainid-1444.js
+++ b/constants/additionalChainRegistry/chainid-1444.js
@@ -1,9 +1,6 @@
 export const data = {
   name: "BesaChain L1",
   chain: "BESA",
-  rpc: [
-    "https://rpc.besachain.io"
-  ],
   features: [
     { name: "EIP155" },
     { name: "EIP1559" }
@@ -18,5 +15,8 @@ export const data = {
   shortName: "besa-l1",
   chainId: 1444,
   networkId: 1444,
-  explorers: []
+  explorers: [],
+  rpc: [
+    "https://rpc.besachain.io"
+  ]
 };

--- a/constants/additionalChainRegistry/chainid-14440.js
+++ b/constants/additionalChainRegistry/chainid-14440.js
@@ -1,0 +1,22 @@
+export const data = {
+  name: "BesaChain L1 Testnet",
+  chain: "BESA",
+  rpc: [
+    "https://testnet-rpc.besachain.io"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Test Besa",
+    symbol: "tBESA",
+    decimals: 18
+  },
+  infoURL: "https://besachain.io",
+  shortName: "besa-l1-testnet",
+  chainId: 14440,
+  networkId: 14440,
+  explorers: []
+};

--- a/constants/additionalChainRegistry/chainid-14440.js
+++ b/constants/additionalChainRegistry/chainid-14440.js
@@ -11,12 +11,12 @@ export const data = {
     symbol: "tBESA",
     decimals: 18
   },
-  infoURL: "https://besachain.io",
+  infoURL: "https://besachain.com",
   shortName: "besa-l1-testnet",
   chainId: 14440,
   networkId: 14440,
   explorers: [],
   rpc: [
-    "https://testnet-rpc.besachain.io"
+    "https://testnet-rpc.besachain.com"
   ]
 };

--- a/constants/additionalChainRegistry/chainid-14440.js
+++ b/constants/additionalChainRegistry/chainid-14440.js
@@ -1,9 +1,6 @@
 export const data = {
   name: "BesaChain L1 Testnet",
   chain: "BESA",
-  rpc: [
-    "https://testnet-rpc.besachain.io"
-  ],
   features: [
     { name: "EIP155" },
     { name: "EIP1559" }
@@ -18,5 +15,8 @@ export const data = {
   shortName: "besa-l1-testnet",
   chainId: 14440,
   networkId: 14440,
-  explorers: []
+  explorers: [],
+  rpc: [
+    "https://testnet-rpc.besachain.io"
+  ]
 };

--- a/constants/additionalChainRegistry/chainid-1912.js
+++ b/constants/additionalChainRegistry/chainid-1912.js
@@ -1,0 +1,22 @@
+export const data = {
+  name: "BesaChain L2",
+  chain: "BESA",
+  rpc: [
+    "https://l2-rpc.besachain.io"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Besa",
+    symbol: "BESA",
+    decimals: 18
+  },
+  infoURL: "https://besachain.io",
+  shortName: "besa-l2",
+  chainId: 1912,
+  networkId: 1912,
+  explorers: []
+};

--- a/constants/additionalChainRegistry/chainid-1912.js
+++ b/constants/additionalChainRegistry/chainid-1912.js
@@ -1,9 +1,6 @@
 export const data = {
   name: "BesaChain L2",
   chain: "BESA",
-  rpc: [
-    "https://l2-rpc.besachain.io"
-  ],
   features: [
     { name: "EIP155" },
     { name: "EIP1559" }
@@ -18,5 +15,8 @@ export const data = {
   shortName: "besa-l2",
   chainId: 1912,
   networkId: 1912,
-  explorers: []
+  explorers: [],
+  rpc: [
+    "https://l2-rpc.besachain.io"
+  ]
 };

--- a/constants/additionalChainRegistry/chainid-1912.js
+++ b/constants/additionalChainRegistry/chainid-1912.js
@@ -11,12 +11,12 @@ export const data = {
     symbol: "BESA",
     decimals: 18
   },
-  infoURL: "https://besachain.io",
+  infoURL: "https://besachain.com",
   shortName: "besa-l2",
   chainId: 1912,
   networkId: 1912,
   explorers: [],
   rpc: [
-    "https://l2-rpc.besachain.io"
+    "https://l2-rpc.besachain.com"
   ]
 };

--- a/constants/additionalChainRegistry/chainid-19120.js
+++ b/constants/additionalChainRegistry/chainid-19120.js
@@ -1,9 +1,6 @@
 export const data = {
   name: "BesaChain L2 Testnet",
   chain: "BESA",
-  rpc: [
-    "https://testnet-l2-rpc.besachain.io"
-  ],
   features: [
     { name: "EIP155" },
     { name: "EIP1559" }
@@ -18,5 +15,8 @@ export const data = {
   shortName: "besa-l2-testnet",
   chainId: 19120,
   networkId: 19120,
-  explorers: []
+  explorers: [],
+  rpc: [
+    "https://testnet-l2-rpc.besachain.io"
+  ]
 };

--- a/constants/additionalChainRegistry/chainid-19120.js
+++ b/constants/additionalChainRegistry/chainid-19120.js
@@ -11,12 +11,12 @@ export const data = {
     symbol: "tBESA",
     decimals: 18
   },
-  infoURL: "https://besachain.io",
+  infoURL: "https://besachain.com",
   shortName: "besa-l2-testnet",
   chainId: 19120,
   networkId: 19120,
   explorers: [],
   rpc: [
-    "https://testnet-l2-rpc.besachain.io"
+    "https://testnet-l2-rpc.besachain.com"
   ]
 };

--- a/constants/additionalChainRegistry/chainid-19120.js
+++ b/constants/additionalChainRegistry/chainid-19120.js
@@ -1,0 +1,22 @@
+export const data = {
+  name: "BesaChain L2 Testnet",
+  chain: "BESA",
+  rpc: [
+    "https://testnet-l2-rpc.besachain.io"
+  ],
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Test Besa",
+    symbol: "tBESA",
+    decimals: 18
+  },
+  infoURL: "https://besachain.io",
+  shortName: "besa-l2-testnet",
+  chainId: 19120,
+  networkId: 19120,
+  explorers: []
+};


### PR DESCRIPTION
  Add support for BesaChain L1 and L2 networks:
  - BesaChain L1 Mainnet (Chain ID: 1444)
  - BesaChain L2 Mainnet (Chain ID: 1912)
  - BesaChain L1 Testnet (Chain ID: 14440)
  - BesaChain L2 Testnet (Chain ID: 19120)

  All networks support EIP155 and EIP1559 features.

  #### Link the service provider's website:
  https://besachain.com

  #### Provide a link to your privacy policy:
  https://besachain.com/privacy-policy

  #### If the RPC has none of the above and you still think it should be added, please explain why:
  N/A - Privacy policy is now published at https://besachain.com/privacy-policy