### PR TITLE
Add AXION icon metadata

### DIFF
--- a/_data/icons/axion.json
+++ b/_data/icons/axion.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreihdzrkjmt4ta4o4eobsxsvdyltc3sxfwtdvnzslvymy3z2nyekzai",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds AXION icon metadata for Chainlist integration.

Chain: AXION Mainnet  
Chain ID: 303030

Icon metadata uses IPFS-hosted 512x512 PNG asset for wallet and explorer compatibility.

Website: https://www.axiondefi.com  
Explorer: https://axscan.axiondefi.com  
RPC: https://rpc.axiondefi.com