### PR TITLE
Add Primox Chain (970803)

### DIFF
--- a/constants/additionalChainRegistry/chainid-970803.js
+++ b/constants/additionalChainRegistry/chainid-970803.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Primox Chain",
+  chain: "PXC",
+  rpc: ["https://rpc.primox.online"],
+  faucets: [],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  nativeCurrency: {
+    name: "Primox Token",
+    symbol: "PXT",
+    decimals: 18,
+  },
+  infoURL: "https://chain.primox.online",
+  shortName: "primox",
+  chainId: 970803,
+  networkId: 970803,
+  explorers: [
+    {
+      name: "Primox Scan",
+      url: "https://scan.primox.online/",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Primox Chain to additionalChainRegistry
- include RPC, explorer, website, and native token metadata
- use chainId/networkId 970803

## Validation
- node tests/check-duplicate-keys.js
- PATH="$PWD/node_modules/.bin:$PATH" bash scripts/build.sh

## Notes
- local environment initially had no dependencies installed
- scripts/build.sh also relies on `next` being available on PATH in the shell environment