### PR TITLE
Remove deprecated Reliable Ninjas ZetaChain RPC endpoints.

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -193,8 +193,6 @@ const privacyStatement = {
     "We never collect, store, or track any identifying information. Data points like request volumes and success rates are only aggregated to monitor API performance. For more details, please visit https://rhinostake.com/resources/rhino-apis-terms-conditions",
   GrandValley:
     "We do not collect, store, process, or log any data from users of our Services. This includes, but is not limited to: IP addresses (we explicitly disable IP logging at both software and infrastructure levels), Device/browser identifiers (e.g., user-agent headers, screen resolution), Network metadata (requests, responses, timestamps), Wallet addresses, private keys, or transaction data, Geolocation or demographic information. https://github.com/hubofvalley/Testnet-Guides/blob/main/PRIVACY_POLICY.md",
-  reliableninjas:
-    "Reliable Ninjas does not collect or track personal user information. IP addresses are only temporarily processed in volatile memory for the sole purpose of rate limiting RPC usage and are purged as soon as they are no longer needed. No identifiable or sensitive information is logged, stored, or retained. Reliable Ninjas does not use cookies or tracking technologies. We do not sell, share, or disclose user data to third parties. For more information, please visit: https://reliableninjas.com/privacy-policy",
   therpc:
     "We temporarily record request method names and IP addresses for 7 days solely for service functionality, such as load balancing and DDoS protection.https://therpc.io/agreement/privacy-policy",
   Spectrum:
@@ -4949,11 +4947,6 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.blastapi,
       },
-      {
-        url: "https://zetachain-testnet-evm.reliableninjas.com",
-        tracking: "none",
-        trackingDetails: privacyStatement.reliableninjas,
-      },
     ],
   },
   7000: {
@@ -4987,11 +4980,6 @@ export const extraRpcs = {
         url: "https://7000.rpc.thirdweb.com",
         tracking: "yes",
         trackingDetails: privacyStatement.thirdweb,
-      },
-      {
-        url: "https://zetachain-mainnet-evm.reliableninjas.com",
-        tracking: "none",
-        trackingDetails: privacyStatement.reliableninjas,
       },
       {
         url: "https://api-zetachain-mainnet.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",


### PR DESCRIPTION
## Summary
- Remove deprecated Reliable Ninjas ZetaChain testnet and mainnet RPC URLs from extra RPC listings.
- Remove the now-unused `privacyStatement.reliableninjas` entry.
- Keep the change targeted to `constants/extraRpcs.js` only.

## Test plan
- [x] Verify no remaining `reliableninjas` references in the repository
- [x] Confirm diff is limited to one file and removes only deprecated entries
- [x] Ensure branch is based on latest `upstream/main`