### PR TITLE
Fix chain 988 slug: `seda` -> `stable` (closes #2650)

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,7 +102,7 @@ export default {
   "888": "wanchain",
   "957": "lyra",
   "964": "bittensor_evm",
-  "988": "seda",
+  "988": "stable",
   "996": "bifrost",
   "999": "hyperliquid",
   "1024": "clv",


### PR DESCRIPTION
## What

\`constants/chainIds.js\` line 105 had \`\"988\": \"seda\"\`. Chain ID 988 is Stable Mainnet, not SEDA.

## Verification on current main

\`constants/additionalChainRegistry/chainid-988.js\` already declares this chain correctly:

\`\`\`js
export const data = {
  name: \"Stable Mainnet\",
  chain: \"stable\",
  rpc: [\"https://rpc.stable.xyz\"],
  ...
  shortName: \"stable\",
  chainId: 988,
  networkId: 988,
  ...
};
\`\`\`

So the registry says \`chain: \"stable\"\` but \`chainIds.js\` mapped 988 to \`seda\`, breaking the slug join.

\`grep -n seda constants/chainIds.js\` returns only line 105 — the value isn't referenced elsewhere, so the rename is contained.

## How

One-line edit:

\`\`\`diff
-  \"988\": \"seda\",
+  \"988\": \"stable\",
\`\`\`

## History

Bad mapping was introduced in commit \`84b1f11f\` (2026-01-16) alongside the \`964: bittensor_evm\` entry. No prior PR has corrected it; the issue reporter on #2650 said they couldn't submit one themselves.