### PR TITLE
Add BSOS Chain (ChainID 77888) 

### DIFF
--- a/constants/additionalChainRegistry/chainid-77888.js
+++ b/constants/additionalChainRegistry/chainid-77888.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "BSOS Chain",
+  "chain": "BSOS",
+  "rpc": [
+    "https://rpc.one.bsos.co"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BSOS",
+    "symbol": "BSOS",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://www.bsos.co",
+  "shortName": "bsos",
+  "chainId": 77888,
+  "networkId": 77888,
+  "explorers": [
+    {
+      "name": "BSOS Chain Explorer",
+      "url": "https://explorer.one.bsos.co",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a new chain entry for BSOS Chain with:

- Chain ID: 77888
- Network ID: 77888
- Native token: BSOS
- RPC: https://rpc.one.bsos.co
- Explorer: https://explorer.one.bsos.co
- Info URL: https://www.bsos.co
