### PR TITLE
Add GridMind Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-20260532.js
+++ b/constants/additionalChainRegistry/chainid-20260532.js
@@ -1,0 +1,29 @@
+export const data = {
+  name: "GridMind Testnet",
+  title: "GridMind Testnet",
+  chain: "GRD",
+  rpc: ["https://testnet-rpc.grid-mind.com"],
+  faucets: ["https://testnet-faucet.grid-mind.com"],
+  nativeCurrency: {
+    name: "GridMind Test GRD",
+    symbol: "testGRD",
+    decimals: 18,
+  },
+  infoURL: "https://www.grid-mind.com/blockchain",
+  shortName: "gridmindt",
+  chainId: 20260532,
+  networkId: 20260532,
+  explorers: [
+    {
+      name: "GridMind Testnet Explorer",
+      url: "https://gridmindblockchain.com",
+      standard: "EIP3091",
+    },
+    {
+      name: "GridMind Technical Explorer",
+      url: "https://testnet-explorer.grid-mind.com",
+      standard: "EIP3091",
+    },
+  ],
+  testnet: true,
+};


### PR DESCRIPTION
Summary:
- Adds GridMind Testnet to `constants/additionalChainRegistry`.
- Includes the public RPC, faucet, campaign info URL, and Blockscout-compatible explorers.
- Marks the network as a testnet.

Validation:
- `node --input-type=module -e "import './constants/additionalChainRegistry/chainid-20260532.js'"`
- `npx prettier --check constants/additionalChainRegistry/chainid-20260532.js`

Notes:
- The live RPC returns `eth_chainId` as `0x13526b4` and `net_version` as `20260532`.
- This is a new-chain registry addition, not an `extraRpcs.js` update.
- The repo's existing `node tests/check-duplicate-keys.js` duplicate-key portions pass, but its syntax-import step currently fails against existing `extraRpcs.js` and `chainIds.js` in this checkout before/independent of this new file.
