### PR TITLE
feat: add Satelink RPC endpoint for Polygon Mainnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1459,10 +1459,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.ankr,
       },
       "https://polygon-rpc.com",
-      {
-        url: "https://rpc.satelink.network/rpc/polygon",
-        tracking: "limited",
-      },
+      "https://rpc.satelink.network/rpc/polygon",
       {
         url: "https://rpc-mainnet.matic.quiknode.pro",
         tracking: "yes",
@@ -10122,3 +10119,4 @@ export const extraRpcs = {
 };
 
 export default extraRpcs;
+

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1618,10 +1618,7 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.rpcfree,
       },
-      { 
-        url: "https://rpc.satelink.network/rpc/polygon",
-       tracking: "none", 
-      },
+
     ],
   },
   25: {
@@ -10119,4 +10116,5 @@ export const extraRpcs = {
 };
 
 export default extraRpcs;
+
 

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1460,6 +1460,10 @@ export const extraRpcs = {
       },
       "https://polygon-rpc.com",
       {
+        url: "https://rpc.satelink.network/rpc/polygon",
+        tracking: "limited",
+      },
+      {
         url: "https://rpc-mainnet.matic.quiknode.pro",
         tracking: "yes",
         trackingDetails: privacyStatement.quicknode,

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10116,5 +10116,3 @@ export const extraRpcs = {
 };
 
 export default extraRpcs;
-
-


### PR DESCRIPTION
Adds Satelink DePIN RPC gateway as an additional Polygon Mainnet endpoint.

**Endpoint:** `https://rpc.satelink.network/rpc/polygon`
**Tracking:** limited
**Uptime:** 99.5%
**Latency:** ~85ms avg