### PR TITLE
Add SuperAIChain Mainnet (chainId 19998)

### DIFF
--- a/constants/additionalChainRegistry/chainid-19998.js
+++ b/constants/additionalChainRegistry/chainid-19998.js
@@ -1,0 +1,26 @@
+export const data = {
+  name: "SuperAIChain Mainnet",
+  chain: "SuperAIChain",
+  icon: "https://ipfs.io/ipfs/bafkreiendbioz6nnvlmwyv5zfqzsh2m5pdz47vrjlmhjve5vflk7yshyye",
+  rpc: ["https://rpc.superaichain.ai"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "SUP",
+    symbol: "SUP",
+    decimals: 18,
+  },
+  infoURL: "https://superaichain.ai",
+  shortName: "sup",
+  chainId: 19998,
+  networkId: 19998,
+  slip44: 60,
+  explorers: [
+    {
+      name: "SuperAIChain Explorer",
+      url: "https://scan.superaichain.ai",
+      standard: "EIP3091",
+    },
+  ],
+  status: "active",
+};


### PR DESCRIPTION
Add support for SuperAIChain Mainnet (Chain ID 19998) to Chainlist.

### Files Added
- `constants/additionalChainRegistry/chainid-19998.js` — SuperAIChain Mainnet

### SuperAIChain Mainnet (Chain ID 19998)
- **Network Name**: SuperAIChain Mainnet
- **Chain ID**: 19998 (hex `0x4e1e`)
- **RPC Endpoint**: https://rpc.superaichain.ai
- **Native Currency**: SUP (18 decimals)
- **Block Explorer**: https://scan.superaichain.ai (EIP-3091 compliant)
- **Features**: EIP155, EIP1559
- **Architecture**: Cosmos SDK + cosmos/evm Layer 1, fully MetaMask JSON-RPC compatible
- **Mainnet status**: Live since January 2026 (4+ months stable)

### Already in ethereum-lists/chains
This chain is already officially registered in `ethereum-lists/chains` as of 2026-04-27 (PR #8247 merged):
https://github.com/ethereum-lists/chains/pull/8247

The canonical chain data is therefore served via `chainid.network/chains.json`. This PR adds the same chain to chainlist.org's own additional registry so users can discover and add SuperAIChain to their wallet directly from chainlist.org without waiting for the next data sync.

### Verified
- RPC `eth_chainId` returns `0x4e1e` (= 19998)
- Block explorer is live at https://scan.superaichain.ai
- Manual "Add Custom Network" works on MetaMask, TokenPocket, imToken (signing, transactions, explorer redirect all confirmed)

### Official Links
- Website: https://www.superaichain.ai
- Block Explorer: https://scan.superaichain.ai
- ethereum-lists registration: https://github.com/ethereum-lists/chains/pull/8247
- Logo (1024×1024 PNG, IPFS): ipfs://bafkreiendbioz6nnvlmwyv5zfqzsh2m5pdz47vrjlmhjve5vflk7yshyye