### PR TITLE
Change the "PopDEX Testnet" chain rpc url

### DIFF
--- a/constants/additionalChainRegistry/chainid-34952.js
+++ b/constants/additionalChainRegistry/chainid-34952.js
@@ -2,7 +2,7 @@ export const data = {
   "name": "PopDEX Testnet",
   "chain": "PopDEX",
   "rpc": [
-    "https://testnet-api.popdex.xyz"
+    "https://testnet-api.popdex.xyz/api/v1/web3/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
This's the updated testnet message:

- Chain ID: 34952
- Native Currency: POP (PopDEX)
- RPC URL: https://testnet-api.popdex.xyz/api/v1/web3/rpc
- explorer: https://testnet-app.popdex.xyz/explorer