### PR TITLE
Add VALYGO Smart Contract (7771777) and VALYGO NFT (7773777)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7771777.js
+++ b/constants/additionalChainRegistry/chainid-7771777.js
@@ -1,0 +1,27 @@
+export default {
+  "name": "VALYGO Smart Contract",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyosc",
+  "chainId": 7771777,
+  "networkId": 7771777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan",
+      "url": "https://vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-7773777.js
+++ b/constants/additionalChainRegistry/chainid-7773777.js
@@ -1,0 +1,27 @@
+export default {
+  "name": "VALYGO NFT",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyonft",
+  "chainId": 7773777,
+  "networkId": 7773777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan NFT",
+      "url": "https://nft.vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds two new Avalanche L1 chains, not new RPCs for existing chains.

**Chains added:**
- VALYGO Smart Contract — Chain ID 7771777
- VALYGO NFT — Chain ID 7773777

**RPC provider:** VALYGO Labs LLC (https://vyochain.com)
**Privacy policy:** https://vyochain.com/privacy
**Explorer:** https://vyoscan.com (smartchain), https://nft.vyoscan.com (nftchain)

Both chains are live and already registered on ethereum-lists/chains:
- https://chainid.network/chain/7771777
- https://chainid.network/chain/7773777