### PR TITLE
Add AICChain Mainnet and Testnet to chainlist

### DIFF
--- a/constants/additionalChainRegistry/chainid-3018.js
+++ b/constants/additionalChainRegistry/chainid-3018.js
@@ -1,0 +1,45 @@
+export const data = {
+  "name": "AICChain Mainnet",
+  "chain": "AIC",
+  "rpc": [
+    "https://rpc.aicchain.io"
+  ],
+  "wss": [
+    "wss://ws.aicchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AICChain",
+    "symbol": "AIC",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://www.aicchain.io",
+  "shortName": "aic",
+  "chainId": 3018,
+  "networkId": 3018,
+  "icon": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
+  "icons": [
+    {
+      "url": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
+      "width": 192,
+      "height": 192,
+      "format": "png"
+    }
+  ],
+  "explorers": [
+    {
+      "name": "AICChain Explorer",
+      "url": "https://scan.aicchain.io",
+      "icon": "aic",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-3018.js
+++ b/constants/additionalChainRegistry/chainid-3018.js
@@ -26,14 +26,6 @@ export const data = {
   "chainId": 3018,
   "networkId": 3018,
   "icon": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
-  "icons": [
-    {
-      "url": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
-      "width": 192,
-      "height": 192,
-      "format": "png"
-    }
-  ],
   "explorers": [
     {
       "name": "AICChain Explorer",

--- a/constants/additionalChainRegistry/chainid-30181.js
+++ b/constants/additionalChainRegistry/chainid-30181.js
@@ -1,0 +1,45 @@
+export const data = {
+  "name": "AICChain Testnet",
+  "chain": "tAIC",
+  "rpc": [
+    "https://testrpc.aicchain.io"
+  ],
+  "wss": [
+    "wss://testws.aicchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AICChain Testnet",
+    "symbol": "tAIC",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://www.aicchain.io",
+  "shortName": "taic",
+  "chainId": 30181,
+  "networkId": 30181,
+  "icon": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
+  "icons": [
+    {
+      "url": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
+      "width": 192,
+      "height": 192,
+      "format": "png"
+    }
+  ],
+  "explorers": [
+    {
+      "name": "AICChain Testnet Explorer",
+      "url": "https://testscan.aicchain.io",
+      "icon": "aic",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-30181.js
+++ b/constants/additionalChainRegistry/chainid-30181.js
@@ -26,14 +26,6 @@ export const data = {
   "chainId": 30181,
   "networkId": 30181,
   "icon": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
-  "icons": [
-    {
-      "url": "https://aic-assets.aicchain.io/android-chrome-192x192.png",
-      "width": 192,
-      "height": 192,
-      "format": "png"
-    }
-  ],
   "explorers": [
     {
       "name": "AICChain Testnet Explorer",


### PR DESCRIPTION
Add support for AICChain Mainnet and Testnet networks to Chainlist

### Files Added
- `constants/additionalChainRegistry/chainid-3018.js` - AICChain Mainnet
- `constants/additionalChainRegistry/chainid-30181.js` - AICChain Testnet

### AICChain Mainnet (Chain ID 3018)
- **Network Name**: AICChain Mainnet
- **RPC Endpoint**: https://rpc.aicchain.io
- **WebSocket**: wss://ws.aicchain.io
- **Native Currency**: AIC (18 decimals)
- **Block Explorer**: https://scan.aicchain.io
- **Features**: EIP155, EIP1559

### AICChain Testnet (Chain ID 30181)
- **Network Name**: AICChain Testnet
- **RPC Endpoint**: https://testrpc.aicchain.io
- **WebSocket**: wss://testws.aicchain.io
- **Native Currency**: tAIC (18 decimals)
- **Block Explorer**: https://testscan.aicchain.io
- **Features**: EIP155, EIP1559

### Unified Logo
- Both networks use: https://aic-assets.aicchain.io/android-chrome-192x192.png (192x192)

### Benefits
- Users can easily add AICChain networks to MetaMask and other Web3 wallets
- RPC endpoints and explorers are readily available on chainlist.org
- Testnet enables development and testing before mainnet deployment
- Supports both EIP155 and EIP1559 standards

### Official Links
- Website: https://www.aicchain.io
- Mainnet Explorer: https://scan.aicchain.io
- Testnet Explorer: https://testscan.aicchain.io


#### Provide a link to your privacy policy:
https://aicchain.io/#/privacy

