### PR TITLE
feat: add Seven Chain (chainId 70007)

### DIFF
--- a/constants/additionalChainRegistry/chainid-70007.js
+++ b/constants/additionalChainRegistry/chainid-70007.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "Seven Chain",
+  "chain": "SEVEN",
+  "rpc": [
+    "https://theseven.meme/api/seven-chain/jsonrpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Seven",
+    "symbol": "SEVEN",
+    "decimals": 18
+  },
+  "infoURL": "https://theseven.meme",
+  "shortName": "seven",
+  "chainId": 70007,
+  "networkId": 70007,
+  "explorers": [
+    {
+      "name": "Seven Chain Explorer",
+      "url": "https://theseven.meme/blockchain/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Adding Seven Chain (Chain ID: 70007)

**Seven Chain** is the settlement layer for [TheSeven.meme](https://theseven.meme) — the world's first on-chain immutable synthetic perpetual futures exchange.

### Chain Details
| Field | Value |
|---|---|
| Chain ID | 70007 |
| Native Currency | SEVEN (18 decimals) |
| RPC | https://theseven.meme/api/seven-chain/jsonrpc |
| Explorer | https://theseven.meme/blockchain/explorer |
| Network Type | L1 Mainnet |

### RPC Provider
- **Provider**: TheSeven.meme (self-hosted)
- **Privacy Policy**: https://theseven.meme
- **Endpoint**: https://theseven.meme/api/seven-chain/jsonrpc (HTTPS, public, no auth required)