### PR TITLE
Add MyRx Network RPC (chainId 8472)

### DIFF
--- a/constants/additionalChainRegistry/chainid-8472.js
+++ b/constants/additionalChainRegistry/chainid-8472.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "MyRxWallet Network",
+  chain: "MRT",
+  rpc: ["https://rpc.myrxwallet.io"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: [],
+  nativeCurrency: {
+    name: "MyRx Token",
+    symbol: "MRT",
+    decimals: 18,
+  },
+  infoURL: "https://myrxwallet.io",
+  shortName: "mrt",
+  chainId: 8472,
+  networkId: 8472,
+  explorers: [
+    {
+      name: "MyRxWallet Explorer",
+      url: "https://explorer.myrxwallet.io",
+      standard: "EIP3091",
+    },
+  ],
+}

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10020,7 +10020,23 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.sentio,
       }
     ]
-  }
+  },
+  8472: {
+    rpcs: [
+      {
+        url: "https://rpc.myrxwallet.io",
+        tracking: "none",
+        trackingDetails:
+          "MyRx Network does not collect or store any user information (IP addresses, wallet addresses, location, etc.) transmitted via our RPC. https://myrxwallet.io",
+      },
+      {
+        url: "wss://rpc.myrxwallet.io",
+        tracking: "none",
+        trackingDetails:
+          "MyRx Network does not collect or store any user information (IP addresses, wallet addresses, location, etc.) transmitted via our RPC. https://myrxwallet.io",
+      },
+    ],
+  },
 };  
 const allExtraRpcs = mergeDeep(llamaNodesRpcs, extraRpcs);
 


### PR DESCRIPTION
## Summary

Adds RPC endpoints for MyRx Network (Chain ID 8472).

- **RPC:** https://rpc.myrxwallet.io
- **WSS:** wss://rpc.myrxwallet.io
- **Tracking:** none
- **Explorer:** https://explorer.myrxwallet.io

MyRx Network is a healthcare EVM-compatible chain. No user data is collected through the RPC.