### PR TITLE
Add Seven Chain mainnet (chainId: 70007)

### DIFF
--- a/_data/chains/eip155-70007.json
+++ b/_data/chains/eip155-70007.json
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Seven Chain",
+  "chain": "7chain",
+  "network": "mainnet",
+  "rpc": [
+    "https://theseven.meme/api/seven-chain/jsonrpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Seven",
+    "symbol": "SEVEN",
+    "decimals": 18
+  },
+  "infoURL": "https://theseven.meme",
+  "shortName": "7chain",
+  "chainId": 70007,
+  "networkId": 70007,
+  "explorers": [
+    {
+      "name": "Seven Chain Explorer",
+      "url": "https://theseven.meme/blockchain/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add Seven Chain (Chain ID: 70007)

**Seven Chain** is an EVM-compatible Layer-1 mainnet serving as the settlement layer for [TheSeven.meme](https://theseven.meme) — a perpetual futures exchange with 100+ trading pairs and up to 2001× leverage.

### Chain Details
- **Chain ID:** 70007 (0x11177)
- **Short name:** 7chain
- **Native Currency:** SEVEN (18 decimals)
- **Public RPC:** https://theseven.meme/api/seven-chain/jsonrpc
- **Explorer:** https://theseven.meme/blockchain/explorer
- **Info URL:** https://theseven.meme

### Verification
```bash
curl -X POST https://theseven.meme/api/seven-chain/jsonrpc \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# Returns: {"result":"0x11177",...}
```