### PR TITLE
Add eGLOBLE Chain RPC (chainId: 224488)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -240,6 +240,14 @@ const privacyStatement = {
 };
 
 export const extraRpcs = {
+  224488: {
+    rpcs: [
+      {
+        url: 'https://rpc.egloble.site',
+        tracking: 'none',
+      },
+    ],
+  },
   1: {
     rpcs: [
       // Quicknode -> tracks IP


### PR DESCRIPTION
#### Link the service provider's website:
https://egloble.site

#### Provide a link to your privacy policy:
Our RPC does not collect or store any user data, 
IP addresses, or personal information. 
Tracking is set to 'none'.

#### If the RPC has none of the above, please explain why:
This is the native RPC of eGLOBLE Chain (ChainID: 224488), 
our own Layer 1 blockchain. No third-party tracking involved.