### PR TITLE
Add Whitechain Sepolia (1874)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1874.js
+++ b/constants/additionalChainRegistry/chainid-1874.js
@@ -1,0 +1,23 @@
+export const data = {
+    "name": "Whitechain Sepolia",
+    "chain": "WCH",
+    "rpc": [
+      "https://rpc.testnet.whitechain.io"
+    ],
+    "faucets": ["https://faucet.testnet.whitechain.io"],
+    "nativeCurrency": {
+      "name": "WBT",
+      "symbol": "WBT",
+      "decimals": 18
+    },
+    "infoURL": "https://docs.whitechain.io",
+    "shortName": "WCH Sepolia",
+    "chainId": 1874,
+    "networkId": 1874,
+    "icon": "https://a.whitechain.io/assets/brand/symbol/png/symbol-on-dark-256.png",
+    "explorers": [{
+      "name": "Whitechain Testnet Explorer",
+      "url": "https://explorer.testnet.whitechain.io",
+      "standard": "EIP3091"
+    }]
+  }


### PR DESCRIPTION
## Add Whitechain Sepolia (chainId 1874)

Adds **Whitechain** testnet via `constants/additionalChainRegistry/chainid-1874.js`.

### Chain details
| field | value |
|---|---|
| name | Whitechain Sepolia |
| chainId / networkId | 1874 |
| shortName | WCH |
| native currency | WBT, 18 decimals |
| RPC | https://rpc.testnet.whitechain.io |
| explorer | https://explorer.testnet.whitechain.io |
| infoURL | https://docs.whitechain.io |
