### PR TITLE
fix(nexus-testnet): update icon URL and fix networkId typo

### DIFF
--- a/constants/additionalChainRegistry/chainid-3945.js
+++ b/constants/additionalChainRegistry/chainid-3945.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "Nexus Testnet",
+  chain: "Nexus",
+  rpc: ["https://testnet.rpc.nexus.xyz"],
+  faucets: ["https://faucet.nexus.xyz"],
+  nativeCurrency: {
+    name: "Nexus",
+    symbol: "NEX",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://nexus.xyz",
+  shortName: "NEX",
+  chainId: 3945,
+  networkId: 3495,
+  icon: "Nexus testnet",
+  explorers: [
+    {
+      name: "Nexus Testnet Explorer",
+      url: "https://nexus.testnet.blockscout.com",
+      icon: "NEX",
+      standard: "EIP3091",
+    },
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-3945.js
+++ b/constants/additionalChainRegistry/chainid-3945.js
@@ -1,6 +1,6 @@
 export const data = {
   name: "Nexus Testnet",
-  chain: "Nexus",
+  chain: "Nexus Testnet",
   rpc: ["https://testnet.rpc.nexus.xyz"],
   faucets: ["https://faucet.nexus.xyz"],
   nativeCurrency: {
@@ -8,17 +8,16 @@ export const data = {
     symbol: "NEX",
     decimals: 18,
   },
-  features: [{ name: "EIP155" }, { name: "EIP1559" }],
   infoURL: "https://nexus.xyz",
   shortName: "NEX",
   chainId: 3945,
   networkId: 3495,
-  icon: "Nexus testnet",
+  icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
   explorers: [
     {
       name: "Nexus Testnet Explorer",
       url: "https://nexus.testnet.blockscout.com",
-      icon: "NEX",
+      icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
       standard: "EIP3091",
     },
   ],

--- a/constants/additionalChainRegistry/chainid-3945.js
+++ b/constants/additionalChainRegistry/chainid-3945.js
@@ -11,13 +11,13 @@ export const data = {
   infoURL: "https://nexus.xyz",
   shortName: "NEX",
   chainId: 3945,
-  networkId: 3495,
-  icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
+  networkId: 3945,
+  icon: "https://drive.google.com/uc?export=view&id=1-JcN3A-KXivWKtxP9LF7YKV5c0AMBrzg",
   explorers: [
     {
       name: "Nexus Testnet Explorer",
       url: "https://nexus.testnet.blockscout.com",
-      icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
+      icon: "https://drive.google.com/uc?export=view&id=1-JcN3A-KXivWKtxP9LF7YKV5c0AMBrzg",
       standard: "EIP3091",
     },
   ],


### PR DESCRIPTION
Updates the Nexus Testnet entry (chain ID 3945).

**Changes:**
- Replaces stale Framer CDN icon URLs with a stable public URL for both `icon` and `explorers[0].icon`
- Fixes `networkId` typo: `3495` → `3945`