### PR TITLE
add Gleec Mainnet (11169)

### DIFF
--- a/constants/additionalChainRegistry/chainid-11169.js
+++ b/constants/additionalChainRegistry/chainid-11169.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Gleec Mainnet",
+  chain: "GLEEC",
+  rpc: ["https://evm-rpc.gleec.com", "wss://evm-ws.gleec.com"],
+  faucets: [],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  nativeCurrency: {
+    name: "GLEEC",
+    symbol: "GLEEC",
+    decimals: 18,
+  },
+  infoURL: "https://evm-info.gleec.com/",
+  shortName: "gleec",
+  chainId: 11169,
+  networkId: 11169,
+  explorers: [
+    {
+      name: "Gleec EVM Explorer",
+      url: "https://evm-explorer.gleec.com",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
  Gleec Chain is an EVM-compatible network built on a fork of evmosd (Evmos /
  Ethermint), so it supports EIP155 (replay protection) and EIP1559 (fee market).

  Source of the chain data: https://evm-info.gleec.com/

  | Field        | Value |
  |--------------|-------|
  | Chain ID     | 11169 (0x2BA1) |
  | Native coin  | GLEEC (18 decimals) |
  | HTTP RPC     | https://evm-rpc.gleec.com |
  | WSS RPC      | wss://evm-ws.gleec.com |
  | Explorer     | https://evm-explorer.gleec.com (Blockscout, EIP3091) |

  Verified:
  - `eth_chainId` over both HTTP and WSS returns `0x2ba1` (= 11169).
  - The node is live and syncing (`eth_blockNumber` advancing).
  - chainId 11169 and shortName `gleec` are not yet present in chainlist.org/rpcs.json.

  #### Link the service provider's website:
  The RPC endpoints are operated by the Gleec project itself: https://evm-info.gleec.com/ (project site: https://gleec.com)

  #### Provide a link to your privacy policy:
  https://gleec.com/privacy-policy