### PR TITLE
Add AgentsCoin (chainId 24368)

### DIFF
--- a/constants/additionalChainRegistry/chainid-24368.js
+++ b/constants/additionalChainRegistry/chainid-24368.js
@@ -1,15 +1,13 @@
 export const data = {
-    "name": "AgentsCoin",
-    "chain": "AGENT",
-    "rpc": ["https://rpc.agents-coin.com"],
-    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
-    "faucets": ["https://faucet.agents-coin.com"],
-    "nativeCurrency": { "name": "AgentsCoin", "symbol": "AGENT", "decimals": 18 },
-    "infoURL": "https://agents-coin.com",
-    "shortName": "agentscoin",
-    "chainId": 24368,
-    "networkId": 24368,
-    "explorers": [
-      { "name": "Blockscout", "url": "https://explorer.agents-coin.com", "standard": "EIP3091" }
-    ]
-  }
+  name: "AgentsCoin",
+  chain: "AGENT",
+  rpc: ["https://rpc.agents-coin.com"],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  faucets: ["https://faucet.agents-coin.com"],
+  nativeCurrency: { name: "AgentsCoin", symbol: "AGENT", decimals: 18 },
+  infoURL: "https://agents-coin.com",
+  shortName: "agentscoin",
+  chainId: 24368,
+  networkId: 24368,
+  explorers: [{ name: "Blockscout", url: "https://explorer.agents-coin.com", standard: "EIP3091" }],
+};

--- a/constants/additionalChainRegistry/chainid-24368.js
+++ b/constants/additionalChainRegistry/chainid-24368.js
@@ -1,0 +1,15 @@
+export const data = {
+    "name": "AgentsCoin",
+    "chain": "AGENT",
+    "rpc": ["https://rpc.agents-coin.com"],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": ["https://faucet.agents-coin.com"],
+    "nativeCurrency": { "name": "AgentsCoin", "symbol": "AGENT", "decimals": 18 },
+    "infoURL": "https://agents-coin.com",
+    "shortName": "agentscoin",
+    "chainId": 24368,
+    "networkId": 24368,
+    "explorers": [
+      { "name": "Blockscout", "url": "https://explorer.agents-coin.com", "standard": "EIP3091" }
+    ]
+  }


### PR DESCRIPTION
Adds AgentsCoin — an EVM L1 where AI agents mine the native coin $AGENT. Website: https://agents-coin.com | RPC: https://rpc.agents-coin.com | Explorer: https://explorer.agents-coin.com