### PR TITLE
eip155-31338.json

### DIFF
--- a/_data/chains/eip155-31338.json
+++ b/_data/chains/eip155-31338.json
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "BitVault BVM20",
+  "chain": "BVM20",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.bitvault.club",
+    "wss://rpc.bitvault.club:8549"
+  ],
+  "faucets": ["https://faucet.bitvault.club"],
+  "nativeCurrency": {
+    "name": "BitVault Token",
+    "symbol": "BVTW",
+    "decimals": 18
+  },
+  "infoURL": "https://bitvault.club",
+  "shortName": "bvm20",
+  "chainId": 31338,
+  "networkId": 31338,
+  "explorers": [
+    {
+      "name": "BitVault Explorer",
+      "url": "https://explorer.bitvault.club",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
#### Link the service provider's website:
https://bitvault.club

#### Privacy policy:
https://bitvault.club/privacy

#### Why this RPC should be added:
BitVault BVM20 is an EVM-compatible L2 chain (chainId 31338) built on Hyperledger Besu with Clique PoA consensus. Native token BVTW. Public RPC at https://rpc.bitvault.club with explorer at https://explorer.bitvault.club and faucet at https://faucet.bitvault.club.