### PR TITLE
add ROON Mainnet (chainId 1492) to additional registry

### DIFF
--- a/constants/additionalChainRegistry/chainid-1492.js
+++ b/constants/additionalChainRegistry/chainid-1492.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "ROON Mainnet",
+  chain: "ROON",
+  rpc: ["https://rpc.roonchain.com"],
+  faucets: [],
+  nativeCurrency: {
+    name: "ROON",
+    symbol: "ROON",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://roonchain.com",
+  shortName: "roonchain",
+  chainId: 1492,
+  networkId: 1492,
+  icon: "roonchain",
+  explorers: [
+    {
+      name: "Roon Mainnet explorer",
+      url: "https://browser.roonchain.com",
+      icon: "roonchain",
+      standard: "EIP3091",
+    },
+  ],
+}

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -43,6 +43,7 @@ export default {
   "146": "sonic",
   "148": "shimmer_evm",
   "151": "rbn",
+  "1492": "roonchain",
   "166": "nomina",
   "169": "manta",
   "173": "eni",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -599,6 +599,16 @@ export const extraRpcs = {
       "wss://wss.cchain.cc"
     ],
   },
+  1492: {
+    rpcs: [
+      {
+        url: "https://rpc.roonchain.com",
+        tracking: "yes",
+        trackingDetails:
+          "Official ROON Mainnet public RPC provided by the RoonChain team. Privacy policy is not publicly available yet.",
+      },
+    ],
+  },
   2517: {
     rpcs: [
       "https://svp-dataseed1-testnet.svpchain.org",


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):
  https://roonchain.com

  #### Provide a link to your privacy policy:
  Not publicly available yet.

  #### If the RPC has none of the above and you still think it should be added, please explain why:
  This is the official public RPC for ROON Mainnet, provided by the chain operator.

  Additional notes:
  - RPC endpoint: https://rpc.roonchain.com
  - Explorer: https://browser.roonchain.com
  - chainId: 1492
  - networkId: 1492
  - tracking set to "yes" based on prior review feedback
  - This PR only includes ROON Mainnet related changes