### PR TITLE
feat(ux): no-results empty state, consistent search debounce, table a11y polish

### DIFF
--- a/components/RPCList/index.js
+++ b/components/RPCList/index.js
@@ -106,12 +106,12 @@ export default function RPCList({ chain, lang }) {
         </caption>
         <thead>
           <tr>
-            <th className="px-3 py-1 font-medium border">RPC Server Address</th>
-            <th className="px-3 py-1 font-medium border">Height</th>
-            <th className="px-3 py-1 font-medium border">Latency</th>
-            <th className="px-3 py-1 font-medium border">Score</th>
-            <th className="px-3 py-1 font-medium border">Privacy</th>
-            <th className="px-3 py-1 font-medium border"></th>
+            <th scope="col" className="px-3 py-1 font-medium border">RPC Server Address</th>
+            <th scope="col" className="px-3 py-1 font-medium border">Height</th>
+            <th scope="col" className="px-3 py-1 font-medium border">Latency</th>
+            <th scope="col" className="px-3 py-1 font-medium border">Score</th>
+            <th scope="col" className="px-3 py-1 font-medium border">Privacy</th>
+            <th scope="col" className="px-3 py-1 font-medium border"></th>
           </tr>
         </thead>
 

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -54,6 +54,7 @@ function Header({ lang, chainName, setChainName }) {
                   }}
                   onKeyUp={(event) => {
                     clearTimeout(timeout.current);
+                    // 300ms — fast enough to feel instant, slow enough to skip per-keystroke navigation
                     timeout.current = setTimeout(() => {
                       router
                         .push(
@@ -67,7 +68,7 @@ function Header({ lang, chainName, setChainName }) {
                         .then(() => {
                           clearTimeout(timeout.current);
                         });
-                    }, 1000);
+                    }, 300);
                   }}
                   className="dark:bg-[#0D0D0D] bg-white dark:text-[#B3B3B3] text-black flex-1 px-3 sm:px-2 pb-4 pt-2 sm:py-4 outline-none"
                 />
@@ -78,6 +79,7 @@ function Header({ lang, chainName, setChainName }) {
                   defaultValue={search ?? ""}
                   onKeyUp={(event) => {
                     clearTimeout(timeout.current);
+                    // 300ms — fast enough to feel instant, slow enough to skip per-keystroke navigation
                     timeout.current = setTimeout(() => {
                       router
                         .push(
@@ -91,7 +93,7 @@ function Header({ lang, chainName, setChainName }) {
                         .then(() => {
                           clearTimeout(timeout.current);
                         });
-                    }, 100);
+                    }, 300);
                   }}
                   className="dark:bg-[#0D0D0D] bg-white dark:text-[#B3B3B3] text-black flex-1 px-3 sm:px-2 pb-4 pt-2 sm:py-4 outline-none"
                 />
@@ -113,7 +115,13 @@ function Header({ lang, chainName, setChainName }) {
           </div>
           <div className="dark:text-[#B3B3B3] text-black py-2 px-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <label className="flex items-center gap-2">
-              <input type="checkbox" name="testnets" checked={includeTestnets} onChange={toggleTestnets} />
+              <input
+                type="checkbox"
+                name="testnets"
+                aria-label="Include Testnets"
+                checked={includeTestnets}
+                onChange={toggleTestnets}
+              />
               <span>Include Testnets</span>
             </label>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,17 +36,24 @@ function Home({ chains }) {
 
       <Layout chainName={chainName} setChainName={setChainName}>
         <React.Suspense fallback={<div className="h-screen"></div>}>
-          <div className="dark:text-[#B3B3B3] text-black grid gap-5 grid-cols-1 place-content-between pb-4 sm:pb-10 sm:grid-cols-[repeat(auto-fit,_calc(50%_-_15px))] 3xl:grid-cols-[repeat(auto-fit,_calc(33%_-_20px))] isolate grid-flow-dense">
-            {finalChains.slice(0, 2).map((chain) => {
-              return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
-            })}
-            <AdBanner />
-            {finalChains.slice(2, end).map((chain) => {
-              return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
-            })}
-          </div>
+          {finalChains.length === 0 ? (
+            <div className="dark:text-[#B3B3B3] text-black flex flex-col items-center justify-center gap-2 py-16 text-center">
+              <p className="text-lg font-medium">No chains found</p>
+              <p className="text-sm opacity-70">Try a different search term, or remove filters to see all chains.</p>
+            </div>
+          ) : (
+            <div className="dark:text-[#B3B3B3] text-black grid gap-5 grid-cols-1 place-content-between pb-4 sm:pb-10 sm:grid-cols-[repeat(auto-fit,_calc(50%_-_15px))] 3xl:grid-cols-[repeat(auto-fit,_calc(33%_-_20px))] isolate grid-flow-dense">
+              {finalChains.slice(0, 2).map((chain) => {
+                return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
+              })}
+              <AdBanner />
+              {finalChains.slice(2, end).map((chain) => {
+                return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
+              })}
+            </div>
+          )}
         </React.Suspense>
-        {end < finalChains.length ? (
+        {finalChains.length > 0 && end < finalChains.length ? (
           <button
             onClick={() => setEnd(finalChains.length)}
             className="w-full border dark:border-[#171717] border-[#EAEAEA] px-4 py-2 rounded-[50px] mb-auto text-white bg-[#2F80ED] mx-auto"


### PR DESCRIPTION
Three small UX and accessibility fixes on chainlist.org.

## 1. No-results empty state

`pages/index.js` previously rendered an empty grid when the search returned zero chains, leaving users staring at a blank screen. Added a friendly "No chains found" empty state with a brief hint to try a different term or clear filters. Renders only when `finalChains.length === 0`.

## 2. Consistent search debounce

`components/header/index.js` had two copy-pasted search-input branches with drifted debounce timeouts: 1000ms in the `setChainName` branch and 100ms in the `defaultValue` branch. The 1000ms branch felt sluggish; the 100ms branch hammered `router.push` on every keystroke. Both branches now use a single 300ms value — fast enough to feel instant, slow enough to skip per-keystroke history pollution.

## 3. Table accessibility polish

- `components/RPCList/index.js`: added `scope="col"` to the RPC table header cells. Screen readers can now reliably associate each cell with its column.
- `components/header/index.js`: added `aria-label="Include Testnets"` to the testnet checkbox so its purpose is exposed without depending on adjacent visible text alone.

No behavioral change beyond the empty-state UI. No dependencies touched.