### PR TITLE
feat: add VALYGO Smartchain and VALYGO NFT RPC endpointsFix/valygo add gw2 v2

### DIFF
--- a/constants/additionalChainRegistry/chainid-7771777.js
+++ b/constants/additionalChainRegistry/chainid-7771777.js
@@ -1,0 +1,27 @@
+export default {
+  "name": "VALYGO Smart Contract",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyosc",
+  "chainId": 7771777,
+  "networkId": 7771777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan",
+      "url": "https://vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-7773777.js
+++ b/constants/additionalChainRegistry/chainid-7773777.js
@@ -1,0 +1,27 @@
+export default {
+  "name": "VALYGO NFT",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyonft",
+  "chainId": 7773777,
+  "networkId": 7773777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan NFT",
+      "url": "https://nft.vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10116,7 +10116,35 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.sentio,
       }
     ]
-  }
+  },
+  7771777: {
+    rpcs: [
+      {
+        url: "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc",
+        tracking: "none",
+        trackingDetails: "VALYGO does not collect or store any user data through its RPC endpoints.",
+      },
+      {
+        url: "https://rpc-gw-2.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc",
+        tracking: "none",
+        trackingDetails: "VALYGO does not collect or store any user data through its RPC endpoints.",
+      },
+    ],
+  },
+  7773777: {
+    rpcs: [
+      {
+        url: "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc",
+        tracking: "none",
+        trackingDetails: "VALYGO does not collect or store any user data through its RPC endpoints.",
+      },
+      {
+        url: "https://rpc-gw-2.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc",
+        tracking: "none",
+        trackingDetails: "VALYGO does not collect or store any user data through its RPC endpoints.",
+      },
+    ],
+  },
 };
 
 export default extraRpcs;


### PR DESCRIPTION
Add RPC endpoints for two VALYGO chains (Avalanche L1s):

- VALYGO Smartchain (7771777) — 2 RPC gateways
- VALYGO NFT (7773777) — 2 RPC gateways

No user data is collected or stored through these endpoints.

Chain data already registered in ethereum-lists/chains.