### PR TITLE
Add Degen Protocol RPC for PulseChain (369)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4337,6 +4337,7 @@ export const extraRpcs = {
       "https://rpc-pulsechain.g4mm4.io",
       "https://evex.cloud/pulserpc",
       "wss://evex.cloud/pulsews",
+      "https://rpc.degenprotocol.io",
       {
         url: "https://pulsechain-rpc.publicnode.com",
         tracking: "none",


### PR DESCRIPTION
New Pulsechain RPC: rpc.degenprotocol.io
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://degenprotocol.io

#### Provide a link to your privacy policy:
No formal privacy policy page exists, but we do not collect, store, or share user IP addresses or transaction logs.

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is a reliable, high-availability public community RPC endpoint for PulseChain users. It provides robust backup infrastructure for the Degen Protocol community.