### PR TITLE
Add Vexidus Testnet (chainId 1618032)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1618032.js
+++ b/constants/additionalChainRegistry/chainid-1618032.js
@@ -1,0 +1,29 @@
+export const data = {
+  "name": "Vexidus Testnet",
+  "chain": "VXS",
+  "rpc": [
+    "https://testnet.vexidus.io"
+  ],
+  "faucets": [
+    "https://vexswap.xyz"
+  ],
+  "nativeCurrency": {
+    "name": "Vexidus",
+    "symbol": "VXS",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" }
+  ],
+  "infoURL": "https://vexidus.io",
+  "shortName": "vxs-testnet",
+  "chainId": 1618032,
+  "networkId": 1618032,
+  "explorers": [
+    {
+      "name": "VexScan",
+      "url": "https://vexscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
### New chain submission: Vexidus Testnet

Adds `constants/additionalChainRegistry/chainid-1618032.js` for **Vexidus Testnet** (chainId 1618032).

Vexidus is a post-quantum L1 blockchain with EVM compatibility via an `eth_*` RPC adapter. The testnet has been live since Feb 26, 2026 with 5 validators across 4 continents and is currently at block 2.18M+.

#### Chain details

| Field | Value |
|---|---|
| Name | Vexidus Testnet |
| Chain ID | 1618032 (`0x18b070`) |
| Native currency | VXS (18 decimals via EVM adapter) |
| RPC | https://testnet.vexidus.io |
| Explorer | https://vexscan.io |
| Faucet | https://vexswap.xyz |
| Info URL | https://vexidus.io |

#### Verification

```bash
$ curl -s -X POST https://testnet.vexidus.io \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","result":"0x18b070","id":1}
```

#### Notes
- Only `EIP155` is listed under `features` — Vexidus has chain-id replay protection but does not implement an EIP-1559 fee market.
- Mainnet (chainId 1618033) will be submitted as a separate PR once it goes live.