### PR TITLE
Add LiterMark Chain (chainId: 5232)

### DIFF
--- a/constants/additionalChainRegistry/chainid-5232.js
+++ b/constants/additionalChainRegistry/chainid-5232.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "LiterMark Chain",
+  "chain": "LMK",
+  "icon": "litermark",
+  "rpc": ["https://litermark.org/rpc"],
+  "features": [{ "name": "EIP155" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LiterMark",
+    "symbol": "LMK",
+    "decimals": 18
+  },
+  "infoURL": "https://litermark.com",
+  "shortName": "lmk",
+  "chainId": 5232,
+  "networkId": 5232,
+  "explorers": [
+    {
+      "name": "LMKscan",
+      "url": "https://litermark.org"
+    }
+  ]
+}


### PR DESCRIPTION
Add LiterMark Chain to the chainlist.

- Chain ID: 5232
- Native Currency: LMK (LiterMark)
- EVM Compatible
- Explorer: https://litermark.org
- Website: https://litermark.com

Already registered in ethereum-lists/chains (PR #8169, merged).