### PR TITLE
Add NirmalX Smart Chain (ChainID 15526)

### DIFF
--- a/_data/chains/eip155-15526.json
+++ b/_data/chains/eip155-15526.json
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "NirmalX Smart Chain",
+  "chain": "NRXN",
+  "network": "mainnet",
+  "rpc": ["https://rpc.nirmalxscan.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NirmalX Nova",
+    "symbol": "NRXN",
+    "decimals": 18
+  },
+  "infoURL": "https://nirmalx.io",
+  "shortName": "nrxn",
+  "chainId": 15526,
+  "networkId": 15526,
+  "explorers": [
+    {
+      "name": "NirmalXScan",
+      "url": "https://nirmalxscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://nirmalx.io

#### Provide a link to your privacy policy:
https://nirmalx.io

#### If the RPC has none of the above and you still think it should be added, please explain why:
This RPC endpoint is a public, read-only infrastructure for the NirmalX Smart Chain. It does not collect or store any user data and is used only for blockchain interaction.
Your RPC should always be added at the end of the array.