### PR TITLE
feat(chains): add BitVault BVM20 chainId 31338

### DIFF
--- a/_data/chains/eip155-31338.json
+++ b/_data/chains/eip155-31338.json
@@ -1,0 +1,25 @@
+{
+  "name": "BitVault BVM20",
+  "chain": "BVM20",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.bitvault.club"
+  ],
+  "faucets": ["https://faucet.bitvault.club"],
+  "nativeCurrency": {
+    "name": "BitVault Token",
+    "symbol": "BVT",
+    "decimals": 18
+  },
+  "infoURL": "https://bitvault.club",
+  "shortName": "bvm20",
+  "chainId": 31338,
+  "networkId": 31338,
+  "explorers": [
+    {
+      "name": "BitVault Explorer",
+      "url": "https://explorer.bitvault.club",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds BitVault BVM20 as a new chain (not just a new RPC).

#### Link the service provider's website:
https://bitvault.club — official first-party RPC operated by the BitVault project.

#### Provide a link to your privacy policy:
https://bitvault.club/privacy

#### Additional context:
BitVault BVM20 is an EVM-compatible L2 chain (chainId 31338) built on Hyperledger Besu, part of the BitVault dual-chain ecosystem (custom L1 + BVM20 EVM L2). The RPC at https://rpc.bitvault.club is live and returning correct responses. Explorer at https://explorer.bitvault.club. Faucet at https://faucet.bitvault.club. Mainnet launch: August 28, 2026.