### PR TITLE
fix: Tempo currency

### DIFF
--- a/constants/additionalChainRegistry/chainid-4217.js
+++ b/constants/additionalChainRegistry/chainid-4217.js
@@ -10,9 +10,9 @@ export const data = {
   ],
   faucets: ["https://docs.tempo.xyz/quickstart/faucet"],
   nativeCurrency: {
-    name: "USD",
-    symbol: "USD",
-    decimals: 6,
+    name: "US Dollar",
+    symbol: "USD", 
+    decimals: 18,
   },
   infoURL: "https://tempo.xyz",
   shortName: "tempo-presto",

--- a/constants/additionalChainRegistry/chainid-42431.js
+++ b/constants/additionalChainRegistry/chainid-42431.js
@@ -1,13 +1,13 @@
 export const data = {
   name: "Tempo Testnet",
-  chain: "Tempo 42431",
-  icon: "tempotestnet",
+  chain: "Tempo",
+  icon: "tempo",
   rpc: ["https://rpc.testnet.tempo.xyz", "wss://rpc.testnet.tempo.xyz"],
   faucets: ["https://docs.tempo.xyz/quickstart/faucet"],
   nativeCurrency: {
-    name: "USD",
+    name: "US Dollar",
     symbol: "USD",
-    decimals: 6,
+    decimals: 18,
   },
   infoURL: "https://tempo.xyz",
   shortName: "tempo-moderato",
@@ -15,7 +15,7 @@ export const data = {
   networkId: 42431,
   explorers: [
     {
-      name: "Tempo Testnet explorer",
+      name: "Tempo Testnet Explorer",
       url: "https://explore.testnet.tempo.xyz",
       standard: "EIP3091",
     },


### PR DESCRIPTION
Made a mistake with the native cyrrebct decimals.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.