### PR TITLE
Add Limonata Testnet (chainId 10777)

### DIFF
--- a/constants/additionalChainRegistry/chainid-10777.js
+++ b/constants/additionalChainRegistry/chainid-10777.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Limonata Testnet",
+  chain: "LIMO",
+  rpc: ["https://rpc.limonata.xyz"],
+  faucets: ["https://faucet.limonata.xyz"],
+  nativeCurrency: {
+    name: "Limonata",
+    symbol: "LIMO",
+    decimals: 18,
+  },
+  infoURL: "https://limonata.xyz",
+  shortName: "limonata-testnet",
+  chainId: 10777,
+  networkId: 10777,
+  icon: "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/limonatatestnet/images/limonatatestnet.png",
+  explorers: [
+    {
+      name: "Limonata Explorer",
+      url: "https://explorer.limonata.xyz",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds **Limonata Testnet** to the additional chain registry.

- **Chain ID:** 10777 (no collision — checked against chainlist.org/rpcs.json)
- **RPC:** https://rpc.limonata.xyz — live, `eth_chainId` returns `0x2a19` (10777)
- **Explorer (EIP3091):** https://explorer.limonata.xyz
- **Info:** https://limonata.xyz
- **Native currency:** LIMO (18 decimals)

Limonata is a Cosmos-EVM Layer 1 testnet. The chain is already listed in [cosmos/chain-registry](https://github.com/cosmos/chain-registry/tree/master/testnets/limonatatestnet) and [keplr-chain-registry](https://github.com/chainapsis/keplr-chain-registry/blob/main/cosmos/limonata_10777.json); an [ethereum-lists/chains PR](https://github.com/ethereum-lists/chains/pull/8466) is pending. File validated locally against `.github/scripts/validate-chain-files.js` rules.