### PR TITLE
Add icon for NirmalX Smart Chain (Chain ID 15526)

### DIFF
--- a/constants/additionalChainRegistry/chainid-15526.js
+++ b/constants/additionalChainRegistry/chainid-15526.js
@@ -14,10 +14,12 @@ export const data = {
   shortName: "nrxn",
   chainId: 15526,
   networkId: 15526,
+  icon: "https://gateway.pinata.cloud/ipfs/bafybeib2n3272ga73alqnis6lsvlnjvt5hilihsf4yfxo4t7ebs6exejhm",
   explorers: [
     {
       name: "NirmalX Explorer",
       url: "https://nirmalxscan.com",
+      icon: "https://gateway.pinata.cloud/ipfs/bafybeib2n3272ga73alqnis6lsvlnjvt5hilihsf4yfxo4t7ebs6exejhm",
       standard: "EIP3091"
     }
   ]


### PR DESCRIPTION
Added icon metadata for NirmalX Smart Chain.

Chain ID: 15526
Website: https://nirmalx.io/
Explorer: https://nirmalxscan.com

Icon hosted on IPFS.