### PR TITLE
fix(sentrix): testnet explorer URL + EIP3091 compliance

### DIFF
--- a/constants/additionalChainRegistry/chainid-7120.js
+++ b/constants/additionalChainRegistry/chainid-7120.js
@@ -9,8 +9,8 @@ export const data = {
       "https://faucet.sentrixchain.com"
     ],
     "nativeCurrency": {
-      "name": "Sentrix Testnet",
-      "symbol": "tSRX",
+      "name": "Sentrix",
+      "symbol": "SRX",
       "decimals": 18
     },
     "infoURL": "https://sentrixchain.com",

--- a/constants/additionalChainRegistry/chainid-7120.js
+++ b/constants/additionalChainRegistry/chainid-7120.js
@@ -20,8 +20,8 @@ export const data = {
     "explorers": [
       {
         "name": "Sentrix Scan (Testnet)",
-        "url": "https://scan.sentrixchain.com",
-        "standard": "none"
+        "url": "https://scan-testnet.sentrixchain.com",
+        "standard": "EIP3091"
       }
     ]
   }


### PR DESCRIPTION
Two small follow-ups to #2707 — both touch `constants/additionalChainRegistry/chainid-7120.js`.

## What changed

### 1. Testnet explorer URL + EIP3091 (commit `7c48cb9`)

```diff
   "explorers": [
     {
       "name": "Sentrix Scan (Testnet)",
-      "url": "https://scan.sentrixchain.com",
-      "standard": "none"
+      "url": "https://scan-testnet.sentrixchain.com",
+      "standard": "EIP3091"
     }
   ]
```

URL was pointing to the mainnet host, so wallet deep-links to testnet tx hashes landed on the mainnet API and rendered "transaction not found". Same Next.js codebase serves both hosts; `/block/<n>`, `/tx/<hash>`, `/address/<addr>`, `/token/<addr>` all return 200 verified live on `scan-testnet.sentrixchain.com`.

### 2. Testnet nativeCurrency drift (commit `d3eb489`)

```diff
   "nativeCurrency": {
-    "name": "Sentrix Testnet",
-    "symbol": "tSRX",
+    "name": "Sentrix",
+    "symbol": "SRX",
     "decimals": 18
   },
```

Brings testnet `nativeCurrency` in line with the mainnet `chainid-7119.js` entry. The drift would surface in MetaMask + every wallet UI's add-network confirmation as a false symbol mismatch with the mainnet 7119 entry — operators expect the same native coin (SRX) on both networks, with the network label distinguishing them, not the ticker.

## Verification

```bash
$ curl -s https://testnet-rpc.sentrixchain.com -X POST -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","result":"0x1bd0","id":1}

$ curl -sI https://scan-testnet.sentrixchain.com/block/1 | head -1
HTTP/2 200
```

Both fixes touch the same file; bundling here saves a second PR.