### PR TITLE
Update DotOne (chainId 505): RPC, infoURL, icon, explorer

### DIFF
--- a/constants/additionalChainRegistry/chainid-505.js
+++ b/constants/additionalChainRegistry/chainid-505.js
@@ -2,7 +2,7 @@ export const data = {
   "name": "DotOne Smart Chain",
   "chain": "DOTO",
   "rpc": [
-    "https://rpc.dotone.network",
+    "https://rpc.dotone.online",
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -10,15 +10,15 @@ export const data = {
     "symbol": "DOTO",
     "decimals": 18
   },
-  "infoURL": "https://dotone.network",
+  "infoURL": "https://dotone.online",
   "shortName": "doto",
   "chainId": 505,
   "networkId": 505,
-  "icon": "doto",
+  "icon": "dotone",
   "explorers": [{
-    "name": "dotoscan",
-    "url": "https://explorer.dotone.network",
-    "icon": "dotoscan",
+    "name": "dotscan",
+    "url": "https://dotscan.one",
+    "icon": "dotone",
     "standard": "EIP3091"
   }]
 }

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -86,6 +86,7 @@ export default {
   "466": "appchain",
   "478": "form network",
   "480": "wc",
+  "505": "dotone",
   "510": "syndicate",
   "529": "firechain",
   "534": "candle",


### PR DESCRIPTION
This PR updates DotOne (chainId 505) network information:

RPC: [https://rpc.dotone.online]
infoURL: [https://dotone.online]
icon: dotone
explorer: dotscan ([https://dotscan.one]
Adds mapping in constants/chainIds.js
