### PR TITLE
Fix MegaETH mainnet chain metadata

### DIFF
--- a/constants/additionalChainRegistry/chainid-4326.js
+++ b/constants/additionalChainRegistry/chainid-4326.js
@@ -16,13 +16,13 @@ export const data = {
   "networkId": 4326,
   "explorers": [
     {
-      "name": "Blockscout",
-      "url": "https://megaeth.blockscout.com",
+      "name": "Etherscan",
+      "url": "https://mega.etherscan.io",
       "standard": "EIP3091"
     },
     {
-      "name": "Etherscan",
-      "url": "https://mega.etherscan.com",
+      "name": "Blockscout",
+      "url": "https://megaeth.blockscout.com",
       "standard": "EIP3091"
     }
   ]

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -158,7 +158,7 @@ export default {
   "4048": "earnm",
   "4114": "citrea",
   "4158": "crossfi",
-  "4326": "polymesh",
+  "4326": "megaeth",
   "4337": "beam",
   "4442": "denergy testnet",
   "4488": "hydra chain",


### PR DESCRIPTION
This updates the MegaETH mainnet entry to:

- correct the human-readable chain mapping for chain ID  in 
- fix the Etherscan URL from  to 
- list Etherscan first in the explorer list, followed by Blockscout

I also reviewed testnet () while checking this repo and did not find a separate chain entry to update in the current tree.