### PR TITLE
Add APChain mainnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-21970.js
+++ b/constants/additionalChainRegistry/chainid-21970.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "APChain",
   "chain": "AP",
   "rpc": [

--- a/constants/additionalChainRegistry/chainid-21970.js
+++ b/constants/additionalChainRegistry/chainid-21970.js
@@ -1,0 +1,29 @@
+{
+  "name": "APChain",
+  "chain": "AP",
+  "rpc": [
+    "https://rpc.apchain.io/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "APX",
+    "symbol": "APX",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "http://scan.apchain.io",
+  "shortName": "apchain",
+  "chainId": 21970,
+  "networkId": 21970,
+  "explorers": [
+    {
+      "name": "APChain Scan",
+      "url": "http://scan.apchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds APChain, an EVM-compatible mainnet.

Chain name: APChain
Chain ID: 21970
Native currency: APX
RPC: https://rpc.apchain.io/
Explorer: http://scan.apchain.io/