### PR TITLE
feat: add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/constants/additionalChainRegistry/chainid-8472.js
+++ b/constants/additionalChainRegistry/chainid-8472.js
@@ -1,0 +1,25 @@
+export const data = {
+    "name": "MYRX-MAINNET",
+    "chain": "MYRX",
+    "rpc": [
+      "https://rpc.myrxwallet.io"
+    ],
+    "features": [{"name": "EIP155"}, {"name": "EIP1559"}],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "MYRX",
+      "symbol": "MYRX",
+      "decimals": 18
+    },
+    "infoURL": "https://myrxwallet.io",
+    "shortName": "myrx",
+    "chainId": 8472,
+    "networkId": 8472,
+    "explorers": [
+      {
+        "name": "MYRX-MAINNET Explorer",
+        "url": "https://explorer.myrxwallet.io",
+        "standard": "EIP3091"
+      }
+    ]
+}


### PR DESCRIPTION
Add MYRX-MAINNET to the chain registry.

**Chain details:**
- Chain ID: 8472
- Symbol: MYRX (18 decimals)
- RPC: https://rpc.myrxwallet.io
- Explorer: https://explorer.myrxwallet.io (Blockscout v6.10.0)
- Website: https://myrxwallet.io
- Operator: MyRxWallet North America Corporation (Wyoming, USA)
- ONC-certified FHIR R4 EHR + healthcare data marketplace
- Mainnet live: 2026-05-07
- Listed in ethereum-lists/chains (PR #8335, merged 2026-05-14)

**File added:** `constants/additionalChainRegistry/chainid-8472.js`