### PR TITLE
Add BiniChain (chainId 837291)

### DIFF
--- a/constants/additionalChainRegistry/chainid-837291.js
+++ b/constants/additionalChainRegistry/chainid-837291.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "BiniChain",
+  chain: "BINI",
+  rpc: ["https://rpc.binibit.com"],
+  faucets: [],
+  nativeCurrency: {
+    name: "BINI",
+    symbol: "BINI",
+    decimals: 18
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://binibit.com",
+  shortName: "bini",
+  chainId: 837291,
+  networkId: 837291,
+  explorers: [
+    {
+      name: "blockscout",
+      url: "https://scan.binibit.com",
+      icon: "blockscout",
+      standard: "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds BiniChain to the additional chain registry.

- **Name:** BiniChain
- **Chain ID / Network ID:** 837291 (0xcc6ab) — verified live via `eth_chainId` and `net_version`
- **Native currency:** BINI (18 decimals)
- **RPC:** https://rpc.binibit.com
- **Explorer:** https://scan.binibit.com (Blockscout, EIP3091)
- **Features:** EIP155, EIP1559

File: `constants/additionalChainRegistry/chainid-837291.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)