### PR TITLE
Add BlockDAG engineering endpoints

### DIFF
--- a/constants/additionalChainRegistry/chainid-1404.js
+++ b/constants/additionalChainRegistry/chainid-1404.js
@@ -21,6 +21,10 @@ export const data = {
       "name": "BlockDAG Explorer",
       "url": "https://bdagscan.com/",
     },
+    {
+      "name": "BlockDAG Engineering Explorer",
+      "url": "https://explorer.blockdag.engineering/",
+    },
   ],
   "status": "active"
 };

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4793,6 +4793,9 @@ export const extraRpcs = {
     rpcs: [],
     rpcWorking: false,
   },
+  1404: {
+    rpcs: ["https://rpc.blockdag.engineering"],
+  },
   1440: {
     rpcs: [
       {


### PR DESCRIPTION
﻿## Summary

Adds community alternative endpoints for BlockDAG mainnet, chain ID `1404`:

- RPC: `https://rpc.blockdag.engineering`
- Explorer: `https://explorer.blockdag.engineering/`

The existing bdagscan endpoint has been intermittent for users, so these alternatives improve network accessibility and resilience.

## Validation

- `https://rpc.blockdag.engineering` returns `eth_chainId = 0x57c`, decimal `1404`.
- `https://explorer.blockdag.engineering/` returns HTTP `200`.
- `node --check constants/extraRpcs.js`
- `node --check constants/additionalChainRegistry/chainid-1404.js`
