### PR TITLE
feat: add SWSS Chain (chainId 122605)

### DIFF
--- a/constants/additionalChainRegistry/chainid-122605.js
+++ b/constants/additionalChainRegistry/chainid-122605.js
@@ -1,0 +1,28 @@
+export const data = {
+  "name": "SWSS Chain",
+  "chain": "SWSS",
+  "icon": "swss",
+  "rpc": [
+    "https://swssrpc.swss.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "SWSS Coin",
+    "symbol": "SWSS",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://swss.io",
+  "shortName": "swss",
+  "chainId": 122605,
+  "networkId": 122605,
+  "explorers": [
+    {
+      "name": "SWSS Chain Scan",
+      "url": "https://swssscan.swss.io",
+      "icon": "swss",
+      "standard": "EIP3091"
+    }
+  ]
+}
+


### PR DESCRIPTION
## Add SWSS Chain — Chain ID 122605 (0x1DEED)

**Chain ID:** 122605 — no collision confirmed on chainlist.org
**RPC:** https://swssrpc.swss.io — live mainnet, responding
**Explorer:** https://swssscan.swss.io (BlockScout, EIP3091 standard)
**Info:** https://swss.io

SwssChain is a live EVM-compatible Layer 1 blockchain for Real World Asset (RWA) settlement. Mainnet live since May 2026 with 6.5M+ blocks produced at 1-second block time.

- Native token: SWSS Coin (SWSS), 18 decimals
- Consensus: BFT-based, 4 active validators
- EVM: Cancun-compatible (full OpenZeppelin v5 + Solidity 0.8.26 support)
- Explorer: BlockScout-based at https://swssscan.swss.io

**Cross-reference:** ethereum-lists/chains PR #8460 (pending merge — icon will propagate once merged)
**Icon:** IPFS bafybeifyn3yb65chgsb2jdjyov5otdzuq6uz433dlmzbdeqg6wh4mwqg7e

---

Service provider: https://swss.io
Privacy policy: https://swss.io/privacy