### PR TITLE
Update/infinite drive

### DIFF
--- a/constants/additionalChainRegistry/chainid-421018.js
+++ b/constants/additionalChainRegistry/chainid-421018.js
@@ -1,8 +1,8 @@
 export const data = {
-  "name": "Infinite Improbability Drive",
+  "name": "Infinite Drive",
   "chain": "INFINITE",
   "rpc": [
-    "https://evm-rpc.infinitedrive.xyz"
+    "https://evm.infinitedrive.xyz"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
This PR updates the chain registry entry for **Infinite Drive** mainnet (chain ID `421018`) to align Chainlist metadata with our current network branding and endpoint conventions.

- **Branding:** Rename the network display name from `Infinite Improbability Drive` to `Infinite Drive` for a more consistent public identity across our ecosystem.

- **RPC endpoint:** Update the primary EVM JSON-RPC URL from `https://evm-rpc.infinitedrive.xyz` to `https://evm.infinitedrive.xyz` to use a cleaner, canonical subdomain.


Thank you.

----

If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://infinitedrive.xyz

#### Provide a link to your privacy policy:

https://infinitedrive.xyz/privacy


The primary EVM JSON-RPC endpoint (`https://evm.infinitedrive.xyz`) is operated as a public infrastructure service for the Infinite Drive mainnet (chain ID `421018`). In line with our [Privacy Policy](https://infinitedrive.xyz/privacy):

- **No user activity tracking:** The RPC does not profile, track, or monitor wallet or dApp usage for analytics, advertising, or third-party marketing purposes.
- **No retention of request content for surveillance:** The endpoint is intended solely to process and relay JSON-RPC requests efficiently. We do not retain transaction or wallet activity for user-level tracking.
- **Operational safeguards only:** Like any public endpoint, standard server or edge infrastructure may process transient technical metadata (e.g. IP address, request timing) strictly for service delivery, abuse prevention, and security. Any such data is used only for operation and protection of the service, not for user profiling.
- **Fair-use & abuse prevention:** The endpoint may enforce rate limits or similar fair-use policies to maintain availability and mitigate abuse (e.g. excessive request volume or denial-of-service patterns).


