### PR TITLE
Add dual network (6301)

### DIFF
--- a/constants/additionalChainRegistry/chainid-6301.js
+++ b/constants/additionalChainRegistry/chainid-6301.js
@@ -1,0 +1,30 @@
+export const data = {
+  "name": "dual network",
+  "chain": "DUAL",
+  "icon": "dual",
+  "rpc": [
+    "https://rpc.dual.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "dual",
+    "symbol": "dual",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "https://dual.org",
+  "shortName": "dual",
+  "chainId": 6301,
+  "networkId": 6301,
+  "explorers": [
+    {
+      "name": "Dual Network",
+      "url": "https://blockscout.dual.network",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds dual network (chainId 6301) to the additional chain registry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://dual.org

#### Provide a link to your privacy policy:
N/A