### PR TITLE
Add mainnet RPC and Blockscout explorer for Robinhood Chain

### DIFF
--- a/constants/additionalChainRegistry/chainid-4663.js
+++ b/constants/additionalChainRegistry/chainid-4663.js
@@ -2,7 +2,7 @@ export const data = {
   name: "Robinhood Chain",
   chain: "Robinhood Chain",
   icon: "https://cdn.robinhood.com/assets/generated_assets/hoodchain_docsite/rh_favicon_120.png",
-  rpc: [],
+  rpc: ["https://rpc.mainnet.chain.robinhood.com"],
   nativeCurrency: {
     name: "Ether",
     symbol: "ETH",
@@ -13,6 +13,11 @@ export const data = {
   chainId: 4663,
   networkId: 4663,
   explorers: [
+    {
+      name: "Robinhood Chain Blockscout Explorer",
+      url: "https://robinhoodchain.blockscout.com",
+      standard: "EIP3091",
+    },
   ],
-  status: "incubating",
+  status: "active",
 };


### PR DESCRIPTION
Sets the RPC endpoint and Blockscout block explorer for Robinhood Chain (chainId 4663) and marks the chain status as active.

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://docs.robinhood.com/chain/

#### Provide a link to your privacy policy:

https://docs.robinhood.com/chain/terms-of-service

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.