### PR TITLE
Update PRC on chainid-1082.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-1082.js
+++ b/constants/additionalChainRegistry/chainid-1082.js
@@ -2,7 +2,7 @@ export const data = {
   "name": "Anannta",
   "chain": "ANANT",
   "rpc": [
-    "http://rpc-anant.ananntascan.io",
+    "https://rpc-anant.ananntascan.io",
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Hello Team,

I have successfully added the Anannta Chain to Chainlist, and the PR has already been merged. However, when adding the network to MetaMask via Chainlist, a warning symbol is still being displayed in the wallet.

Details:
Chain Name: Anannta
Chain ID: 1082
RPC URL: https://rpc-anant.ananntascan.io
Currency Symbol: ANANT
Issue:

Even after the chain is listed on Chainlist and added through it, MetaMask shows a warning indicating that the network may not be verified or trusted.

What I Checked:
RPC endpoint is working correctly
Chain ID is unique and properly configured
Network is successfully added and usable in MetaMask
Request:

Could you please verify if:

There is any additional verification step required from Chainlist’s side?
The registry entry needs any modification?
This warning is expected behavior from MetaMask despite Chainlist listing?

If needed, I can provide logs or additional details.

Thank you for your support.