### PR TITLE
Add RPC for chain 7777 (TTL Coin)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5279,6 +5279,15 @@ export const extraRpcs = {
       "https://canto.dexrouting.com",
     ],
   },
+  7777: {
+    rpcs: [
+      {
+        url: "https://rpc.ttl1.top",
+        tracking: "none",
+        trackingDetails: "TTL Coin official RPC operated by TTL Inc. No request logging, no user tracking.",
+      },
+    ],
+  },
   7924: {
     rpcs: ["https://mainnet-rpc.mochain.app/"],
   },


### PR DESCRIPTION
Adding a public RPC for chain 7777, which is already merged in ethereum-lists/chains:
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-7777.json

RPC info:
- Operator: TTL Inc. (official)
- Tracking: none. No request logging, no IP retention.
- Rate limited: [No / TTL]
- Operator website: https://scan.ttl1.top/