### PR TITLE
Add Sentrix Chain (mainnet 7119, testnet 7120)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7119.js
+++ b/constants/additionalChainRegistry/chainid-7119.js
@@ -19,11 +19,6 @@ export const data = {
       {
         "name": "Sentrix Scan",
         "url": "https://scan.sentrixchain.com",
-        "standard": "none"
-      },
-      {
-        "name": "Blockscout",
-        "url": "https://blockscout.sentrixchain.com",
         "standard": "EIP3091"
       }
     ]

--- a/constants/additionalChainRegistry/chainid-7119.js
+++ b/constants/additionalChainRegistry/chainid-7119.js
@@ -1,0 +1,30 @@
+export const data = {
+    "name": "Sentrix Chain",
+    "chain": "SRX",
+    "rpc": [
+      "https://rpc.sentrixchain.com"
+    ],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Sentrix",
+      "symbol": "SRX",
+      "decimals": 18
+    },
+    "infoURL": "https://sentrixchain.com",
+    "shortName": "srx",
+    "chainId": 7119,
+    "networkId": 7119,
+    "explorers": [
+      {
+        "name": "Sentrix Scan",
+        "url": "https://scan.sentrixchain.com",
+        "standard": "none"
+      },
+      {
+        "name": "Blockscout",
+        "url": "https://blockscout.sentrixchain.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/additionalChainRegistry/chainid-7120.js
+++ b/constants/additionalChainRegistry/chainid-7120.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "Sentrix Testnet",
+    "chain": "SRX",
+    "rpc": [
+      "https://testnet-rpc.sentrixchain.com"
+    ],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": [
+      "https://faucet.sentrixchain.com"
+    ],
+    "nativeCurrency": {
+      "name": "Sentrix Testnet",
+      "symbol": "tSRX",
+      "decimals": 18
+    },
+    "infoURL": "https://sentrixchain.com",
+    "shortName": "srx-testnet",
+    "chainId": 7120,
+    "networkId": 7120,
+    "explorers": [
+      {
+        "name": "Sentrix Scan (Testnet)",
+        "url": "https://scan.sentrixchain.com",
+        "standard": "none"
+      }
+    ]
+  }


### PR DESCRIPTION
Adding Sentrix Chain — open-source Rust L1 with DPoS+BFT consensus and EVM compatibility (revm).

**Mainnet** (`chainid-7119.js`): chainId 7119, RPC https://rpc.sentrixchain.com  
**Testnet** (`chainid-7120.js`): chainId 7120, RPC https://testnet-rpc.sentrixchain.com

**Block explorers (both registered):**
- Sentrix Scan: https://scan.sentrixchain.com (custom Next.js explorer, `standard: "none"`)
- Blockscout: https://blockscout.sentrixchain.com (`standard: "EIP3091"`)

**Project:** [github.com/sentrix-labs/sentrix](https://github.com/sentrix-labs/sentrix) — solo-built, BUSL-1.1 licensed, mainnet live since 2026-04 with 4 active validators.

JSON validated locally — both files parse cleanly via dynamic import. `shortName` (`srx`, `srx-testnet`) and `chainId` (7119, 7120) verified unique against existing chainids in this repo.

A companion PR is open at ethereum-lists/chains#8266 (currently in review).