### PR TITLE
feat: add Cryptos Testnet Beta (chainId 77777777)

### DIFF
--- a/constants/additionalChainRegistry/chainid-77777777.js
+++ b/constants/additionalChainRegistry/chainid-77777777.js
@@ -1,0 +1,24 @@
+export const data = {
+    "name": "Cryptos Testnet Beta",
+    "chain": "CRYPTOS",
+    "rpc": [
+      "https://rpc-testnet-beta-evm.cryptos.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Cryptos",
+      "symbol": "CRPTOS",
+      "decimals": 18
+    },
+    "infoURL": "https://cryptos.com",
+    "shortName": "cryptos-testnet-beta",
+    "chainId": 77777777,
+    "networkId": 77777777,
+    "explorers": [
+      {
+        "name": "Cryptos Explorer (Testnet Beta)",
+        "url": "https://explorer-beta.cryptos.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/constants/additionalChainRegistry/chainid-77777777.js
+++ b/constants/additionalChainRegistry/chainid-77777777.js
@@ -14,6 +14,9 @@ export const data = {
     "shortName": "cryptos-testnet-beta",
     "chainId": 77777777,
     "networkId": 77777777,
+    "icon": "cryptos",
+    "chainSlug": "cryptos",
+    "isTestnet": true,
     "explorers": [
       {
         "name": "Cryptos Explorer (Testnet Beta)",


### PR DESCRIPTION
Adds Cryptos Testnet Beta to chainlist.

- **Chain ID:** 77777777
- **Chain:** CRYPTOS
- **RPC:** https://rpc-testnet-beta-evm.cryptos.com
- **Explorer:** https://explorer-beta.cryptos.com
- **Info:** https://cryptos.com

This chain is already merged in [ethereum-lists/chains#8230](https://github.com/ethereum-lists/chains/pull/8230).

**Icon:** Please add icon slug `cryptos` to the icon CDN — logo SVG available at https://cryptos.com/assets/images/cryptos-logo.svg