### PR TITLE
Add privacy policy and tracking details for Degen Protocol RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4375,10 +4375,10 @@ export const extraRpcs = {
       "https://rpc-pulsechain.g4mm4.io",
       "https://evex.cloud/pulserpc",
       "wss://evex.cloud/pulsews",
-       {
+      {
         url: "https://rpc.degenprotocol.io",
         tracking: "none",
-        trackingDetails: privacyStatement.degenprotocol,
+        trackingDetails: "Degen Protocol RPC does not track or store any user data, IP addresses, or transaction logs. https://degenprotocol.io/privacy",
       },
       {
         url: "https://pulsechain-rpc.publicnode.com",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4375,7 +4375,11 @@ export const extraRpcs = {
       "https://rpc-pulsechain.g4mm4.io",
       "https://evex.cloud/pulserpc",
       "wss://evex.cloud/pulsews",
-      "https://rpc.degenprotocol.io",
+       {
+        url: "https://rpc.degenprotocol.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.degenprotocol,
+      },
       {
         url: "https://pulsechain-rpc.publicnode.com",
         tracking: "none",


### PR DESCRIPTION
Added Degen Protocol RPC's privacy policy and tracking metadata to constants/extraRpcs.js.

- Linked privacy statement description referencing https://degenprotocol.io/privacy
- Configured tracking field to "none" matching our zero-logging policy

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://degenprotocol.io

#### Provide a link to your privacy policy:
https://degenprotocol.io/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
N/A (website and privacy policy links are both provided above).