### PR TITLE
feat: add MyrxWallet Network (Chain 8472, MYRX)

### DIFF
--- a/constants/additionalChainRegistry/chainid-8472.js
+++ b/constants/additionalChainRegistry/chainid-8472.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "MyrxWallet Network",
+  "chain": "MYRX",
+  "rpc": [
+    "https://rpc.myrxwallet.io"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MyrxWallet Token",
+    "symbol": "MYRX",
+    "decimals": 18
+  },
+  "infoURL": "https://myrxwallet.io",
+  "shortName": "myrx",
+  "chainId": 8472,
+  "networkId": 8472,
+  "explorers": [
+    {
+      "name": "MyrxWallet Explorer",
+      "url": "https://explorer.myrxwallet.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Chain 8472 — MyrxWallet Network to chainlist.org.

### Chain Details
- **Chain ID**: 8472
- **Symbol**: MYRX
- **RPC**: https://rpc.myrxwallet.io (reth v2.2.0, live block production)
- **Explorer**: https://explorer.myrxwallet.io (Blockscout v6.10)
- **Info**: https://myrxwallet.io
- **Features**: EIP155, EIP1559

### File Added
