### PR TITLE
feat: add MYRX-MAINNET (Chain 8472, MRT) to chain registry

### DIFF
--- a/constants/additionalChainRegistry/chainid-8472.js
+++ b/constants/additionalChainRegistry/chainid-8472.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "MyRxWallet Network",
+  chain: "MRT",
+  rpc: ["https://rpc.myrxwallet.io"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "MyRx Token",
+    symbol: "MRT",
+    decimals: 18,
+  },
+  infoURL: "https://myrxwallet.io",
+  shortName: "mrt",
+  chainId: 8472,
+  networkId: 8472,
+  explorers: [
+    {
+      name: "MyRxWallet Explorer",
+      url: "https://explorer.myrxwallet.io",
+      standard: "EIP3091",
+    },
+  ],
+}


### PR DESCRIPTION
## Add MYRX-MAINNET to DefiLlama Chain Registry

**Chain:** MYRX-MAINNET
**Chain ID:** 8472
**Native token:** MRT (MyRx Token, 18 decimals)
**RPC:** https://rpc.myrxwallet.io
**Explorer:** https://explorer.myrxwallet.io

MYRX-MAINNET is a live EVM chain serving as healthcare-native blockchain rails — payment infrastructure for patients, providers, and pharmacies. A TVL adapter PR (#19295) is pending in DefiLlama-Adapters tracking WMRT/WBTC and WMRT/MUSD DEX pairs.