### PR TITLE
Update rpc/explorer url for Arc mainnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-5042.js
+++ b/constants/additionalChainRegistry/chainid-5042.js
@@ -1,7 +1,7 @@
 export const data = {
   "name": "Arc",
   "chain": "arc",
-  "rpc": ["https://rpc.testnet.arc.network"],
+  "rpc": ["https://rpc.arc.network"],
   "faucets": [],
   "nativeCurrency": {
     "name": "USDC",
@@ -13,5 +13,5 @@ export const data = {
   "chainId": 5042,
   "networkId": 5042,
   "icon": "arc",
-  "explorers": ["https://testnet.arcscan.app"]
+  "explorers": ["https://arcscan.app"]
 }


### PR DESCRIPTION
 # Update Arc Mainnet RPC/explorer 

Arc is a blockchain built by Circle where USDC is the native gas token, offering stable and predictable transaction fees with sub-second finality.

 ## Summary                                                                                                                                                                                                                                                                   
  - Update Arc mainnet RPC and explorer to the mainnet ones.
  - More info: https://www.arc.network/

  ## Notes                                                                                                                                                                                                                                                                     
  - We have reserved these domains and will use them as Arc mainnet RPC/explorer url once public live.