### PR TITLE
update ronin mainnet explorer + remove inactive rpc

### DIFF
--- a/constants/additionalChainRegistry/chainid-2020.js
+++ b/constants/additionalChainRegistry/chainid-2020.js
@@ -5,7 +5,6 @@ export const data = {
     "rpc": [
       "https://api.roninchain.com/rpc",
       "https://api-gateway.skymavis.com/rpc?apikey=9aqYLBbxSC6LROynQJBvKkEIsioqwHmr",
-      "https://ronin.lgns.net/rpc",
       "https://ronin.drpc.org"
     ],
     "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
@@ -22,7 +21,7 @@ export const data = {
     "explorers": [
       {
         "name": "Ronin Explorer",
-        "url": "https://app.roninchain.com/"
+        "url": "https://explorer.roninchain.com/"
       }
     ]
   }


### PR DESCRIPTION
Update Ronin Mainnet explorer to https://explorer.roninchain.com

Remove inactive RPC provider. 