### PR TITLE
Add icon for Vexanium EVM (chainId 6736)

### DIFF
--- a/constants/additionalChainRegistry/chainid-6736.js
+++ b/constants/additionalChainRegistry/chainid-6736.js
@@ -1,0 +1,28 @@
+export const data = {
+    "name": "Vexanium Mainnet",
+    "chain": "VEX",
+    "rpc": [
+      "https://vexascan.com/rpc"
+    ],
+    "features": [
+      { "name": "EIP155" },
+      { "name": "EIP1559" }
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Vexanium",
+      "symbol": "VEX",
+      "decimals": 18
+    },
+    "infoURL": "https://vexascan.com",
+    "shortName": "vex",
+    "chainId": 6736,
+    "networkId": 6736,
+    "explorers": [
+      {
+        "name": "Vexascan",
+        "url": "https://vexascan.com/evm",
+        "standard": "EIP3091"
+      }
+    ]
+}

--- a/constants/additionalChainRegistry/chainid-6736.js
+++ b/constants/additionalChainRegistry/chainid-6736.js
@@ -1,6 +1,7 @@
 export const data = {
     "name": "Vexanium Mainnet",
     "chain": "VEX",
+    "icon": "vex",
     "rpc": [
       "https://vexascan.com/rpc"
     ],


### PR DESCRIPTION
Add `"icon": "vex"` field to chainid-6736.js.

Icon PR submitted to DefiLlama/icons: https://github.com/DefiLlama/icons/pull/2426