### PR TITLE
Add Sentrix mainnet (7119) to chainIds slug map

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -179,6 +179,7 @@ export default {
   "6969": "tombchain",
   "7000": "zetachain",
   "7070": "planq",
+  "7119": "sentrix",
   "7171": "bitrock",
   "7200": "xsat",
   "7332": "horizen_eon",


### PR DESCRIPTION
Adds the chainSlug entry for Sentrix Chain mainnet (chain ID 7119) so the chain card on chainlist.org resolves the icon CDN URL (`icons.llamao.fi/icons/chains/rsz_sentrix.jpg`) instead of falling back to `/unknown-logo.png`.

**Context:**
- The Sentrix Chain entries (`chainid-7119.js`, `chainid-7120.js`) were merged via #2707.
- Without an entry in `constants/chainIds.js`, `populateChain()` leaves `chainSlug` undefined and `components/chain/index.js` falls back to the diamond placeholder.

**Companion PR:**
- DefiLlama/icons (branch `v2`) — adding `assets/chains/rsz_sentrix.png` so the CDN actually serves a thumbnail. Linked in the comments below once opened.

**Verification (post-merge expected):**
- `https://icons.llamao.fi/icons/chains/rsz_sentrix.jpg` should return 200 image/webp
- chainlist.org chain card for ID 7119 should render the Sentrix mark instead of the Ethereum diamond

Single-line addition, sorted between `7070` (planq) and `7171` (bitrock).