### PR TITLE
Adding missing Tatum RPC endpoints

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1356,6 +1356,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
       },
+      {
+        url: "https://avax-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   250: {
@@ -1991,6 +1996,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.rpcfree,
       },
+      {
+        url: "https://arbitrum-one-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   421613: {
@@ -2225,6 +2235,11 @@ export const extraRpcs = {
         url: "https://harmony.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+      {
+        url: "https://one-mainnet-s0.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
       },
     ],
   },
@@ -3254,6 +3269,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.onerpc,
       },
+      {
+        url: "https://oasis-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   40: {
@@ -3427,6 +3447,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
       },
+      {
+        url: "https://rsk-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
 
@@ -3553,6 +3578,11 @@ export const extraRpcs = {
         tracking: "yes",
         trackingDetails: privacyStatement.tokenview,
       },
+      {
+        url: "https://kcs-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   888: {
@@ -3581,6 +3611,11 @@ export const extraRpcs = {
       "https://songbird-api.flare.network/ext/C/rpc",
       "https://rpc.ftso.au/songbird",
       "https://songbird.solidifi.app/ext/C/rpc",
+      {
+        url: "https://flare-songbird.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   122: {
@@ -4037,6 +4072,11 @@ export const extraRpcs = {
         url: "https://api.evm.eosnetwork.com",
         tracking: "yes",
         trackingDetails: privacyStatement.eosnetwork,
+      },
+      {
+        url: "https://eos-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
       },
     ],
   },
@@ -4662,6 +4702,11 @@ export const extraRpcs = {
         url: "https://zksync-era.rpc.sentio.xyz",
         tracking: "limited",
         trackingDetails: privacyStatement.sentio,
+      },
+      {
+        url: "https://zksync-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
       },
     ],
   },
@@ -7676,6 +7721,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
       },
+      {
+        url: "https://lisk-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   656476: {
@@ -8559,6 +8609,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
       },
+      {
+        url: "https://sonic-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   57054: {
@@ -9287,6 +9342,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.fastnode,
       },
+      {
+        url: "https://tron-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
 
@@ -9483,6 +9543,11 @@ export const extraRpcs = {
         url: "https://rpc.swiftnodes.io/rpc/plasma",
         tracking: "limited",
         trackingDetails: privacyStatement.swiftnodes,
+      },
+      {
+        url: "https://plasma-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
       },
     ],
     websiteDead: false,
@@ -9878,6 +9943,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://near-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
+      },
     ],
   },
   2523: {
@@ -10129,6 +10199,11 @@ export const extraRpcs = {
         url: "https://testnet-1.seismictest.net/rpc",
         tracking: "none",
         trackingDetails: "No user tracking or data collection",
+      },
+      {
+        url: "https://hyperevm-mainnet.gateway.tatum.io",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tatum,
       },
     ],
   },


### PR DESCRIPTION
Hi,

I've reviewed constants/extraRpcs.js against Tatum's public gateway endpoints and added 16 missing Tatum RPC URLs for chains that already had other providers listed but were missing Tatum.

All new entries follow the existing pattern:

tracking: "yes"
trackingDetails: privacyStatement.tatum

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://tatum.io/

#### Provide a link to your privacy policy:
https://tatum.io/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.