### PR TITLE
chore: rename 1rpc.io to public.1rpc.io

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -12,7 +12,7 @@ const privacyStatement = {
   nodereal: `We may automatically record certain information about how you use our Sites (we refer to this information as "Log Data"). Log Data may include information such as a user's Internet Protocol (IP) address, device and browser type, operating system, the pages or features of our Sites to which a user browsed and the time spent on those pages or features, the frequency with which the Sites are used by a user, search terms, the links on our Sites that a user clicked on or used, and other statistics. We use this information to administer the Service and we analyze (and may engage third parties to analyze) this information to improve and enhance the Service by expanding its features and functionality and tailoring it to our users' needs and preferences. https://nodereal.io/terms`,
   publicnode: `We do not store or track any user data with the exception of data that will be public on chain. We do not correlate wallets address's with IP's,  any data which is needed to transact is deleted after 24 hours. We also do no use any Analytics or 3rd party website tracking. https://www.publicnode.com/privacy`,
   onerpc:
-    "With the exception of data that will be public on chain, all the other metadata / data should remain private to users and other parties should not be able to access or collect it. 1RPC uses many different techniques to prevent the unnecessary collection of user privacy, which prevents tracking from RPC providers. https://docs.1rpc.io/technology/zero-tracking",
+    "With the exception of data that will be public on chain, all the other metadata / data should remain private to users and other parties should not be able to access or collect it. 1RPC uses many different techniques to prevent the unnecessary collection of user privacy, which prevents tracking from RPC providers. https://docs.1rpc.io/web3-relay/overview",
   builder0x69: "Private transactions / MM RPC: https://twitter.com/builder0x69",
   MEVBlockerRPC:
     "Privacy notice: MEV Blocker RPC does not store any kind of user information (i.e. IP, location, user agent, etc.) in any data bases. Only transactions are preserved to be displayed via status endpoint like https://rpc.mevblocker.io/tx/0x627b09d5a9954a810cd3c34b23694439da40558a41b0d87970f2c3420634a229. Connect to MEV Blocker via https://rpc.mevblocker.io",
@@ -280,7 +280,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/eth",
+        url: "https://public.1rpc.io/eth",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1009,7 +1009,7 @@ export const extraRpcs = {
       "https://bsc-mainnet.rpcfast.com?api_key=xbhWBI1Wkguk8SNMu1bvvLurPGLXmgwYeC4S6g2H7WdwFigZSmPWVZRxrskEQwIf",
       "https://nodes.vefinetwork.org/smartchain",
       {
-        url: "https://1rpc.io/bnb",
+        url: "https://public.1rpc.io/bnb",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1265,7 +1265,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/avax/c",
+        url: "https://public.1rpc.io/avax/c",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1375,7 +1375,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://1rpc.io/ftm",
+        url: "https://public.1rpc.io/ftm",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1475,7 +1475,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://1rpc.io/matic",
+        url: "https://public.1rpc.io/matic",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1638,7 +1638,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/cro",
+        url: "https://public.1rpc.io/cro",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -1827,7 +1827,7 @@ export const extraRpcs = {
       },
       "https://arb1.arbitrum.io/rpc",
       {
-        url: "https://1rpc.io/arb",
+        url: "https://public.1rpc.io/arb",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -2151,7 +2151,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.onfinality,
       },
       {
-        url: "https://1rpc.io/klay",
+        url: "https://public.1rpc.io/klay",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -2188,7 +2188,7 @@ export const extraRpcs = {
       "https://a.api.s0.t.hmny.io",
       "https://api.s0.t.hmny.io",
       {
-        url: "https://1rpc.io/one",
+        url: "https://public.1rpc.io/one",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -2377,7 +2377,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/opbnb",
+        url: "https://public.1rpc.io/opbnb",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -2428,7 +2428,7 @@ export const extraRpcs = {
     rpcs: [
       "https://mainnet.aurora.dev",
       {
-        url: "https://1rpc.io/aurora",
+        url: "https://public.1rpc.io/aurora",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -2649,7 +2649,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://1rpc.io/op",
+        url: "https://public.1rpc.io/op",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3042,7 +3042,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/gnosis",
+        url: "https://public.1rpc.io/gnosis",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3241,7 +3241,7 @@ export const extraRpcs = {
     rpcs: [
       "https://emerald.oasis.io",
       {
-        url: "https://1rpc.io/oasis/emerald",
+        url: "https://public.1rpc.io/oasis/emerald",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3251,7 +3251,7 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc.telos.net",
       {
-        url: "https://1rpc.io/telos/evm",
+        url: "https://public.1rpc.io/telos/evm",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3316,7 +3316,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.unitedbloc,
       },
       {
-        url: "https://1rpc.io/glmr",
+        url: "https://public.1rpc.io/glmr",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3459,7 +3459,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://1rpc.io/oktc",
+        url: "https://public.1rpc.io/oktc",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3499,7 +3499,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.tenderly,
       },
       {
-        url: "https://1rpc.io/boba/eth",
+        url: "https://public.1rpc.io/boba/eth",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3660,7 +3660,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.getblock,
       },
       {
-        url: "https://1rpc.io/astr",
+        url: "https://public.1rpc.io/astr",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -3875,7 +3875,7 @@ export const extraRpcs = {
   17000: {
     rpcs: [
       {
-        url: "https://1rpc.io/holesky",
+        url: "https://public.1rpc.io/holesky",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -4248,7 +4248,7 @@ export const extraRpcs = {
     rpcs: [
       "https://pacific-rpc.manta.network/http",
       {
-        url: "https://1rpc.io/manta",
+        url: "https://public.1rpc.io/manta",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -4508,7 +4508,7 @@ export const extraRpcs = {
       "https://rpc.coredao.org",
       "wss://ws.coredao.org",
       {
-        url: "https://1rpc.io/core",
+        url: "https://public.1rpc.io/core",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -4606,7 +4606,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
       {
-        url: "https://1rpc.io/zksync2-era",
+        url: "https://public.1rpc.io/zksync2-era",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -5157,7 +5157,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.drpc,
       },
       {
-        url: "https://1rpc.io/mantle",
+        url: "https://public.1rpc.io/mantle",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -5575,11 +5575,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blastapi,
       },
       {
-        url: "https://1rpc.io/base-goerli",
-        tracking: "none",
-        trackingDetails: privacyStatement.onerpc,
-      },
-      {
         url: "https://base-goerli.gateway.tenderly.co",
         tracking: "yes",
         trackingDetails: privacyStatement.tenderly,
@@ -5622,7 +5617,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.blockpi,
       },
       {
-        url: "https://1rpc.io/base",
+        url: "https://public.1rpc.io/base",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -5904,7 +5899,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.unifra,
       },
       {
-        url: "https://1rpc.io/scroll",
+        url: "https://public.1rpc.io/scroll",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -6057,7 +6052,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.publicnode,
       },
       {
-        url: "https://1rpc.io/sepolia",
+        url: "https://public.1rpc.io/sepolia",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -6498,7 +6493,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.gateway,
       },
       {
-        url: "https://1rpc.io/polygon/zkevm",
+        url: "https://public.1rpc.io/polygon/zkevm",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -6543,7 +6538,7 @@ export const extraRpcs = {
     rpcs: [
       "https://rpc.linea.build",
       {
-        url: "https://1rpc.io/linea",
+        url: "https://public.1rpc.io/linea",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -7057,7 +7052,7 @@ export const extraRpcs = {
     rpcs: [
       "https://sapphire.oasis.io",
       {
-        url: "https://1rpc.io/oasis/sapphire",
+        url: "https://public.1rpc.io/oasis/sapphire",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
@@ -7167,11 +7162,6 @@ export const extraRpcs = {
     rpcs: [
       "https://api.kroma.network",
       {
-        url: "https://1rpc.io/kroma",
-        tracking: "none",
-        trackingDetails: privacyStatement.onerpc,
-      },
-      {
         url: "https://kroma.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
@@ -7188,7 +7178,7 @@ export const extraRpcs = {
     rpcs: [
       "https://mainnet.mode.network",
       {
-        url: "https://1rpc.io/mode",
+        url: "https://public.1rpc.io/mode",
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },


### PR DESCRIPTION
We are migrating the domain from 1rpc.io to subdomain public.1rpc.io for a better domain management, please help to review.