### PR TITLE
Add Blockmaze Testnet V2 - chainid-6162.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-6162.js
+++ b/constants/additionalChainRegistry/chainid-6162.js
@@ -15,7 +15,7 @@ export const data = {
   },
   features: [{ name: "EIP155" }, { name: "EIP1559" }],
   infoURL: "https://blockmaze.com",
-  shortName: "BMZ",
+  shortName: "bmz",
   chainId: 6162,
   networkId: 6162,
   icon: "BMZ",

--- a/constants/additionalChainRegistry/chainid-6162.js
+++ b/constants/additionalChainRegistry/chainid-6162.js
@@ -1,0 +1,28 @@
+export const data = {
+  name: "Blockmaze Testnet V2",
+  chain: "BLOCKMAZE",
+  rpc: [
+    "https://v2-evm-rpc.testnet.stackflow.site",
+    "https://v2-evm-rpc-arc.testnet.stackflow.site",
+    "wss://v2-evm-ws-arc.testnet.stackflow.site",
+    "wss://v2-evm-ws.testnet.stackflow.site",
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "BMZ",
+    symbol: "BMZ",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://blockmaze.com",
+  shortName: "BMZ",
+  chainId: 6162,
+  networkId: 6162,
+  icon: "BMZ",
+  explorers: [
+    {
+      name: "Blockmaze testnet explorer",
+      url: "https://explorer.testnet.stackflow.site",
+    },
+  ],
+};


### PR DESCRIPTION
This PR adds Blockmaze Testnet V2 (Chain ID `6162`) to the additional chain registry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://blockmaze.com/

The RPC endpoints are operated for the Blockmaze Testnet V2 network.

#### Provide a link to your privacy policy:

https://blockmaze.com/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

N/A. The RPC endpoints are official Blockmaze Testnet V2 infrastructure and are provided to allow users and applications to connect to the network.

