### PR TITLE
Add AICChain Mainnet (Chain ID 3018)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3018.js
+++ b/constants/additionalChainRegistry/chainid-3018.js
@@ -1,0 +1,45 @@
+export const data = {
+  "name": "AICChain Mainnet",
+  "chain": "AIC",
+  "rpc": [
+    "https://rpc.aicchain.io"
+  ],
+  "wss": [
+    "wss://ws.aicchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AICChain",
+    "symbol": "AIC",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://www.aicchain.io",
+  "shortName": "aic",
+  "chainId": 3018,
+  "networkId": 3018,
+  "icon": "https://aic-assets.aicchain.io/Logo_Black.png",
+  "icons": [
+    {
+      "url": "https://aic-assets.aicchain.io/Logo_Black.png",
+      "width": 500,
+      "height": 500,
+      "format": "png"
+    }
+  ],
+  "explorers": [
+    {
+      "name": "AICChain Explorer",
+      "url": "https://scan.aicchain.io",
+      "icon": "aic",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-30181.js
+++ b/constants/additionalChainRegistry/chainid-30181.js
@@ -1,0 +1,45 @@
+export const data = {
+  "name": "AICChain Testnet",
+  "chain": "tAIC",
+  "rpc": [
+    "https://testrpc.aicchain.io"
+  ],
+  "wss": [
+    "wss://testws.aicchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AICChain Testnet",
+    "symbol": "tAIC",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://www.aicchain.io",
+  "shortName": "taic",
+  "chainId": 30181,
+  "networkId": 30181,
+  "icon": "https://aic-assets.aicchain.io/Logo_Black.png",
+  "icons": [
+    {
+      "url": "https://aic-assets.aicchain.io/Logo_Black.png",
+      "width": 500,
+      "height": 500,
+      "format": "png"
+    }
+  ],
+  "explorers": [
+    {
+      "name": "AICChain Testnet Explorer",
+      "url": "https://testscan.aicchain.io",
+      "icon": "aic",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add support for AICChain Mainnet with the following details:

Chain Name: AICChain Mainnet
Chain ID: 3018
RPC Endpoint: https://rpc.aicchain.io/
WebSocket: wss://ws.aicchain.io
Native Currency: AIC
Block Explorer: https://scan.aicchain.io/
Logo: https://aic-assets.aicchain.io/Logo_Black.png (500x500)
This PR adds the chainid-3018.js file to the additionalChainRegistry folder to enable AICChain Mainnet support on Chainlist.

If you are adding a new RPC, please answer the following questions.