### PR TITLE
Remove Bloxroute X Layer endpoints

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4677,16 +4677,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.bloxroute,
       },
       {
-        url: "https://okx-xlayer.rpc.blxrbdn.com",
-        tracking: "yes",
-        trackingDetails: privacyStatement.bloxroute,
-      },
-      {
-        url: "https://flap-xlayer.rpc.blxrbdn.com",
-        tracking: "yes",
-        trackingDetails: privacyStatement.bloxroute,
-      },
-      {
         url: "https://xlayer-mainnet.rpc.sentio.xyz",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://bloxroute.com/

#### Provide a link to your privacy policy:

Our privacy policy is already listed in extraRpcs.js


#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.