### PR TITLE
Add Radius Network (723487) and Radius Testnet (72344)

### DIFF
--- a/constants/additionalChainRegistry/chainid-72344.js
+++ b/constants/additionalChainRegistry/chainid-72344.js
@@ -1,0 +1,31 @@
+export const data = {
+  name: "Radius Test Network",
+  chain: "RADIUS",
+  icon: "rad",
+  rpc: ["https://rpc.testnet.radiustech.xyz"],
+  faucets: ["https://testnet.radiustech.xyz/faucet"],
+  nativeCurrency: {
+    name: "Radius USD",
+    symbol: "RUSD",
+    decimals: 18,
+  },
+  features: [
+    {
+      name: "EIP155",
+    },
+    {
+      name: "EIP1559",
+    },
+  ],
+  infoURL: "https://radiustech.xyz",
+  shortName: "radius-network-testnet",
+  chainId: 72344,
+  networkId: 72344,
+  explorers: [
+    {
+      name: "Radius Test Network Explorer",
+      url: "https://testnet.radiustech.xyz",
+      standard: "none",
+    },
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-723487.js
+++ b/constants/additionalChainRegistry/chainid-723487.js
@@ -1,0 +1,31 @@
+export const data = {
+  name: "Radius Network",
+  chain: "RADIUS",
+  icon: "rad",
+  rpc: ["https://rpc.radiustech.xyz"],
+  faucets: [],
+  nativeCurrency: {
+    name: "Radius USD",
+    symbol: "RUSD",
+    decimals: 18,
+  },
+  features: [
+    {
+      name: "EIP155",
+    },
+    {
+      name: "EIP1559",
+    },
+  ],
+  infoURL: "https://radiustech.xyz",
+  shortName: "radius",
+  chainId: 723487,
+  networkId: 723487,
+  explorers: [
+    {
+      name: "Radius Network Explorer",
+      url: "https://network.radiustech.xyz",
+      standard: "none",
+    },
+  ],
+};


### PR DESCRIPTION
## Add Radius Network and Radius Test Network

Adding Radius Network mainnet and testnet to the chain registry.

### Radius Network (Mainnet)
| Field | Value |
|---|---|
| Chain ID | 723487 |
| Native Currency | Radius USD / RUSD (18 decimals) |
| RPC | https://rpc.radiustech.xyz |
| Explorer | https://network.radiustech.xyz |
| Website | https://radiustech.xyz |

### Radius Test Network
| Field | Value |
|---|---|
| Chain ID | 72344 |
| Native Currency | Radius USD / RUSD (18 decimals) |
| RPC | https://rpc.testnet.radiustech.xyz |
| Explorer | https://testnet.radiustech.xyz |
| Faucet | https://testnet.radiustech.xyz/faucet |
| Website | https://radiustech.xyz |

### RPC Provider
- **Provider**: Radius Technologies (self-hosted)
- **Privacy Policy**: https://www.radiustech.xyz/privacy-policy
- **Endpoints**: HTTPS, public, no auth required

### Verification
- Both RPC endpoints respond correctly to `eth_chainId` and `eth_blockNumber`
- Both block explorers are live and publicly accessible
- Testnet faucet is live with web UI and programmatic API
- Chain IDs 723487 and 72344 match existing ethereum-lists/chains registrations
- Files added to `constants/additionalChainRegistry/` per repo conventions
- Formatted with Prettier