### PR TITLE
Add Azul RPC for Base (chainId 8453)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -245,6 +245,8 @@ const privacyStatement = {
     "To route your requests, blockmachine temporarily processes your IP address for up to 2 minutes - used only to count and rate-limit requests. It is never stored beyond that window and cannot be linked to any individual user or account.",
   keccakio:
     "keccak.io does not require accounts, email, or KYC, does not log client IP addresses, and does not correlate requests to users. https://keccak.io/privacy",
+  azul:
+    "Azul does not log IP addresses, request bodies, wallet addresses, or any other identifying information. No cookies or session identifiers are set on the RPC path. No third-party analytics or trackers run on the RPC endpoint. https://baseazul.dev/privacy",
 };
 
 export const extraRpcs = {
@@ -5856,6 +5858,11 @@ export const extraRpcs = {
         url: "https://base-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.baseazul.dev",
+        tracking: "none",
+        trackingDetails: privacyStatement.azul,
       },
     ],
   },


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://baseazul.dev

#### Provide a link to your privacy policy:

https://baseazul.dev/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

N/A

---

Adding **Azul** — a free, no-signup public RPC for Base mainnet (chainId 8453).

- Endpoint: `https://rpc.baseazul.dev`
- Region: us-east-1 (Virginia)
- Tracking: `none` (no IP logs, no request bodies, no wallet correlation, no cookies, no third-party trackers on the RPC path)
- CORS: `Access-Control-Allow-Origin: *`
- Tip parity with `mainnet.base.org` verified at submission time (delta 0 blocks)

Two-line diff: privacy statement added to `privacyStatement`, RPC entry appended at the end of the `8453.rpcs` array per the template.