### PR TITLE
Add LunaroChain Mainnet (Chain ID 389)

### DIFF
--- a/constants/additionalChainRegistry/chainid-389.js
+++ b/constants/additionalChainRegistry/chainid-389.js
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   "name": "LunaroChain Mainnet",
   "chain": "LNR",
   "rpc": [

--- a/constants/additionalChainRegistry/chainid-389.js
+++ b/constants/additionalChainRegistry/chainid-389.js
@@ -1,0 +1,25 @@
+module.exports = {
+  "name": "LunaroChain Mainnet",
+  "chain": "LNR",
+  "rpc": [
+    "https://rpc.lunaro.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Lunaro",
+    "symbol": "LNR",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://lunaro.network",
+  "shortName": "lnr",
+  "chainId": 389,
+  "networkId": 389,
+  "icon": "lunaro",
+  "explorers": [{
+    "name": "LunaroScan",
+    "url": "https://scan.lunaro.network",
+    "icon": "lunaro",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Project Name: LunaroChain Mainnet
Mission: To provide a robust and developer-friendly infrastructure for DeFi and NFT projects.

Key Technical Specs:

Chain ID: 389

Native Currency: LNR (Lunaro)

Network Type: EVM-Compatible

Official Links:

Website: https://lunaro.network/

Blockchain Explorer: https://scan.lunaro.network/

Public RPC: https://rpc.lunaro.network/

Welcome to the Lunaro Era.

LunaroChain is an independent EVM-compatible blockchain ecosystem (Chain ID: 389) focused on delivering high-speed transactions and near-zero fees. Our mission is to bridge the gap between complex blockchain technology and real-world utility.

By utilizing a state-of-the-art infrastructure, LunaroChain enables the deployment of secure Smart Contracts, Decentralized Exchanges (DEXs), and innovative dApps. We are committed to transparency, community-driven growth, and the continuous evolution of our digital economy.

Explore the future of finance at lunaro.network.

If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC):


 Provide a link to your privacy policy:


 If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.