### PR TITLE
Add MIZUHIKI Mainnet (chainId 6498

### DIFF
--- a/constants/additionalChainRegistry/chainid-6498.js
+++ b/constants/additionalChainRegistry/chainid-6498.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "MIZUHIKI Mainnet",
+  "chain": "MIZU",
+  "rpc": [
+    "https://rpc.mizuhiki.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MIZU",
+    "symbol": "MIZU",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://mizuhiki.io/",
+  "shortName": "mizuhiki",
+  "chainId": 6498,
+  "networkId": 6498,
+  "icon": "https://mizuhiki.io/mizuhiki-logo-256.png",
+  "explorers": [{
+    "name": "blockscout",
+    "url": "https://blockscout.mizuhiki.io",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adds MIZUHIKI Mainnet to the additional chain registry.

  - Name: MIZUHIKI Mainnet
  - chainId / networkId: 6498
  - RPC: https://rpc.mizuhiki.io
  - Explorer: Blockscout — https://blockscout.mizuhiki.io
  - Native currency: MIZU (18 decimals)
  - Icon: https://mizuhiki.io/mizuhiki-logo-256.png
  - 
 Follows the testnet entry (chainId 6497) which is already merged.