### PR TITLE
Add BEXChain (chainId 140586)

### DIFF
--- a/constants/additionalChainRegistry/chainid-140586.js
+++ b/constants/additionalChainRegistry/chainid-140586.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "BEXChain",
+  chain: "BEX",
+  rpc: [
+    "https://rpc.bexchain.com",
+  ],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "BEX",
+    symbol: "BEX",
+    decimals: 18,
+  },
+  infoURL: "https://bexchain.com",
+  shortName: "bexchain",
+  chainId: 140586,
+  networkId: 140586,
+  explorers: [
+    {
+      name: "BEXChain Scan",
+      url: "https://scan.bexchain.com",
+      standard: "EIP3091",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
Add BEXChain network entry to Chainlist registry.

## Network Details
- Chain ID: `140586`
- Chain Name: `bexchain`
- Native Symbol: `BEX`
- RPC: `https://rpc.bexchain.com`
- Explorer: `https://scan.bexchain.com`
- API chain info: `https://api.bexchain.com/api/chain_info`

## Validation
- `eth_chainId` on RPC returns: `0x2252a`
