### PR TITLE
Add TPIX Chain (chainId: 4289) to additionalChainRegistry

### DIFF
--- a/constants/additionalChainRegistry/chainid-4289.js
+++ b/constants/additionalChainRegistry/chainid-4289.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "TPIX Chain",
+    "chain": "TPIX",
+    "rpc": [
+      "https://rpc.tpix.online"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+    "name": "TPIX",
+          "symbol": "TPIX",
+          "decimals": 18
+      },
+  "features": [
+      { "name": "EIP155" }
+  ],
+  "infoURL": "https://tpix.online",
+      "shortName": "tpix",
+      "chainId": 4289,
+      "networkId": 4289,
+      "explorers": [
+    {
+          "name": "TPIX Explorer",
+          "url": "https://explorer.tpix.online",
+          "standard": "EIP3091"
+    }
+  ]
+    }


### PR DESCRIPTION
## Add TPIX Chain (chainId: 4289)

Adds TPIX Chain to the additional chain registry.

### Chain Details
- **Chain Name**: TPIX Chain
- - **Chain ID**: 4289
- - **Network ID**: 4289
- - **Native Currency**: TPIX (18 decimals)
- - **Consensus**: IBFT 2.0 (Polygon Edge)
- - **Block Time**: ~2 seconds
- - **Gas**: Zero gas fees
### Endpoints
- **RPC**: https://rpc.tpix.online (verified, returns correct chainId `0x10c1` = 4289)
- - **Block Explorer**: https://explorer.tpix.online (Blockscout, EIP-3091 standard)
- - **Website**: https://tpix.online
### Verification
- RPC responds correctly to `eth_chainId`, `net_version`, `eth_blockNumber`, `eth_getBlockByNumber`
- - Explorer is live and accessible (HTTP 200)
- - Website is live and accessible (HTTP 200)
- - Chain ID 4289 is not already registered
- - shortName `tpix` is not already taken
- - No EIP-1559 (no `baseFeePerGas` in blocks), only EIP-155 listed in features