### PR TITLE
Create chainid-5069.js‎

### DIFF
--- a/constants/additionalChainRegistry/chainid-5069.js‎
+++ b/constants/additionalChainRegistry/chainid-5069.js‎
@@ -1,0 +1,28 @@
+export const data = {
+    name: "Danny",
+    chain: "DAN",
+    icon: "https://alchemy.mypinata.cloud/ipfs/bafkreiducbup2ftkpyvjopdr77sstkjjnhsqkayfxllc5ruvgkdq4gjrom",
+    rpc: ["https://rpc.dannyscan.com"],
+    features: [
+        { name: "EIP155" }, 
+        { name: "EIP1559" }
+    ],
+    faucets: [],
+    nativeCurrency: {
+        "name": "Danny",
+        "symbol": "DAN",
+        "decimals": 18
+    },
+    infoURL: "https://dannychain.com",
+    shortName: "dan",
+    chainId: 5069,
+    networkId: 5069,
+    explorers: [
+        {
+            "name": "Dannyscan",
+            "url": "https://dannyscan.com",
+            "standard": "EIP3091"
+        }
+    ],
+    status: "active",
+};


### PR DESCRIPTION
**Add support for Danny Mainnet (Chain ID 5069) to Chainlist.**

Files Added
 constants/additionalChainRegistry/chainid-5069.js — Danny Mainnet

Network Name: Danny Mainnet
Chain ID: 5069 (hex 0x13cd)
RPC Endpoint: https://rpc.dannyscan.com
Native Currency: DAN (18 decimals)
Block Explorer: https://dannyscan.com (EIP-3091 compliant)
Features: EIP155, EIP1559