### PR TITLE
Add BrainArk RPC (chainId 1236)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1726,6 +1726,14 @@ export const extraRpcs = {
       },
     ],
   },
+  1236: {
+    rpcs: [
+      {
+        url: "https://rpc.brainark.online",
+        tracking: "none",
+      },
+    ],
+  },
   2340: {
     rpcs: [
       {


### PR DESCRIPTION
Add BrainArk Layer 1 blockchain RPC
- Chain ID: 1236
- Symbol: BAK (native coin)
- RPC: https://rpc.brainark.online
- Tracking: none
- ethereum-lists/chains PR: https://github.com/ethereum-lists/chains/pull/8318 (merged 2026-05-17)