### PR TITLE
Add Nexus Mainnet (chain ID 3946)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3946.js
+++ b/constants/additionalChainRegistry/chainid-3946.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "Nexus Mainnet",
+  chain: "NEX",
+  rpc: ["https://mainnet.rpc.nexus.xyz"],
+  faucets: [],
+  nativeCurrency: {
+    name: "Nexus",
+    symbol: "NEX",
+    decimals: 18,
+  },
+  infoURL: "https://nexus.xyz",
+  shortName: "nex",
+  chainId: 3946,
+  networkId: 3946,
+  icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
+  explorers: [
+    {
+      name: "Nexus Explorer",
+      url: "https://explorer.nexus.xyz",
+      icon: "https://framerusercontent.com/images/AeDwlPlZaXChRFVGExpfgFn1crs.png?width=433&height=497",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds Nexus Mainnet to the additional chain registry.

**Chain details:**
- Name: Nexus Mainnet
- Chain ID: 3946
- Network ID: 3946
- Symbol: NEX
- RPC: https://mainnet.rpc.nexus.xyz
- Explorer: https://explorer.nexus.xyz
- Info: https://nexus.xyz