### PR TITLE
Add BEXChain support

### DIFF
--- a/_data/chains/bexchain.json
+++ b/_data/chains/bexchain.json
@@ -1,0 +1,20 @@
+{
+  "name": "BEXChain",
+  "chainId": 140586,
+  "shortName": "bex",
+  "nativeCurrency": {
+    "name": "BEX",
+    "symbol": "BEX",
+    "decimals": 18
+  },
+  "rpc": [
+    "https://rpc.bexchain.com"
+  ],
+  "explorers": [
+    {
+      "name": "BEX Explorer",
+      "url": "https://scan.bexchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add BEXChain to Chainlist registry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.bexchain.com

#### Provide a link to your privacy policy:
https://docs.bexchain.com/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:
This RPC is maintained by the BEXChain core team and provides stable public access for network interaction and blockchain data retrieval.