### PR TITLE
Add TreasureNet Aurora chain 5570 override

### DIFF
--- a/constants/additionalChainRegistry/chainid-5570.js
+++ b/constants/additionalChainRegistry/chainid-5570.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Treasurenet Aurora",
+  chain: "Treasurenet Aurora",
+  rpc: ["https://rpc.treasurenet.io"],
+  features: [{ name: "EIP155" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "UNIT",
+    symbol: "UNIT",
+    decimals: 18,
+  },
+  infoURL: "https://www.treasurenet.io",
+  shortName: "treasurenet",
+  chainId: 5570,
+  networkId: 5570,
+  explorers: [
+    {
+      name: "Treasurenet EVM BlockExplorer",
+      url: "https://scan.treasurenet.io",
+      standard: "none",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Chainlist override for TreasureNet Aurora using chainId 5570
- use the canonical RPC endpoint https://rpc.treasurenet.io
- point the explorer URL to https://scan.treasurenet.io

## Context
Chainlist currently resolves TreasureNet with the old chain ID 5002 from upstream metadata. This override adds the correct 5570 entry for Chainlist while the upstream chain registry change is submitted separately.