### PR TITLE
Update Orbinum RPC, icon, explorer and faucet (270, 2700)

### DIFF
--- a/constants/additionalChainRegistry/chainid-270.js
+++ b/constants/additionalChainRegistry/chainid-270.js
@@ -1,9 +1,10 @@
 export const data = {
     "name": "Orbinum",
     "chain": "ORB",
-    "icon": "https://orbinum.network/isotipo-black.svg",
+    "icon": "https://cdn.orbinum.io/assets/isotipo-black.png",
     "rpc": [
-      "https://rpc.orbinum.io"
+      "https://rpc-1.orbinum.io",
+      "https://rpc-2.orbinum.io"
     ],
     "faucets": [],
     "nativeCurrency": {
@@ -18,8 +19,8 @@ export const data = {
     "explorers": [
       {
         "name": "Orbinum Privacy Explorer",
-        "url": "https://explorer.orbinum.network/",
-        "icon": "https://orbinum.network/isotipo-black.svg",
+        "url": "https://explorer.orbinum.network",
+        "icon": "https://cdn.orbinum.io/assets/isotipo-black.png",
         "standard": "EIP3091"
       }
     ]

--- a/constants/additionalChainRegistry/chainid-2700.js
+++ b/constants/additionalChainRegistry/chainid-2700.js
@@ -1,11 +1,14 @@
 export const data = {
     "name": "Orbinum Testnet",
     "chain": "ORB",
-    "icon": "https://orbinum.network/isotipo-black.svg",
+    "icon": "https://cdn.orbinum.io/assets/isotipo-black.png",
     "rpc": [
-      "https://testnet-rpc.orbinum.io"
+      "https://rpc-1.testnet.orbinum.io",
+      "https://rpc-2.testnet.orbinum.io"
     ],
-    "faucets": [],
+    "faucets": [
+      "https://faucet.orbinum.network"
+    ],
     "nativeCurrency": {
       "name": "ORB",
       "symbol": "ORB",
@@ -18,8 +21,8 @@ export const data = {
     "explorers": [
       {
         "name": "Orbinum Privacy Explorer",
-        "url": "https://testnet-explorer.orbinum.network/",
-        "icon": "https://orbinum.network/isotipo-black.svg",
+        "url": "https://explorer.testnet.orbinum.network",
+        "icon": "https://cdn.orbinum.io/assets/isotipo-black.png",
         "standard": "EIP3091"
       }
     ]


### PR DESCRIPTION
## Summary

Updates the Orbinum network metadata for both Mainnet (chainId 270) and Testnet (chainId 2700):

- **Icon**: migrated to CDN-hosted PNG (`https://cdn.orbinum.io/assets/isotipo-black.png`)
- **RPC**: updated endpoints and added a second RPC node for redundancy
- **Explorer**: updated to the new explorer URLs
- **Faucet**: added the testnet faucet (`https://faucet.orbinum.network`)

## Changes

### chainId 270 (Orbinum Mainnet)
- RPC: `rpc.orbinum.io` → `rpc-1.orbinum.io` + `rpc-2.orbinum.io`
- Explorer: `https://explorer.orbinum.network`
- Icon: CDN PNG

### chainId 2700 (Orbinum Testnet)
- RPC: `testnet-rpc.orbinum.io` → `rpc-1.testnet.orbinum.io` + `rpc-2.testnet.orbinum.io`
- Explorer: `https://explorer.testnet.orbinum.network`
- Faucet: `https://faucet.orbinum.network`
- Icon: CDN PNG