### PR TITLE
Add GMAChain Mainnet (Chain ID 4189)

### DIFF
--- a/_data/chains/eip155-4189.json
+++ b/_data/chains/eip155-4189.json
@@ -1,0 +1,19 @@
+{
+  "name": "GMAChain",
+  "chain": "GMA",
+  "icon": "gmachain",
+  "rpc": [
+    "https://api.gmachain.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "GMA",
+    "symbol": "GMA",
+    "decimals": 18
+  },
+  "infoURL": "https://gmachain.xyz",
+  "shortName": "gma",
+  "chainId": 4189,
+  "networkId": 4189,
+  "explorers": []
+}


### PR DESCRIPTION
Add GMAChain EVM-compatible Clique PoA mainnet.
- Chain ID: 4189
- RPC: https://api.gmachain.xyz
- Native token: GMA (18 decimals)
- Website: https://gmachain.xyz