### PR TITLE
Add TradeXcele Chain (chainId 47294)

### DIFF
--- a/constants/additionalChainRegistry/chainid-47294.js
+++ b/constants/additionalChainRegistry/chainid-47294.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "TradeXcele",
+    "chain": "TXCL",
+    "rpc": [
+          "https://tradexcele.cloud/rpc/"
+        ],
+    "features": [{ "name": "EIP155" }],
+    "faucets": [
+          "https://tradexcele.cloud/chain/faucet/"
+        ],
+    "nativeCurrency": {
+          "name": "TXCL",
+          "symbol": "TXCL",
+          "decimals": 18
+    },
+    "infoURL": "https://tradexcele.com/chain",
+    "shortName": "txcl",
+    "chainId": 47294,
+    "networkId": 47294,
+    "explorers": [
+      {
+              "name": "TXCL Explorer",
+              "url": "https://tradexcele.cloud/chain"
+      }
+        ]
+}


### PR DESCRIPTION
Adds **TradeXcele Chain** — a new EVM-compatible Layer-1.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://tradexcele.com  (project) and https://tradexcele.cloud  (RPC infra). The RPC is operated by the same team that operates the chain itself, not a third-party RPC provider.

#### Provide a link to your privacy policy:
https://tradexcele.com/Privacy_Policy.php

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the canonical first-party RPC for chainId 47294. There are no other RPCs for this chain. The chain owner / RPC provider are the same entity (TradeXcele).

---

Technical details:
- **Chain ID**: 47294 (`0xb8be`)
- - **Native token**: TXCL (18 decimals)
- - **Consensus**: Clique PoA, 5-second blocks
- - **RPC**: https://tradexcele.cloud/rpc/  — verified `eth_chainId` returns `0xb8be`
- - **Explorer**: https://tradexcele.cloud/chain  (EIP-3091 routes verified)
- - **Faucet**: https://tradexcele.cloud/chain/faucet/
- - **Info**: https://tradexcele.com/chain
Corresponding ethereum-lists/chains PR: https://github.com/ethereum-lists/chains/pull/8299