### PR TITLE
Add Gravity (chainId 127001)

### DIFF
--- a/constants/additionalChainRegistry/127001.js
+++ b/constants/additionalChainRegistry/127001.js
@@ -1,4 +1,4 @@
-export default {
+export const data = {
   name: "Gravity",
   chain: "Gravity",
   icon: "gravity",

--- a/constants/additionalChainRegistry/127001.js
+++ b/constants/additionalChainRegistry/127001.js
@@ -1,0 +1,19 @@
+export default {
+  name: "Gravity",
+  chain: "Gravity",
+  icon: "gravity",
+  rpc: ["https://mainnet-rpc.gravity.xyz"],
+  faucets: [],
+  nativeCurrency: { name: "Gravity", symbol: "G", decimals: 18 },
+  infoURL: "https://gravity.xyz",
+  shortName: "grav",
+  chainId: 127001,
+  networkId: 127001,
+  explorers: [
+    {
+      name: "Gravity Mainnet Explorer",
+      url: "https://mainnet-explorer.gravity.xyz",
+      standard: "EIP3091",
+    },
+  ],
+}


### PR DESCRIPTION
## Add Gravity (chainId 127001)

Adds **Gravity** mainnet via `constants/additionalChainRegistry/127001.js`.

### Chain details
| field | value |
|---|---|
| name | Gravity |
| chainId / networkId | 127001 |
| shortName | grav |
| native currency | G (Gravity), 18 decimals |
| RPC | https://mainnet-rpc.gravity.xyz |
| explorer | https://mainnet-explorer.gravity.xyz (EIP3091) |
| infoURL | https://gravity.xyz |
| icon | gravity (already present in `constants/chainIcons/`) |

Chain metadata has already been merged into `ethereum-lists/chains` in https://github.com/ethereum-lists/chains/pull/8380.
