### PR TITLE
Add RANNTA X-Chain configuration

### DIFF
--- a/constants/additionalChainRegistry/chainid-13113.js
+++ b/constants/additionalChainRegistry/chainid-13113.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "RANNTA X-Chain",
+  chain: "RANNTA",
+  rpc: ["https://rpc.rannta.com/"],
+  nativeCurrency: {
+    name: "RANNTA Core X",
+    symbol: "RNTX",
+    decimals: 18,
+  },
+  features: [],
+  infoURL: "https://rannta.com/",
+  shortName: "rntx",
+  chainId: 13113,
+  networkId: 13113,
+  icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+  explorers: [
+    {
+      name: "RANNTA X-Chain Explorer",
+      url: "https://explorer.rannta.com/",
+      icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
This PR adds RANNTA X-Chain to ChainList.

Network details:

- Network name: RANNTA X-Chain
- Chain ID: 13113
- Network ID: 13113
- Native currency: RANNTA Core X
- Symbol: RNTX
- Decimals: 18
- RPC: https://rpc.rannta.com/
- Explorer: https://explorer.rannta.com/
- Website: https://rannta.com/

Registry evidence:

- RANNTA X-Chain is already registered in ethereum-lists/chains.
- chainid.network propagation is verified.
- Chain ID 13113 is present in https://chainid.network/chains.json.