### PR TITLE
Add zkTanenbaum Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-57057.js
+++ b/constants/additionalChainRegistry/chainid-57057.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "zkTanenbaum Testnet",
+  chain: "ZKSYS",
+  rpc: ["https://rpc-zk.tanenbaum.io"],
+  faucets: ["https://faucet-zk.tanenbaum.io"],
+  nativeCurrency: {
+    name: "Testnet Syscoin",
+    symbol: "TSYS",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://syscoin.org",
+  shortName: "zktanenbaum",
+  chainId: 57057,
+  networkId: 57057,
+  explorers: [
+    {
+      name: "zkTanenbaum Block Explorer",
+      url: "https://explorer-zk.tanenbaum.io",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Adds zkTanenbaum Testnet (`57057`) to Chainlist's additional chain registry.

Network metadata:
- RPC: `https://rpc-zk.tanenbaum.io`
- Explorer: `https://explorer-zk.tanenbaum.io`
- Faucet: `https://faucet-zk.tanenbaum.io`
- Native currency: `TSYS`
- Chain metadata PR: https://github.com/ethereum-lists/chains/pull/8391

zkTanenbaum is a Syscoin zkSYS edge testnet running ZKsync OS v31. It exposes standard EVM JSON-RPC for wallets and developer tooling, uses Syscoin DA, and settles through the zkSYS Gateway on Syscoin Tanenbaum.

## Validation

- `node --input-type=module -e "import './constants/additionalChainRegistry/chainid-57057.js'"`
- `npx prettier --check constants/additionalChainRegistry/chainid-57057.js`
- `npm test`
