### PR TITLE
Add chain QanTera

### DIFF
--- a/constants/additionalChainRegistry/chainid-974621.js
+++ b/constants/additionalChainRegistry/chainid-974621.js
@@ -1,0 +1,29 @@
+export const data ={
+    "name": "QanTera Testnet",
+    "chain": "QTER",
+    "rpc": [
+      "https://rpc1.qantera.network",
+      "https://rpc2.qantera.network"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "QanTera",
+      "symbol": "QTER",
+      "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "infoURL": "https://qantera.network",
+    "shortName": "qantera",
+    "chainId": 974621,
+    "networkId": 974621,
+    "icon": "qantera",
+    "explorers": [
+      {
+        "name": "QanTera Explorer",
+        "url": "https://explorer.qantera.network",
+        "icon": "qantera",
+        "standard": "EIP3091"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Adds community alternative endpoints for QanTera TestNet, chainid: 974621

RPC: "https://rpc1.qantera.network",
      "https://rpc2.qantera.network
Explorer: https://explorer.qantera.network
