### PR TITLE
Add INRI chain icon and RPC endpoint

### DIFF
--- a/constants/additionalChainRegistry/chainid-3777.js
+++ b/constants/additionalChainRegistry/chainid-3777.js
@@ -1,7 +1,8 @@
 export const data = {
   name: "INRI CHAIN",
   chain: "INRI",
-  rpc: ["https://rpc.inri.life"],
+  icon: "inri",
+  rpc: ["https://rpc.inri.life", "https://rpc-chain.inri.life"],
   faucets: [],
   nativeCurrency: {
     name: "INRI",


### PR DESCRIPTION
Adds the INRI chain icon and updates the RPC endpoints.

Network:
- Name: INRI CHAIN
- Chain ID: 3777
- Short name: inri
- RPCs:
  - https://rpc.inri.life
  - https://rpc-chain.inri.life
- Explorer: https://explorer.inri.life
- Website: https://inri.life
- Platform/apps: https://platform.inri.life

Changes:
- Adds icon: "inri"
- Adds the secondary official RPC endpoint

RPC provider information:
The RPC endpoints are official INRI CHAIN public RPC endpoints operated by the INRI CHAIN project for public access to chainId 3777.

Privacy policy:
A dedicated RPC privacy policy page is not currently published. These are official chain infrastructure endpoints, not a third-party RPC provider.