### PR TITLE
Fix KONET Mainnet icon resolution on ChainList

### DIFF
--- a/constants/additionalChainRegistry/chainid-17217.js
+++ b/constants/additionalChainRegistry/chainid-17217.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "KONET Mainnet",
+    "chain": "KONET",
+    "rpc": [
+        "https://api.kon-wallet.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "KONET",
+        "symbol": "KONET",
+        "decimals": 18
+    },
+    "infoURL": "https://konetmain.com",
+    "shortName": "KONET",
+    "chainId": 17217,
+    "networkId": 17217,
+    "slip44": 1,
+    "icon": "konet",
+    "explorers": [
+        {
+            "name": "konet-explorer",
+            "url": "https://konetexplorer.io/",
+            "standard": "EIP3091"
+        }
+    ]
+}

--- a/constants/additionalChainRegistry/chainid-17217.js
+++ b/constants/additionalChainRegistry/chainid-17217.js
@@ -19,7 +19,7 @@ export const data = {
     "explorers": [
         {
             "name": "konet-explorer",
-            "url": "https://konetexplorer.io/",
+            "url": "https://konetexplorer.io",
             "standard": "EIP3091"
         }
     ]


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://konetmain.com

#### Provide a link to your privacy policy:

No publicly linked privacy policy was found on the official KONET site or explorer page.

#### If the RPC has none of the above and you still think it should be added, please explain why:

This PR is not adding a new third-party RPC provider.

The existing KONET Mainnet RPC remains:

`https://api.kon-wallet.com`

This PR originally tracked KONET Mainnet metadata alignment for ChainList.

The explorer URL is now correctly reflected on chainlist.org:

- Chain ID: `17217` / `0x4341`
- Explorer URL: `https://konetexplorer.io`

The remaining issue is that the KONET chain icon is still not displayed on ChainList.

Local validation confirms that the KONET ChainList pages are generated correctly:

- `out/chain/17217.html`
- `out/chain/konet mainnet.html`
- `out/add-network/17217.html`
- `out/add-network/konet mainnet.html`

Build validation:

- `git rebase upstream/main`: succeeded
- `pnpm install`: succeeded
- `pnpm lint`: not available in this repository, `Command "lint" not found`
- `pnpm build`: succeeded

From the ChainList source, chain icons appear to be resolved through:

`https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg`

For KONET, the expected icon URL appears to be:

`https://icons.llamao.fi/icons/chains/rsz_konet.jpg`

I could not find a KONET icon asset inside this repository, so this appears to be an external icon asset / icons.llamao.fi pipeline issue rather than a local ChainList build issue.

Could you please confirm how the KONET icon asset should be added or refreshed for ChainList?