### PR TITLE
Add LightchainAI mainnet & testnet support

### DIFF
--- a/constants/additionalChainRegistry/chainid-8200.js
+++ b/constants/additionalChainRegistry/chainid-8200.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "LightchainAI Testnet",
+  "chain": "LCAI",
+  "rpc": [
+    "https://rpc.testnet.lightchain.ai",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LightchainAI",
+    "symbol": "LCAI",
+    "decimals": 18
+  },
+  "infoURL": "https://lightchain.ai",
+  "shortName": "lcai",
+  "chainId": 8200,
+  "networkId": 8200,
+  "icon": "lcai",
+  "explorers": [{
+    "name": "Lightchain Testnet Explorer",
+    "url": "https://testnet.lightscan.app",
+    "icon": "lcai",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-8200.js
+++ b/constants/additionalChainRegistry/chainid-8200.js
@@ -11,7 +11,7 @@ export const data = {
     "decimals": 18
   },
   "infoURL": "https://lightchain.ai",
-  "shortName": "lcai",
+  "shortName": "lcai-t",
   "chainId": 8200,
   "networkId": 8200,
   "icon": "lcai",

--- a/constants/additionalChainRegistry/chainid-9200.js
+++ b/constants/additionalChainRegistry/chainid-9200.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "LightchainAI Mainnet",
+  "chain": "LCAI",
+  "rpc": [
+    "https://rpc.mainnet.lightchain.ai",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LightchainAI",
+    "symbol": "LCAI",
+    "decimals": 18
+  },
+  "infoURL": "https://lightchain.ai",
+  "shortName": "lcai",
+  "chainId": 9200,
+  "networkId": 9200,
+  "icon": "lcai",
+  "explorers": [{
+    "name": "Lightchain Explorer",
+    "url": "https://lightscan.app",
+    "icon": "lcai",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adds LightchainAI Mainnet & Testnet to the additional chain registry.

