### PR TITLE
Add additional RPC endpoints for TAAQO Mainnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-5566.js
+++ b/constants/additionalChainRegistry/chainid-5566.js
@@ -2,7 +2,9 @@ export const data = {
   "name": "TAAQO Mainnet",
   "chain": "TAAQO",
   "rpc": [
-    "https://rpc.taaqo.com"
+    "https://rpc.taaqo.com",
+    "https://rpc2.taaqo.com",
+    "https://rpc3.taaqo.com"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
We added 2 new rpc url

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC): https://taaqo.com


#### Provide a link to your privacy policy:  https://taaqo.com/privacy


#### If the RPC has none of the above and you still think it should be added, please explain why:

We are adding 2 additional RPC endpoints (rpc2.taaqo.com and rpc3.taaqo.com) 
for the existing TAAQO Mainnet (Chain ID 5566). These endpoints are hosted on 
independent validator nodes for high availability and fault tolerance. 
All 3 RPC endpoints are live, validated, and serving the same chain data.

Your RPC should always be added at the end of the array.