### PR TITLE
Add Alpen Testnet III - chainid-20310.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-20310.js
+++ b/constants/additionalChainRegistry/chainid-20310.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "Alpen Testnet III",
+  "chain": "Alpen",
+  "rpc": [
+    "https://alpen.testnet.alpen.org",
+  ],
+  "faucets": ["https://tally.so/r/aQKLZZ"],
+  "nativeCurrency": {
+    "name": "Signet BTC",
+    "symbol": "sBTC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" },{ "name": "EIP1559" }],
+  "infoURL": "https://docs.alpenlabs.io",
+  "shortName": "alpen",
+  "chainId": 20310,
+  "networkId": 20310,
+    "icon": "https://avatars.githubusercontent.com/u/113091135",
+  "explorers": [{
+    "name": "Alpen Testnet Explorer",
+    "url": "https://explorer.testnet.alpen.org",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Alpen Testnet III is live with a new Strata Bridge with Bitcoin signet, and a new ChainID 20310.

Link the service provider's website (the company/protocol/individual providing the RPC): https://alpenlabs.io

Link to your privacy policy:
https://alpenlabs.notion.site/privacy-policy