### PR TITLE
Fix Stable chain slug

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,7 +102,7 @@ export default {
   "888": "wanchain",
   "957": "lyra",
   "964": "bittensor_evm",
-  "988": "seda",
+  "988": "stable",
   "996": "bifrost",
   "999": "hyperliquid",
   "1024": "clv",


### PR DESCRIPTION
## Summary
- update chainId 988 in constants/chainIds.js from seda to stable
- keep the slug aligned with constants/additionalChainRegistry/chainid-988.js, which already uses Stable metadata

Closes #2650.

## Validation
- ONLY_LIST_FILE=1 ./scripts/build.sh
- yarn test
- node --input-type=module -e "import('./constants/chainIds.js').then(({default: ids}) => { if (ids['988'] !== 'stable') throw new Error(ids['988']); console.log(ids['988']); })"