### PR TITLE
Add Sentrix Chain (mainnet 7119) + Sentrix Testnet (7120)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7119.js
+++ b/constants/additionalChainRegistry/chainid-7119.js
@@ -19,11 +19,6 @@ export const data = {
       {
         "name": "Sentrix Scan",
         "url": "https://scan.sentrixchain.com",
-        "standard": "none"
-      },
-      {
-        "name": "Blockscout",
-        "url": "https://blockscout.sentrixchain.com",
         "standard": "EIP3091"
       }
     ]

--- a/constants/additionalChainRegistry/chainid-7119.js
+++ b/constants/additionalChainRegistry/chainid-7119.js
@@ -1,0 +1,30 @@
+export const data = {
+    "name": "Sentrix Chain",
+    "chain": "SRX",
+    "rpc": [
+      "https://rpc.sentrixchain.com"
+    ],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Sentrix",
+      "symbol": "SRX",
+      "decimals": 18
+    },
+    "infoURL": "https://sentrixchain.com",
+    "shortName": "srx",
+    "chainId": 7119,
+    "networkId": 7119,
+    "explorers": [
+      {
+        "name": "Sentrix Scan",
+        "url": "https://scan.sentrixchain.com",
+        "standard": "none"
+      },
+      {
+        "name": "Blockscout",
+        "url": "https://blockscout.sentrixchain.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/additionalChainRegistry/chainid-7120.js
+++ b/constants/additionalChainRegistry/chainid-7120.js
@@ -1,0 +1,27 @@
+export const data = {
+    "name": "Sentrix Testnet",
+    "chain": "SRX",
+    "rpc": [
+      "https://testnet-rpc.sentrixchain.com"
+    ],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": [
+      "https://faucet.sentrixchain.com"
+    ],
+    "nativeCurrency": {
+      "name": "Sentrix Testnet",
+      "symbol": "tSRX",
+      "decimals": 18
+    },
+    "infoURL": "https://sentrixchain.com",
+    "shortName": "srx-testnet",
+    "chainId": 7120,
+    "networkId": 7120,
+    "explorers": [
+      {
+        "name": "Sentrix Scan (Testnet)",
+        "url": "https://scan.sentrixchain.com",
+        "standard": "none"
+      }
+    ]
+  }


### PR DESCRIPTION
Sentrix Chain — Rust-based EVM-compatible L1, mainnet live since 2026-04. Already submitted to ethereum-lists/chains via PR #8266 (open, awaiting reviewer). Adding here in parallel for the DefiLlama UI.

**Mainnet**: chain ID 7119, RPC `https://rpc.sentrixchain.com`, explorer `https://scan.sentrixchain.com`.
**Testnet**: chain ID 7120, RPC `https://testnet-rpc.sentrixchain.com`, explorer `https://scan-testnet.sentrixchain.com`, faucet `https://faucet.sentrixchain.com`.

Both endpoints live + EIP-3091 compliant. Verifiable now:

```
$ curl -s -X POST -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
    https://rpc.sentrixchain.com
{"jsonrpc":"2.0","result":"0x1bcf","id":1}
```

Single-token (SRX, 18 decimals at the EVM boundary). EIP-155 supported.