### PR TITLE
Add Nowa Chain (Chain ID: 262144)

### DIFF
--- a/constants/additionalChainRegistry/chainid-262144.js
+++ b/constants/additionalChainRegistry/chainid-262144.js
@@ -1,0 +1,27 @@
+  export const data = {
+    "name": "NOWA Devnet",
+    "title": "NOWA Devnet",
+    "chain": "NOWA",
+    "icon": "nowa",
+    "rpc": [
+      "https://node1.nowa.finance",
+       "https://node2.nowa.finance",
+    ],
+    "faucets": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "nativeCurrency": {
+      "name": "NOWA",
+      "symbol": "NOWA",
+      "decimals": 18
+    },
+    "infoURL": "https://nowa.finance/",
+    "shortName": "nowachain",
+    "chainId": 262144,
+    "networkId": 262144,
+    "explorers": [
+      {
+        "name": "Nowa Explorer",
+        "url": "https://explorer.nowa.finance",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
## Summary

Added NOWA Devnet (Chain ID: 262144) to Chainlist.

### Chain Details

* Chain Name: NOWA Devnet
* Chain ID: 262144
* Native Currency: NOWA
* Symbol: NOWA
* RPC Endpoints:

  * https://node1.nowa.finance/
  * https://node2.nowa.finance/
* Explorer: https://explorer.nowa.finance/
* Website: https://nowa.finance/

This PR adds the NOWA Devnet network configuration to the Chainlist registry.