### PR TITLE
 Campione Infrastructure BSC RPC endpointe  

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -956,6 +956,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.nodeflare,
       },
       "https://bsc-dataseed.bnbchain.org/",
+      "https://bsc.campioneinfrastructure.com",
       "https://bsc-dataseed1.defibit.io/",
       "https://bsc-dataseed1.ninicoin.io/",
       "https://bsc-dataseed2.defibit.io/",


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://campioneinfrastructure.com

#### Provide a link to your privacy policy:
 (https://www.campioneinfrastructure.com/compliance.html)

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is a self-hosted BSC full node operated by Campione Infrastructure, an independent blockchain infrastructure provider. The endpoint is publicly accessible over HTTPS with rate limiting in place. No privacy policy is currently published as this is a small independent operator, not a commercial data-collecting service — no user data is logged or tracked beyond standard server access logs.

Your RPC should always be added at the end of the array.