### PR TITLE
Add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10033,4 +10033,14 @@ export const extraRpcs = {
 };  
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 
-export default allExtraRpcs;
+export default allExtraRpcs;,
+  8472: {
+    rpcs: [
+      {
+        url: "https://rpc.myrxwallet.io",
+        tracking: "none",
+        trackingDetails: "MyRxWallet does not log or store RPC request data.",
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## MYRX-MAINNET — Chain ID 8472

Sovereign EVM blockchain operated by MyRxWallet North America Corporation. Mainnet live since 2026-05-07.

**Changes:** Add MYRX-MAINNET (Chain ID 8472) to `constants/extraRpcs.js` with public RPC endpoint.

### Verification
```
cast chain-id --rpc-url https://rpc.myrxwallet.io
# Returns: 8472
```
- Repository: https://github.com/MyRxWallet/mainnet
- Explorer: https://explorer.myrxwallet.io (EIP-3091)
- Treasury multisig: 0x7636345d9d3c375ac9af0d98eb2eed588d7a61d7

### Use case
Healthcare data and payments infrastructure. HIPAA-aligned data flows, provider settlement, patient-controlled data licensing.

### Contact
developer@myrxwallet.io | https://myrxwallet.io