### PR TITLE
Add Tea Mainnet (chainId 6122)

### DIFF
--- a/constants/additionalChainRegistry/chainid-6122.js
+++ b/constants/additionalChainRegistry/chainid-6122.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "Tea Mainnet",
   "chain": "TEA",
   "rpc": [

--- a/constants/additionalChainRegistry/chainid-6122.js
+++ b/constants/additionalChainRegistry/chainid-6122.js
@@ -1,0 +1,23 @@
+{
+  "name": "Tea Mainnet",
+  "chain": "TEA",
+  "rpc": [
+    "https://rpc.tea.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Tea",
+    "symbol": "TEA",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://tea.xyz",
+  "shortName": "tea",
+  "chainId": 6122,
+  "networkId": 6122,
+  "explorers": [{
+    "name": "Blockscout",
+    "url": "https://explorer.tea.xyz",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adds Tea Mainnet to the additional chain registry.

- Chain ID: 6122
- RPC: https://rpc.tea.xyz
- Explorer: https://explorer.tea.xyz
- EIP-1559 supported
- OP Stack L2 settling on Ethereum mainnet
- ethereum-lists entry: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-6122.json