### PR TITLE
Fix workflow pnpm setup version conflict

### DIFF
--- a/.github/workflows/check-duplicate-keys.yml
+++ b/.github/workflows/check-duplicate-keys.yml
@@ -16,10 +16,10 @@ jobs:
   check-duplicates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 

--- a/.github/workflows/validate-chain-files.yml
+++ b/.github/workflows/validate-chain-files.yml
@@ -10,18 +10,17 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 11.5.0
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.13
           cache: 'pnpm'
@@ -51,7 +50,7 @@ jobs:
 
       - name: Comment on PR if validation fails
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- update workflow actions to Node 24-capable major versions
- remove the duplicate pnpm version input so pnpm/action-setup uses package.json packageManager
- update the duplicate key workflow checkout and setup-node actions

## Verification
- YAML files load successfully
- git diff --check passes