### PR TITLE
Add Oxin Chain (4457)

### DIFF
--- a/constants/additionalChainRegistry/chainid-4457.js
+++ b/constants/additionalChainRegistry/chainid-4457.js
@@ -1,0 +1,29 @@
+export const data = {
+  "name": "Oxin Chain",
+  "chain": "OXIN",
+  "rpc": [
+    "https://rpc.oxinchain.io",
+    "https://rpc1.oxinchain.io",
+    "https://rpc2.oxinchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Oxin",
+    "symbol": "OXIN",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" }
+  ],
+  "infoURL": "https://oxinchain.io",
+  "shortName": "oxin",
+  "chainId": 4457,
+  "networkId": 4457,
+  "explorers": [
+    {
+      "name": "oxinscan",
+      "url": "https://scan.oxinchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Link the service provider's website:
https://oxinchain.io/

Provide a link to your privacy policy:
https://oxinchain.io/privacy-policy

If the RPC has none of the above and you still think it should be added, please explain why:
We are adding a new PoA-based EVM chain named Oxin Chain. These are our official public RPC nodes maintained by the core team to provide access to the network for our community and developers.