### PR TITLE
Add Satelink public RPC for Polygon Amoy (80002)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -844,6 +844,7 @@ export const extraRpcs = {
   80002: {
     rpcs: [
       "https://rpc-amoy.polygon.technology",
+      "https://satelink-dashboard.vercel.app/gateway/rpc/amoy"
       {
         url: "https://polygon-bor-amoy-rpc.publicnode.com",
         tracking: "none",


### PR DESCRIPTION
## Summary
Adds Satelink DePIN Network as a public RPC provider for Polygon Amoy testnet.

## RPC Details
- **URL:** `https://rpc.satelink.network/rpc/amoy`
- **Chain ID:** 80002 (Polygon Amoy Testnet)
- **Tracking:** None — no user data collected
- **Rate Limit:** 100 requests/day (public tier, no key needed)

## Verification
```bash
curl -X POST https://rpc.satelink.network/rpc/amoy \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
```
Returns: {"jsonrpc":"2.0","id":1,"result":"0x..."}

## Provider
Satelink Network — Decentralized Physical Infrastructure (DePIN)
Website: https://satelink.network