### PR TITLE
Fix MIZUHIKI Mainnet blockscout explorer URL

### DIFF
--- a/constants/additionalChainRegistry/chainid-6498.js
+++ b/constants/additionalChainRegistry/chainid-6498.js
@@ -18,7 +18,7 @@ export const data = {
   "icon": "https://mizuhiki.io/mizuhiki-logo-256.png",
   "explorers": [{
     "name": "blockscout",
-    "url": "https://blockscout.mizuhiki.io",
+    "url": "https://mizuhiki.blockscout.com",
     "icon": "blockscout",
     "standard": "EIP3091"
   }]


### PR DESCRIPTION
Corrects the Blockscout explorer URL for MIZUHIKI Mainnet (chainId 6498). The previously merged entry used `https://blockscout.mizuhiki.io`; the correct URL is `https://mizuhiki.blockscout.com`.