### PR TITLE
Add BattleChain Mainnet (chainId 626)

### DIFF
--- a/constants/additionalChainRegistry/chainid-626.js
+++ b/constants/additionalChainRegistry/chainid-626.js
@@ -1,0 +1,26 @@
+export const data = {
+    "name": "BattleChain Mainnet",
+    "chain": "BattleChain",
+    "rpc": [
+      "https://mainnet.battlechain.com"
+    ],
+    "features": [{ "name": "EIP155" }],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18
+    },
+    "infoURL": "https://battlechain.com",
+    "shortName": "battlechain",
+    "chainId": 626,
+    "networkId": 626,
+    "status": "active",
+    "explorers": [
+      {
+        "name": "BattleChain Explorer",
+        "url": "https://explorer.battlechain.com",
+        "standard": "EIP3091"
+      }
+    ]
+  };


### PR DESCRIPTION
Adds `constants/additionalChainRegistry/chainid-626.js` for BattleChain mainnet, a ZKsync-based Ethereum L2. Modeled on the existing testnet entry (627).