### PR TITLE
Add Ruby Chain Testnet slug for icon (chainId 1810)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1810.js
+++ b/constants/additionalChainRegistry/chainid-1810.js
@@ -1,0 +1,35 @@
+export const data = {
+  "name": "Ruby Chain Testnet",
+  "title": "Ruby Chain Testnet",
+  "shortName": "ruby-testnet",
+  "chain": "RUBY",
+  "rpc": [
+    "https://rpc.ruby.testnet.finetry.win",
+    "https://rpc2.ruby.testnet.finetry.win"
+  ],
+  "faucets": [
+    "https://faucet.ruby.testnet.finetry.win"
+  ],
+  "nativeCurrency": {
+    "name": "Ruby",
+    "symbol": "RUBY",
+    "decimals": 18
+  },
+  "infoURL": "https://elektrum.io",
+  "chainId": 1810,
+  "networkId": 1810,
+  "explorers": [
+    {
+      "name": "Ruby Chain Explorer",
+      "url": "https://explorer.ruby.testnet.finetry.win",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": []
+  },
+  "icon": "https://ipfs.io/ipfs/bafkreickc2hgej3bjhlj24k7dqupsrki3cp7xpzrj25s3g46iltteufi7i",
+  "status": "active"
+};

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -125,6 +125,7 @@ export default {
   "1559": "tenet",
   "1625": "gravity",
   "1729": "reya network",
+  "1810": "ruby",
   "1818": "cube",
   "1868": "soneium",
   "1890": "lightlink",


### PR DESCRIPTION
Maps **chainId 1810 (Ruby Chain Testnet)** to slug `ruby` so chainlist.org resolves the icon via DefiLlama's CDN at `https://icons.llamao.fi/icons/chains/rsz_ruby.jpg`.

## Context

Ruby Chain Testnet was added in #2697 (already merged). It now appears in the listing but without an icon because `constants/chainIds.js` doesn't have an entry for 1810.

This PR adds the slug mapping. Same pattern as cube (1818), soneium (1868), swellchain (1923).

## About Ruby Chain

OP Stack L2 testnet on Ethereum Sepolia. Native gas token RUBY (Custom Gas Token mode). Operated by Elektrum SAS — https://elektrum.io.

| Service | URL |
|---|---|
| RPC | https://rpc.ruby.testnet.finetry.win |
| Explorer | https://explorer.ruby.testnet.finetry.win |
| Faucet | https://faucet.ruby.testnet.finetry.win |

Already merged in [ethereum-lists/chains#8267](https://github.com/ethereum-lists/chains/pull/8267).

## Note about the icon CDN

The icon at `icons.llamao.fi/icons/chains/rsz_ruby.jpg` will return 404 until DefiLlama's icon pipeline picks it up. If a separate process/repo is needed to upload the icon to that CDN, please advise — happy to submit there too.