### PR TITLE
Add daventre Mainnet (chainId 8770570)

### DIFF
--- a/constants/additionalChainRegistry/chainid-8770570
+++ b/constants/additionalChainRegistry/chainid-8770570
@@ -1,0 +1,26 @@
+module.exports = {
+  "name": "daventre Chain",
+  "chain": "DEV",
+  "rpc": [
+    "https://rpc.8770570.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "DEV",
+    "symbol": "DEV",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "http://8770570.xyz",
+  "shortName": "daventre",
+  "chainId": 8770570,
+  "networkId": 8770570,
+  "explorers": [
+    {
+      "name": "daventre Explorer",
+      "url": "https://explorer.8770570.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+};

--- a/constants/additionalChainRegistry/chainid-8770570
+++ b/constants/additionalChainRegistry/chainid-8770570
@@ -1,4 +1,4 @@
-module.exports = {
+export const data = {
   "name": "daventre Chain",
   "chain": "DEV",
   "rpc": [


### PR DESCRIPTION
**Link the service provider's website (the company/protocol/individual providing the RPC):**
The official website for the network is currently under construction and will be hosted at [http://8770570.xyz](http://8770570.xyz). The RPC infrastructure is directly managed and hosted by the core creators of daventre Chain.

**Provide a link to your privacy policy:**
We do not have a dedicated privacy policy page yet, as the website is still under construction.

**If the RPC has none of the above and you still think it should be added, please explain why:**
This is a brand-new network registration for daventre Chain (Chain ID: 8770570). The RPC endpoint [https://rpc.8770570.xyz](https://rpc.8770570.xyz) is the official, primary bootstrap node required for the community and developers to connect to the chain. The node is configured as a standard, secure Geth RPC endpoint and we guarantee that we do not log, store, or track any user data or IP addresses. We are fully committed to privacy and will publish a formal policy as soon as the landing page is live.