### PR TITLE
Add SwiftNodes RPC endpoints for 35 EVM chains

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -67,6 +67,8 @@ const privacyStatement = {
   iota: "When you visit any of our websites or use any features or resources available on or through our websites. When you visit our website, your device and browser may automatically disclose certain information (such as device type, operating system, browser type, browser settings, IP address, language settings, dates and times of connecting to a website and other technical communications information), some of which may constitute Personal Data; https://www.iota.org/privacy-policy",
   markrgo:
     "We only collect the minimum necessary information to provide our blockchain RPC service (caching). We do not use your data for commercial purposes. Any collected data is short-term and will be automatically deleted within 24 hours if not actively used. https://www.markr.io/privacy-policy",
+  swiftnodes:
+    "SwiftNodes does not log IP addresses or correlate wallet transactions with request origins. Usage data (request counts) is collected per API key for rate limiting only. No personal information is stored. https://swiftnodes.io/docs/privacy-policy",
   diamondswap:
     "We record limited metadata from requests. This data is stored for a maximum of 90 days and is solely used for debugging, identifying suspicious activity, and generating analytics.",
   unifra:
@@ -575,6 +577,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/mainnet",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/eth",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -1102,6 +1110,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/bsc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   97: {
@@ -1281,6 +1295,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/avalanche",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/avalanche",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -1524,6 +1544,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/polygon",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   25: {
@@ -1582,6 +1608,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/cronos",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/cronos",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -1863,6 +1895,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/arbitrum-one",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/arbitrum",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -2208,6 +2246,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/blast",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   5611: {
@@ -2281,6 +2325,12 @@ export const extraRpcs = {
         url: "https://api-opbnb-mainnet.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/opbnb",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -2434,6 +2484,12 @@ export const extraRpcs = {
         url: "https://api-celo-mainnet-archive.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/celo",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -2648,6 +2704,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/optimism",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   11155420: {
@@ -2815,6 +2877,12 @@ export const extraRpcs = {
       },
       "https://api.blockeden.xyz/metis/67nCBdZQSH9z3YqDDjdm",
       "https://metis.rpc.hypersync.xyz/",
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/metis",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   59902: {
@@ -2918,6 +2986,12 @@ export const extraRpcs = {
         url: "wss://gnosis.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/gnosis",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -3067,6 +3141,12 @@ export const extraRpcs = {
         url: "https://moonriver.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/moonriver",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -3226,6 +3306,12 @@ export const extraRpcs = {
         url: "https://moonbeam.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/moonbeam",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -3876,6 +3962,12 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.tatum,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/etc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   //Morden testnet deprecated
@@ -4039,6 +4131,12 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.Hightower,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/monad",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   163: {
@@ -4173,6 +4271,12 @@ export const extraRpcs = {
         url: "wss://rpc.hairylabs.io/ws",
         tracking: "none",
         trackingDetails: privacyStatement.hairylabs,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/pulsechain",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -4884,6 +4988,12 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/kava",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   2559: {
@@ -4989,6 +5099,12 @@ export const extraRpcs = {
         url: "https://api-mantle-mainnet.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/mantle",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -5164,6 +5280,12 @@ export const extraRpcs = {
         url: "https://evmos.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/evmos",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -5535,6 +5657,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/base",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   11235: {
@@ -5725,6 +5853,12 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/scroll",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   88888: {
@@ -5743,6 +5877,12 @@ export const extraRpcs = {
         url: "https://api-chiliz-mainnet-archive.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/chiliz",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -6348,6 +6488,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/linea",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   2442: {
@@ -6566,6 +6712,12 @@ export const extraRpcs = {
         url: "https://taiko.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/taiko",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -6977,6 +7129,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/dymension",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   7070: {
@@ -7330,6 +7488,12 @@ export const extraRpcs = {
         url: "https://fraxtal.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/fraxtal",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -7910,6 +8074,12 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/sei",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   130: {
@@ -7964,6 +8134,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/unichain-mainnet",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/unichain",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -8265,6 +8441,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/sonic",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   57054: {
@@ -8334,6 +8516,12 @@ export const extraRpcs = {
         url: "https://story-json-rpc.stakely.io/",
         tracking: "none",
         trackingDetails: privacyStatement.Stakely,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/story",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -8457,6 +8645,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/berachain",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
   },
   2741: {
@@ -8519,6 +8713,12 @@ export const extraRpcs = {
         url: "https://rpc.sentio.xyz/soneium-mainnet",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/soneium",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },
@@ -9170,6 +9370,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.onfinality,
       },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/plasma",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
+      },
     ],
     websiteDead: false,
     rpcWorking: true,
@@ -9303,6 +9509,12 @@ export const extraRpcs = {
         url: "wss://katana.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    
+      {
+        url: "https://rpc.swiftnodes.io/rpc/katana",
+        tracking: "limited",
+        trackingDetails: privacyStatement.swiftnodes,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds [SwiftNodes](https://swiftnodes.io) as an RPC provider for 35 EVM chains in extraRpcs.js.

### About SwiftNodes

- Multi-chain RPC provider (53+ chains, EVM + non-EVM)
- Load-balanced across 500+ upstream nodes with health checking and auto-failover
- Free tier available, no KYC required
- Flat-rate monthly pricing (no per-request fees)

### Privacy

SwiftNodes does not log IP addresses or correlate wallet transactions with request origins. Usage data (request counts) is collected per API key for rate limiting only.

Full privacy policy: https://swiftnodes.io/docs/privacy-policy

### Links

- Website: https://swiftnodes.io
- Docs: https://swiftnodes.io/docs
- Support: https://t.me/SwiftNodesBot