### PR TITLE
Add MetaFlux Devnet (114514)

### DIFF
--- a/constants/additionalChainRegistry/chainid-114514.js
+++ b/constants/additionalChainRegistry/chainid-114514.js
@@ -1,0 +1,21 @@
+export const data = {
+  "name": "MetaFlux Devnet",
+  "chain": "MetaFluxEVM",
+  "rpc": [
+    "https://devnet-gateway.mtf.exchange/evm"
+  ],
+  "faucets": [
+    "https://devnet.mtf.exchange/faucet"
+  ],
+  "nativeCurrency": {
+    "name": "MetaFlux",
+    "symbol": "MTF",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://mtf.exchange",
+  "shortName": "mtf",
+  "chainId": 114514,
+  "networkId": 114514,
+  "icon": "https://mtf.exchange/logo/metaflux-mark-square-mono.svg"
+}


### PR DESCRIPTION
Adds the MetaFlux Devnet (chainId 114514) to the additional chain registry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://mtf.exchange — the RPC endpoint is operated by the MetaFlux project itself.

#### Provide a link to your privacy policy:
https://mtf.exchange

#### If the RPC has none of the above and you still think it should be added, please explain why:
This PR adds a new chain (not just an RPC). The RPC `https://devnet-gateway.mtf.exchange/evm` is the official gateway operated by the chain/project.