### PR TITLE
Add dchain testnet and mainnet chain ids

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -309,4 +309,6 @@ export default {
   "836542336838601": "curio",
   "2716446429837000": "dchain",
   "15526": "nrxn",
+  "430": "dchain-testnet",
+  "433": "dchain-mainnet",
 }


### PR DESCRIPTION
Adding the chain ids for the Dchain protocol.
The website is https://dfoundation.io/