### PR TITLE
Add LUST Chain mainnet (chain ID 6923)

### DIFF
--- a/constants/additionalChainRegistry/chainid-6923.js
+++ b/constants/additionalChainRegistry/chainid-6923.js
@@ -1,0 +1,33 @@
+export const data = {
+name: "LUST Chain",
+chain: "LUST",
+icon: "lust",
+rpc: [
+"https://rpc.lustchain.org"
+],
+faucets: [],
+nativeCurrency: {
+name: "LUST",
+symbol: "LST",
+decimals: 18
+},
+features: [
+{
+name: "EIP155"
+},
+{
+name: "EIP1559"
+}
+],
+infoURL: "https://lustchain.org/",
+shortName: "lust",
+chainId: 6923,
+networkId: 6923,
+explorers: [
+{
+name: "LUST Explorer",
+url: "https://explorer.lustchain.org/",
+standard: "EIP3091"
+}
+]
+};

--- a/constants/additionalChainRegistry/chainid-6923.js
+++ b/constants/additionalChainRegistry/chainid-6923.js
@@ -1,33 +1,31 @@
 export const data = {
-name: "LUST Chain",
-chain: "LUST",
-icon: "lust",
-rpc: [
-"https://rpc.lustchain.org"
-],
-faucets: [],
-nativeCurrency: {
-name: "LUST",
-symbol: "LST",
-decimals: 18
-},
-features: [
-{
-name: "EIP155"
-},
-{
-name: "EIP1559"
-}
-],
-infoURL: "https://lustchain.org/",
-shortName: "lust",
-chainId: 6923,
-networkId: 6923,
-explorers: [
-{
-name: "LUST Explorer",
-url: "https://explorer.lustchain.org/",
-standard: "EIP3091"
-}
-]
+  name: "LUST Chain",
+  chain: "LUST",
+  icon: "lust",
+  rpc: ["https://rpc.lustchain.org"],
+  faucets: [],
+  nativeCurrency: {
+    name: "LUST",
+    symbol: "LST",
+    decimals: 18,
+  },
+  features: [
+    {
+      name: "EIP155",
+    },
+    {
+      name: "EIP1559",
+    },
+  ],
+  infoURL: "https://lustchain.org/",
+  shortName: "lust",
+  chainId: 6923,
+  networkId: 6923,
+  explorers: [
+    {
+      name: "LUST Explorer",
+      url: "https://explorer.lustchain.org/",
+      standard: "EIP3091",
+    },
+  ],
 };


### PR DESCRIPTION
## Summary

Adds LUST Chain mainnet to Chainlist with its official public RPC, native currency, explorer, website, and chain icon reference.

## Network details

* Chain name: LUST Chain
* Chain ID: 6923
* Network ID: 6923
* Short name: `lust`
* Native currency: LST
* Native currency decimals: 18
* Network type: Mainnet
* Layer: L1
* EVM compatible: Yes
* EIP-155: Supported
* EIP-1559: Supported
* Official website: https://lustchain.org/
* Ecosystem platform: https://platform.lustchain.org/
* Public RPC: https://rpc.lustchain.org/
* Explorer: https://explorer.lustchain.org/
* Icon slug: `lust`

## Icon

The matching LUST Chain icon was submitted here:

https://github.com/DefiLlama/icons/pull/2410

Expected icon file:

`assets/chains/rsz_lust.png`

## RPC provider information

The RPC endpoint is an official LUST Chain public infrastructure endpoint operated by the LUST Chain project.

Provider website:

https://lustchain.org/

## Verification

* The RPC uses HTTPS.
* The RPC serves LUST Chain mainnet.
* The expected chain ID is 6923.
* The explorer is publicly accessible.
* The official website is publicly accessible.
* The ecosystem platform is publicly accessible.