### PR TITLE
fix: update iTani Network Chain RPC and explorer

### DIFF
--- a/constants/additionalChainRegistry/chainid-1229800785.js
+++ b/constants/additionalChainRegistry/chainid-1229800785.js
@@ -1,10 +1,10 @@
 export const data = {
   "name": "iTani Network Chain",
-  "chain": "ITN",
+  "chain": "ITANI",
   "icon": "itani",
   "rpc": [
-    "https://node.itaninetworkchain.com/jsonrpc",
-    "https://relay.itaninetworkchain.com/jsonrpc"
+    "https://rpc.itaninetworkchain.com/jsonrpc",
+    "https://node.itaninetworkchain.com/jsonrpc"
   ],
   "features": [
     {
@@ -17,20 +17,14 @@ export const data = {
     "symbol": "ITANI",
     "decimals": 18
   },
-  "infoURL": "https://github.com/itanidreams-dev/iTani-Network-Chain",
+  "infoURL": "https://www.itaninetworkchain.com",
   "shortName": "itani",
   "chainId": 1229800785,
   "networkId": 1229800785,
   "explorers": [
     {
       "name": "iTani Explorer",
-      "url": "https://node.itaninetworkchain.com",
-      "icon": "itani",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "iTani Explorer (Relay)",
-      "url": "https://relay.itaninetworkchain.com",
+      "url": "https://explorer.itaninetworkchain.com",
       "icon": "itani",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
## Summary
- Replace relay.itaninetworkchain.com with the healthy official RPC endpoint https://rpc.itaninetworkchain.com/jsonrpc
- Keep node.itaninetworkchain.com/jsonrpc as secondary alias
- Update explorer to https://explorer.itaninetworkchain.com
- Update chain key from ITN to ITANI and infoURL to the official website

## Validation
- eth_chainId returns 0x494d4551
- net_version returns 1229800785
- eth_blockNumber returns a valid 0x-prefixed value
- web3_clientVersion returns iTani/v3.2.2/rust
- Explorer and official website return HTTP 200

relay.itaninetworkchain.com is intentionally excluded until its SSL 525 issue is fixed.