### PR TITLE
Add Mawari Mainnet (1576)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1576.js
+++ b/constants/additionalChainRegistry/chainid-1576.js
@@ -1,0 +1,27 @@
+export const data = {
+  name: "Mawari Mainnet",
+  chain: "MAWARI",
+  rpc: [
+    "https://rpc.mawari.net/http",
+    "wss://rpc.mawari.net/ws"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "MAWARI",
+    symbol: "MAWARI",
+    decimals: 18
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://mawari.net",
+  shortName: "mawari",
+  chainId: 1576,
+  networkId: 1576,
+  icon: "mawari",
+  explorers: [
+    {
+      name: "blockscout",
+      url: "https://explorer.mainnet.mawari.net",
+      standard: "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- Add Mawari Mainnet (chain ID 1576) to the additional chain registry
- RPC: https://rpc.mawari.net/http
- WebSocket: wss://rpc.mawari.net/ws
- Explorer: https://hub.mawari.net/
- website: https://www.mawari.net/