### PR TITLE
Add Mars Chain Testnet (chainId 704852)

### DIFF
--- a/constants/additionalChainRegistry/chainid-704852.js
+++ b/constants/additionalChainRegistry/chainid-704852.js
@@ -1,0 +1,33 @@
+export const data = {
+  "name": "Mars Chain Testnet",
+  "title": "Mars Chain Testnet",
+  "shortName": "marschain-testnet",
+  "chain": "MARS",
+  "rpc": [
+    "https://rpc-testnet.mars-scan.io",
+    "wss://rpc-testnet.mars-scan.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Mars Coin",
+    "symbol": "MarsC",
+    "decimals": 18
+  },
+  "infoURL": "https://testnet-explorer.mars-chain.io/",
+  "chainId": 704852,
+  "networkId": 704852,
+  "explorers": [
+    {
+      "name": "Mars Chain Testnet Explorer",
+      "url": "https://testnet-explorer.mars-chain.io/",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": []
+  },
+  "icon": "https://ipfs.io/ipfs/bafkreiahnorlibpuklbzedc3x3lw6mqry2kjmaqh3rtkdlw2ydpom2gs7y",
+  "status": "active"
+};

--- a/constants/additionalChainRegistry/chainid-704852.js
+++ b/constants/additionalChainRegistry/chainid-704852.js
@@ -4,8 +4,8 @@ export const data = {
   "shortName": "marschain-testnet",
   "chain": "MARS",
   "rpc": [
-    "https://rpc-testnet.mars-scan.io",
-    "wss://rpc-testnet.mars-scan.io"
+    "https://testnet-rpc.mars-chain.io",
+    "wss://testnet-rpc.mars-chain.io"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Arbitrum Orbit Stack L2 testnet on Ethereum Sepolia. Native gas token MarsC (Custom Gas Token mode). Operated by XINFINITY.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://altlayer.io/

#### Provide a link to your privacy policy:
https://mars-chain.io/privacy-policy

AltLayer RaaS Nodes don't log and personal user data neither we don't store or log any user data on our end.

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.