### PR TITLE
Add Ruby Chain Testnet (chainId 1810)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1810.js
+++ b/constants/additionalChainRegistry/chainid-1810.js
@@ -1,0 +1,35 @@
+export const data = {
+  "name": "Ruby Chain Testnet",
+  "title": "Ruby Chain Testnet",
+  "shortName": "ruby-testnet",
+  "chain": "RUBY",
+  "rpc": [
+    "https://rpc.ruby.testnet.finetry.win",
+    "https://rpc2.ruby.testnet.finetry.win"
+  ],
+  "faucets": [
+    "https://faucet.ruby.testnet.finetry.win"
+  ],
+  "nativeCurrency": {
+    "name": "Ruby",
+    "symbol": "RUBY",
+    "decimals": 18
+  },
+  "infoURL": "https://elektrum.io",
+  "chainId": 1810,
+  "networkId": 1810,
+  "explorers": [
+    {
+      "name": "Ruby Chain Explorer",
+      "url": "https://explorer.ruby.testnet.finetry.win",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": []
+  },
+  "icon": "https://ipfs.io/ipfs/bafkreickc2hgej3bjhlj24k7dqupsrki3cp7xpzrj25s3g46iltteufi7i",
+  "status": "active"
+};


### PR DESCRIPTION
Adds **Ruby Chain Testnet** (chainId `1810`).

## What

OP Stack L2 testnet running on Ethereum Sepolia, with **RUBY** as the native gas token (using OP Stack's Custom Gas Token mode).

## Endpoints

| Service | URL |
|---|---|
| RPC | https://rpc.ruby.testnet.finetry.win |
| RPC (alternate) | https://rpc2.ruby.testnet.finetry.win |
| Explorer | https://explorer.ruby.testnet.finetry.win |
| Faucet | https://faucet.ruby.testnet.finetry.win |

## Verification

```bash
curl -X POST https://rpc.ruby.testnet.finetry.win \
  -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# {"jsonrpc":"2.0","id":1,"result":"0x712"}   (1810)
```

## Already in ethereum-lists/chains

This chain was already merged into [ethereum-lists/chains#8267](https://github.com/ethereum-lists/chains/pull/8267). This PR adds it to chainlist.org as well.

## Operator

Elektrum SAS — https://elektrum.io