### PR TITLE
feat: add AiFi (3600) metadata and RPC endpoints

### DIFF
--- a/constants/additionalChainRegistry/chainid-3600.js
+++ b/constants/additionalChainRegistry/chainid-3600.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "AiFinance Smart Chain",
+  "chain": "AiFi",
+  "rpc": [
+    "https://rpc.aifisc.io",
+    "https://rpc.ascscan.io",
+    "https://rpc.aifiv2.ai"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AIFI",
+    "symbol": "AIFI",
+    "decimals": 18
+  },
+  "infoURL": "https://aifisc.io/",
+  "shortName": "AiFi",
+  "chainId": 3600,
+  "networkId": 3600,
+  "explorers": [
+    {
+      "name": "AiFiScan",
+      "url": "https://ascscan.io/",
+      "standard": "EIP3091"
+    }
+  ]
+};

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3766,6 +3766,9 @@ export const extraRpcs = {
   35: {
     rpcs: ["https://rpc.tbwg.io"],
   },
+  3600: {
+    rpcs: ["https://rpc.aifisc.io", "https://rpc.ascscan.io", "https://rpc.aifiv2.ai"],
+  },
   38: {
     rpcs: ["https://rpc.valorbit.com/v2"],
     websiteDead: true,


### PR DESCRIPTION
### Description
This PR adds the metadata and official RPC endpoints for **AiFi** (ChainID: 3600).

### Changes
- Added `constants/additionalChainRegistry/chainid-3600.js` with chain details.
- Updated `constants/extraRpcs.js` to include high-availability RPC nodes.

### Verification
- [x] The RPC endpoint `https://rpc.aifisc.io` has been tested and returns the correct `chainId`.
- [x] Verified that the chain ID 3600 does not conflict with existing chains in the registry.
- [x] Ran `npm run lint` and no errors were found.
