### PR TITLE
Add COTI mainnet WebSocket RPC (chainId 2632500)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9331,6 +9331,7 @@ export const extraRpcs = {
       },
       "https://tokyo.fullnode.mainnet.coti.io/rpc",
       "wss://tokyo.fullnode.mainnet.coti.io/ws",
+      "wss://mainnet.coti.io/ws",
       "https://virginia.fullnode.mainnet.coti.io/rpc",
       "wss://virginia.fullnode.mainnet.coti.io/ws",
       "https://new-york.fullnode.mainnet.coti.io/rpc",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9338,6 +9338,8 @@ export const extraRpcs = {
       "wss://new-york.fullnode.mainnet.coti.io/ws",
       "https://community-enabler-1.fullnode.mainnet.coti.io/rpc",
       "wss://community-enabler-1.fullnode.mainnet.coti.io/ws",
+      "https://frankfurt.fullnode.mainnet.coti.io/rpc",
+      "wss://frankfurt.fullnode.mainnet.coti.io/ws",
     ],
   },
   7082400: {


### PR DESCRIPTION
Adds the official COTI mainnet WebSocket RPC endpoint `wss://mainnet.coti.io/ws`, "https://frankfurt.fullnode.mainnet.coti.io/rpc",
"wss://frankfurt.fullnode.mainnet.coti.io/ws",
 to the extraRpcs for chain ID 2632500.