### PR TITLE
fix: Correct MANTRA Chain name and native currency (chainId 5888)

### DIFF
--- a/constants/additionalChainRegistry/chainid-5888.js
+++ b/constants/additionalChainRegistry/chainid-5888.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "MANTRA Chain",
+  "chain": "MANTRA",
+  "rpc": [
+    "https://evm.mantrachain.io",
+    "wss://evm.mantrachain.io/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MANTRA",
+    "symbol": "MANTRA",
+    "decimals": 18
+  },
+  "infoURL": "https://mantrachain.io",
+  "shortName": "mantra",
+  "chainId": 5888,
+  "networkId": 5888,
+  "explorers": [
+    {
+      "name": "MANTRA Explorer",
+      "url": "https://blockscout.mantrascan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

MANTRA Chain (chainId 5888) currently appears on chainlist.org with incorrect values:
- **Name** shows `MANTRACHAIN` → should be `MANTRA Chain`
- **Currency symbol** shows `OM` → should be `MANTRA`

The token was redenominated from OM to MANTRA, and the chain name should include a space.

## Fix

Added `constants/additionalChainRegistry/chainid-5888.js` with the correct chain name, native currency symbol, RPC endpoints, and explorer.

## References

- Chain docs: https://docs.mantrachain.io
- EVM RPC: https://evm.mantrachain.io
- Explorer: https://blockscout.mantrascan.io
- Official website: https://mantrachain.io