### PR TITLE
Add Arc (chain ID 5042) to additionalChainRegistry

### DIFF
--- a/constants/additionalChainRegistry/chainid-5042.js
+++ b/constants/additionalChainRegistry/chainid-5042.js
@@ -1,0 +1,17 @@
+export const data = {
+  "name": "Arc",
+  "chain": "arc",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": 18
+  },
+  "infoURL": "https://www.arc.network/",
+  "shortName": "arc",
+  "chainId": 5042,
+  "networkId": 5042,
+  "icon": "arc",
+  "explorers": []
+}

--- a/constants/additionalChainRegistry/chainid-5042.js
+++ b/constants/additionalChainRegistry/chainid-5042.js
@@ -1,7 +1,7 @@
 export const data = {
   "name": "Arc",
   "chain": "arc",
-  "rpc": [],
+  "rpc": ["https://rpc.testnet.arc.network"],
   "faucets": [],
   "nativeCurrency": {
     "name": "USDC",
@@ -13,5 +13,5 @@ export const data = {
   "chainId": 5042,
   "networkId": 5042,
   "icon": "arc",
-  "explorers": []
+  "explorers": ["https://testnet.arcscan.app"]
 }


### PR DESCRIPTION
 # Add Arc Mainnet chainID 

Arc is a blockchain built by Circle where USDC is the native gas token, offering stable and predictable transaction fees with sub-second finality.

 ## Summary                                                                                                                                                                                                                                                                   
  - Add Arc mainnet (chain ID 5042) to the additional chain registry
  - More info: https://www.arc.network/

  ## Notes                                                                                                                                                                                                                                                                     
  - RPC endpoints and block explorer URLs are not yet available and will be filled in via a follow-up PR once they are publicly live