### PR TITLE
Fix USDC native currency decimals to 18 for Arc Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-5042002.js
+++ b/constants/additionalChainRegistry/chainid-5042002.js
@@ -6,7 +6,7 @@ export const data = {
   "nativeCurrency": {
     "name": "USDC",
     "symbol": "USDC",
-    "decimals": 6
+    "decimals": 18
   },
   "infoURL": "https://www.arc.network/",
   "shortName": "arc-testnet",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
  Update the native currency decimals from 6 to 18 for Arc testnet (5042002).                                                                                                                                                                      

  ## Details                                                                                                                                                                                                                                                                   
  Arc uses USDC as its native gas token with 18 decimals for native balances (same as ETH on Ethereum), not 6 decimals like ERC-20 USDC on other chains.                                                                                                                       

  Reference: https://docs.arc.network/arc/references/evm-compatibility                                                                                                                                                                                                         
  > "Native balances behave like ETH on Ethereum and are represented with 18 decimals."                                                                                                                                                                                        
