### PR TITLE
Add Unitsky String Technologies (778889)

### DIFF
--- a/constants/additionalChainRegistry/chainid-778889.js
+++ b/constants/additionalChainRegistry/chainid-778889.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "Unitsky String Technologies",
+  "chain": "Unitsky String Technologies",
+  "rpc": [
+    "https://147-45-143-23.sslip.io/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Unitsky Token",
+    "symbol": "UST",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://147-45-143-23.sslip.io",
+  "shortName": "ust",
+  "chainId": 778889,
+  "networkId": 778889,
+  "icon": "https://147-45-143-23.sslip.io/icon.svg",
+  "explorers": [
+    {
+      "name": "Unitsky Explorer",
+      "url": "https://147-45-143-23.sslip.io",
+      "icon": "https://147-45-143-23.sslip.io/icon.svg",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-778889.js
+++ b/constants/additionalChainRegistry/chainid-778889.js
@@ -1,6 +1,6 @@
 export const data = {
   "name": "Unitsky String Technologies",
-  "chain": "Unitsky String Technologies",
+  "chain": "Unitsky",
   "rpc": [
     "https://147-45-143-23.sslip.io/rpc"
   ],
@@ -20,8 +20,7 @@ export const data = {
     {
       "name": "Unitsky Explorer",
       "url": "https://147-45-143-23.sslip.io",
-      "icon": "https://147-45-143-23.sslip.io/icon.svg",
-      "standard": "EIP3091"
+      "standard": "none"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add **Unitsky String Technologies** — private EVM network (Geth, Clique PoA).

| Field | Value |
|-------|-------|
| Chain ID | 778889 (0xbe289) |
| Native token | UST (18 decimals) |
| HTTPS RPC | https://147-45-143-23.sslip.io/rpc |
| Explorer | https://147-45-143-23.sslip.io |
| Icon | https://147-45-143-23.sslip.io/icon.svg |

## Verification
- [x] eth_chainId returns 0xbe289
- [x] net_version returns 778889
- [x] HTTPS RPC with valid TLS
- [x] Block explorer online at infoURL
- [x] Explorer standard: none (Geth JSON-RPC, not EIP-3091)