### PR TITLE
bugs: add iconVersion field for per-chain icon cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,6 @@ Submit a PR that adds a new file to the [constants/additionalChainRegistry folde
 }
 ```
 
-## Update a chain icon
-
-Chain icons are served from `https://icons.llamao.fi/icons/chains/rsz_<slug>.jpg` and may be cached by the CDN. If you've updated an icon in the icons repo but Chainlist still shows the old image, add an optional `iconVersion` field to your chain's override file:
-
-```
-{
-  ...
-  "icon": "ethereum",
-  "iconVersion": 2
-}
-```
-
-This appends `?v=<n>` to the icon URL, forcing the CDN to fetch a fresh copy. Bump the number on each subsequent update.
-
 ## Add an RPC to a chain that is already listed
 
 If you wish to add your RPC, please submit a PR modifying [constants/extraRpcs.js](https://github.com/DefiLlama/chainlist/blob/main/constants/extraRpcs.js) to add your RPC to the given chains.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Submit a PR that adds a new file to the [constants/additionalChainRegistry folde
 }
 ```
 
+## Update a chain icon
+
+Chain icons are served from `https://icons.llamao.fi/icons/chains/rsz_<slug>.jpg` and may be cached by the CDN. If you've updated an icon in the icons repo but Chainlist still shows the old image, add an optional `iconVersion` field to your chain's override file:
+
+```
+{
+  ...
+  "icon": "ethereum",
+  "iconVersion": 2
+}
+```
+
+This appends `?v=<n>` to the icon URL, forcing the CDN to fetch a fresh copy. Bump the number on each subsequent update.
+
 ## Add an RPC to a chain that is already listed
 
 If you wish to add your RPC, please submit a PR modifying [constants/extraRpcs.js](https://github.com/DefiLlama/chainlist/blob/main/constants/extraRpcs.js) to add your RPC to the given chains.

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import RPCList from "../RPCList";
-import { renderProviderText } from "../../utils";
+import { renderProviderText, getChainIcon } from "../../utils";
 import { useRouter } from "next/router";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
@@ -15,7 +15,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
   const router = useRouter();
 
   const icon = React.useMemo(() => {
-    return chain.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const chainId = useChain((state) => state.id);

--- a/constants/additionalChainRegistry/chainid-190415.js
+++ b/constants/additionalChainRegistry/chainid-190415.js
@@ -16,6 +16,7 @@ export const data = {
   "chainId": 190415,
   "networkId": 190415,
   "icon": "ethereum",
+  "iconVersion": 2,
   "explorers": [{
     "name": "HPP Mainnet Explorer",
     "url": "https://explorer.hpp.io",

--- a/pages/add-network/[chain].js
+++ b/pages/add-network/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../utils";
+import { notTranslation as useTranslations, getChainIcon } from "../../utils";
 import { populateChain, fetchWithCache } from "../../utils/fetch";
 import AddNetwork from "../../components/chain";
 import Layout from "../../components/Layout";
@@ -71,7 +71,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "en");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const chainName = chain.name === "OP Mainnet" ? "Optimism Maninnet" : chain.name;

--- a/pages/chain/[chain].js
+++ b/pages/chain/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../utils";
+import { notTranslation as useTranslations, getChainIcon } from "../../utils";
 import { populateChain, fetchWithCache } from "../../utils/fetch";
 import AddNetwork from "../../components/chain";
 import Layout from "../../components/Layout";
@@ -85,7 +85,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "en");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const { data: blockGasLimit } = useQuery({

--- a/pages/zh/chain/[chain].js
+++ b/pages/zh/chain/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../../utils";
+import { notTranslation as useTranslations, getChainIcon } from "../../../utils";
 import { populateChain, fetchWithCache } from "../../../utils/fetch";
 import AddNetwork from "../../../components/chain";
 import Layout from "../../../components/Layout";
@@ -72,7 +72,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "zh");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   return (

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,6 +2,12 @@ import { useState, useEffect } from "react";
 import en from "../translations/en.json" with { type: "json" };
 import zh from "../translations/zh.json" with { type: "json" };
 
+export function getChainIcon(chain) {
+  if (!chain?.chainSlug) return "/unknown-logo.png";
+  const base = `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg`;
+  return chain.iconVersion ? `${base}?v=${chain.iconVersion}` : base;
+}
+
 export function formatCurrency(amount, decimals = 2) {
   if (!isNaN(amount)) {
     const formatter = new Intl.NumberFormat(undefined, {


### PR DESCRIPTION
#2628

Adds an optional iconVersion field to chain override files. When set, appends ?v=<n> to the chain icon URL, forcing the CDN to serve a fresh copy. Chains without the field are unaffected.

Proof that it has been tested locally.
<img width="859" height="722" alt="Screenshot 2026-04-28 at 11 11 52" src="https://github.com/user-attachments/assets/fe21cd41-ea02-4ff9-920f-78a04dbd03d0" />
