### PR TITLE
Add LadyChain (chainId 589) RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3485,6 +3485,15 @@ export const extraRpcs = {
       "https://test-rpc.netxscan.io",
     ],
   },
+  589: {
+      rpcs: [
+        {
+          url: "https://ladyrpc.us/rpc",
+          tracking: "none",
+          trackingDetails: "LadyRPC does not collect or store any user data including IP addresses or transaction details.",
+        },
+      ],
+    },
   288: {
     rpcs: [
       "https://mainnet.boba.network/",


### PR DESCRIPTION
## Add LadyChain RPC

  Adds the public RPC endpoint for **LadyChain** (chain ID 589), a production EVM-compatible chain running Hyperledger Besu with QBFT consensus.

  - **Chain ID:** 589
  - **RPC:** https://ladyrpc.us/rpc
  - **Explorer:** https://ladyscan.us
  - **Native currency:** LADY (18 decimals)
  - **Tracking:** none — LadyRPC does not collect or store any user data including IP addresses or transaction details.