### PR TITLE
Add rpcfree.com RPC endpoints for Ethereum, Base, Polygon, Arbitrum

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -240,7 +240,9 @@ const privacyStatement = {
   mirasmanda:
     "Mirasmanda RPC does not collect or store any personally identifiable information (PII), including IP addresses, wallet addresses, or request metadata. The only data recorded on our infrastructure is what is publicly available on the blockchain. No user data is shared with third parties. For more information, visit https://asterium.uz",
   mevx:
-    "Source IP address is stored in an in-memory cache for the rate-limit sliding window (seconds) and is not written to persistent logs. No cookies, no cross-site tracking, no third-party analytics. Data is processed in the EU (Germany). Lawful basis: legitimate interest (service protection and anti-abuse)."
+    "Source IP address is stored in an in-memory cache for the rate-limit sliding window (seconds) and is not written to persistent logs. No cookies, no cross-site tracking, no third-party analytics. Data is processed in the EU (Germany). Lawful basis: legitimate interest (service protection and anti-abuse).",
+  rpcfree:
+    "rpcfree (operated by Etox) logs IP addresses transiently for rate limiting, DDoS protection, and abuse prevention via Cloudflare. Logs are retained for up to 24 hours and not correlated with wallet addresses. No analytics or third-party trackers run on the RPC endpoint itself. Privacy details: https://etox.io/privacy"
 };
 
 export const extraRpcs = {
@@ -585,6 +587,11 @@ export const extraRpcs = {
         url: "https://rpc.swiftnodes.io/rpc/eth",
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
+      },
+      {
+        url: "https://rpcfree.com/ethereum-rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.rpcfree,
       },
     ],
   },
@@ -1562,7 +1569,12 @@ export const extraRpcs = {
         url: "https://matic.rpc.sentio.xyz",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
-      }
+      },
+      {
+        url: "https://rpcfree.com/polygon-rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.rpcfree,
+      },
     ],
   },
   25: {
@@ -1914,6 +1926,11 @@ export const extraRpcs = {
         url: "https://rpc.swiftnodes.io/rpc/arbitrum",
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
+      },
+      {
+        url: "https://rpcfree.com/arbitrum-rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.rpcfree,
       },
     ],
   },
@@ -5682,6 +5699,11 @@ export const extraRpcs = {
         url: "https://rpc.swiftnodes.io/rpc/base",
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
+      },
+      {
+        url: "https://rpcfree.com/base-rpc",
+        tracking: "limited",
+        trackingDetails: privacyStatement.rpcfree,
       },
     ],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -242,7 +242,7 @@ const privacyStatement = {
   mevx:
     "Source IP address is stored in an in-memory cache for the rate-limit sliding window (seconds) and is not written to persistent logs. No cookies, no cross-site tracking, no third-party analytics. Data is processed in the EU (Germany). Lawful basis: legitimate interest (service protection and anti-abuse).",
   rpcfree:
-    "rpcfree (operated by Etox) logs IP addresses transiently for rate limiting, DDoS protection, and abuse prevention via Cloudflare. Logs are retained for up to 24 hours and not correlated with wallet addresses. No analytics or third-party trackers run on the RPC endpoint itself. Privacy details: https://etox.io/privacy"
+    "rpcfree (operated by Etox) logs IP addresses transiently for rate limiting, DDoS protection, and abuse prevention via Cloudflare. Logs are retained for up to 24 hours and not correlated with wallet addresses. No analytics or third-party trackers run on the RPC endpoint itself. Privacy details: https://rpcfree.com/privacy"
 };
 
 export const extraRpcs = {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://rpcfree.com

#### Provide a link to your privacy policy:

https://rpcfree.com/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.

This PR adds rpcfree.com public RPC endpoints to four already-listed chains: Ethereum (1), Base (8453), Polygon (137), and Arbitrum One (42161).

#### Endpoints
- `https://rpcfree.com/ethereum-rpc`
- `https://rpcfree.com/base-rpc`
- `https://rpcfree.com/polygon-rpc`
- `https://rpcfree.com/arbitrum-rpc`

#### Verification
Each endpoint returns the correct chainId via `eth_chainId`:

```bash
curl -X POST https://rpcfree.com/ethereum-rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# {"jsonrpc":"2.0","id":1,"result":"0x1"}

curl -X POST https://rpcfree.com/base-rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# {"jsonrpc":"2.0","id":1,"result":"0x2105"}

curl -X POST https://rpcfree.com/polygon-rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# {"jsonrpc":"2.0","id":1,"result":"0x89"}

curl -X POST https://rpcfree.com/arbitrum-rpc -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# {"jsonrpc":"2.0","id":1,"result":"0xa4b1"}
```

Happy to address any feedback or questions.