### PR TITLE
feat: add FAVO Mainnet (chainId 3838)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3838.js
+++ b/constants/additionalChainRegistry/chainid-3838.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "FAVO Mainnet",
+  "chain": "FAVO",
+  "rpc": ["https://rpc.favoscan.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "FAVO",
+    "symbol": "FAVO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.favoscan.com",
+  "shortName": "favo",
+  "chainId": 3838,
+  "networkId": 3838,
+  "icon": "https://www.favoscan.com/token-logos/favo-logo-512.png",
+  "explorers": [{
+    "name": "favoscan",
+    "url": "https://www.favoscan.com",
+    "icon": "https://www.favoscan.com/token-logos/favo-logo-512.png",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.favoscan.com

#### Provide a link to your privacy policy:
https://www.favoscan.com

#### If the RPC has none of the above and you still think it should be added, please explain why:
Adding FAVO Mainnet (Chain ID 3838) with RPC endpoint https://rpc.favoscan.com and a 512x512 PNG icon. The chain is already listed in ethereum-lists/chains (PR #8216, merged 2026-04-29).