### PR TITLE
feat: add additional rpc for Seismic Testnet

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10114,7 +10114,16 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.sentio,
       }
     ]
-  }
+  },
+  5124: {
+    rpcs: [
+      {
+        url: "https://testnet-1.seismictest.net/rpc",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
+    ],
+  },
 };
 
 export default extraRpcs;


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.seismic.systems/

#### Provide a link to your privacy policy:
N/A

#### If the RPC has none of the above and you still think it should be added, please explain why:
Currently displayed endpoints for Seismic Tesnet (5124) are not available.

Your RPC should always be added at the end of the array.