### PR TITLE
Add NodeFlare public RPC endpoints (8 chains)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -238,12 +238,19 @@ const privacyStatement = {
   mevx:
     "Source IP address is stored in an in-memory cache for the rate-limit sliding window (seconds) and is not written to persistent logs. No cookies, no cross-site tracking, no third-party analytics. Data is processed in the EU (Germany). Lawful basis: legitimate interest (service protection and anti-abuse).",
   rpcfree:
-    "rpcfree (operated by Etox) logs IP addresses transiently for rate limiting, DDoS protection, and abuse prevention via Cloudflare. Logs are retained for up to 24 hours and not correlated with wallet addresses. No analytics or third-party trackers run on the RPC endpoint itself. Privacy details: https://rpcfree.com/privacy"
+    "rpcfree (operated by Etox) logs IP addresses transiently for rate limiting, DDoS protection, and abuse prevention via Cloudflare. Logs are retained for up to 24 hours and not correlated with wallet addresses. No analytics or third-party trackers run on the RPC endpoint itself. Privacy details: https://rpcfree.com/privacy",
+  nodeflare:
+    "NodeFlare does not collect or store any personally identifiable information. IP addresses may be temporarily used for rate limiting and DDoS protection and are not correlated with wallet addresses or request data. https://nodeflare.app/privacy"
 };
 
 export const extraRpcs = {
   1: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/eth/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       // Quicknode -> tracks IP
       {
         url: "https://go.getblock.io/aefd01aa907c4805ba3c00a9e5b48c6b",
@@ -931,6 +938,11 @@ export const extraRpcs = {
   },
   56: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/bnb/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://bsc-dataseed.bnbchain.org/",
       "https://bsc-dataseed1.defibit.io/",
       "https://bsc-dataseed1.ninicoin.io/",
@@ -1207,6 +1219,11 @@ export const extraRpcs = {
   },
   43114: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/avax/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://api.avax.network/ext/bc/C/rpc",
       "https://avalanche.public-rpc.com",
       {
@@ -1777,6 +1794,11 @@ export const extraRpcs = {
   },
   42161: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/arb/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://arb1.arbitrum.io/rpc",
       {
         url: "https://1rpc.io/arb",
@@ -2589,6 +2611,11 @@ export const extraRpcs = {
   },
   10: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/op/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://mainnet.optimism.io/",
       {
         url: "https://optimism-mainnet.public.blastapi.io",
@@ -3709,6 +3736,11 @@ export const extraRpcs = {
   },
   88: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/vic/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       {
         url: "https://viction.blockpi.network/v1/rpc/public",
         tracking: "limited",
@@ -5545,6 +5577,11 @@ export const extraRpcs = {
   },
   8453: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/base/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://mainnet.base.org",
       "https://developer-access-mainnet.base.org",
       "https://li-fi-base.intustechno.workers.dev/rpc",
@@ -10042,6 +10079,11 @@ export const extraRpcs = {
   },
   999: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/hl/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       {
         url: "https://hyperevm.rpc.sentio.xyz",
         tracking: "limited",


### PR DESCRIPTION
## Summary

Adds [NodeFlare](https://nodeflare.app) as a public RPC provider for 8 EVM chains:

| Chain | Chain ID | Endpoint |
|-------|----------|----------|
| Ethereum | 1 | `https://rpc.nodeflare.app/eth/public` |
| BNB Chain | 56 | `https://rpc.nodeflare.app/bnb/public` |
| Avalanche | 43114 | `https://rpc.nodeflare.app/avax/public` |
| Arbitrum | 42161 | `https://rpc.nodeflare.app/arb/public` |
| Optimism | 10 | `https://rpc.nodeflare.app/op/public` |
| Base | 8453 | `https://rpc.nodeflare.app/base/public` |
| Viction | 88 | `https://rpc.nodeflare.app/vic/public` |
| HyperLiquid EVM | 999 | `https://rpc.nodeflare.app/hl/public` |

NodeFlare is a multi-region EVM RPC infrastructure service. The `/public` endpoints are fully open and require no API key.

Privacy: IP addresses are used transiently for rate limiting and DDoS protection only, not correlated with wallet addresses. Full policy: https://nodeflare.app/privacy