### PR TITLE
fix: replace defunct Sepolia faucet URL and remove leaked Alchemy key

### DIFF
--- a/constants/additionalChainRegistry/chainid-11155111.js
+++ b/constants/additionalChainRegistry/chainid-11155111.js
@@ -1,0 +1,49 @@
+export const data = {
+  "name": "Ethereum Sepolia",
+  "title": "Ethereum Testnet Sepolia",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.sepolia.org",
+    "https://rpc2.sepolia.org",
+    "https://rpc.sepolia.ethpandaops.io",
+    "https://sepolia.infura.io/v3/${INFURA_API_KEY}",
+    "wss://sepolia.infura.io/v3/${INFURA_API_KEY}",
+    "https://sepolia.gateway.tenderly.co",
+    "wss://sepolia.gateway.tenderly.co",
+    "https://ethereum-sepolia-rpc.publicnode.com",
+    "wss://ethereum-sepolia-rpc.publicnode.com",
+    "https://sepolia.drpc.org",
+    "wss://sepolia.drpc.org"
+  ],
+  "faucets": [
+    "https://sepolia-faucet.pk910.de",
+    "https://cloud.google.com/application/web3/faucet/ethereum/sepolia"
+  ],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://sepolia.otterscan.io",
+  "shortName": "sep",
+  "chainId": 11155111,
+  "networkId": 11155111,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "etherscan-sepolia",
+      "url": "https://sepolia.etherscan.io",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "otterscan-sepolia",
+      "url": "https://sepolia.otterscan.io",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Routescan",
+      "url": "https://11155111.testnet.routescan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Fixes #2567

The faucet URL for Ethereum Sepolia (chainId 11155111) pointed to 
`fauceth.komputing.org` — a defunct faucet whose domain expired and 
was squatted by a gambling/unrelated website. This affected anyone 
using Chainlist to configure Sepolia testnet.

Additionally, the upstream `chainid.network/chains.json` entry 
contained a hardcoded Alchemy API key in the RPC list which has 
been removed from the override.

## Changes

- Added `constants/additionalChainRegistry/chainid-11155111.js` to 
  override the upstream Sepolia entry
- Replaced broken faucet with two working alternatives:
  - `https://sepolia-faucet.pk910.de` (community PoW faucet, stable)
  - `https://cloud.google.com/application/web3/faucet/ethereum/sepolia`
- Removed hardcoded Alchemy API key from RPC list
- All other chain data (explorers, currency, chainId) kept identical 
  to upstream

## RPC template questions (N/A)

This PR does not add a new RPC — it fixes a broken faucet URL and 
removes a leaked API key. RPC template questions are not applicable.