### PR TITLE
Added Nowa Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-22052010.js
+++ b/constants/additionalChainRegistry/chainid-22052010.js
@@ -1,0 +1,20 @@
+export const data = {
+  name: "Nowa Testnet",
+  chain: "NOWA",
+  rpc: [
+    "https://tnode1.nowa.finance",
+    "https://tnode2.nowa.finance",
+    "https://tnode3.nowa.finance"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Nowa",
+    symbol: "NOWA",
+    decimals: 18
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://nowa.finance",
+  shortName: "nowa-testnet",
+  chainId: 22052010,
+  networkId: 22052010
+};

--- a/constants/additionalChainRegistry/chainid-22052010.js
+++ b/constants/additionalChainRegistry/chainid-22052010.js
@@ -6,7 +6,9 @@ export const data = {
     "https://tnode2.nowa.finance",
     "https://tnode3.nowa.finance"
   ],
-  faucets: [],
+  faucets: [
+    "https://faucet.nowa.finance"
+  ],
   nativeCurrency: {
     name: "Nowa",
     symbol: "NOWA",
@@ -16,5 +18,13 @@ export const data = {
   infoURL: "https://nowa.finance",
   shortName: "nowa-testnet",
   chainId: 22052010,
-  networkId: 22052010
+  networkId: 22052010,
+  icon: "https://nowa.finance/favicon.svg",
+  explorers: [
+    {
+      name: "Nowa Testnet Explorer",
+      url: "https://explorer.nowa.finance",
+      standard: "EIP3091"
+    }
+  ]
 };


### PR DESCRIPTION
Adding the new Nowa Testnet to the registry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://nowa.finance

#### Provide a link to your privacy policy:
https://nowa.finance/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:
We are adding the official public RPC endpoints for the Nowa Testnet (Chain ID 22052010). Nowa is an open, public Layer 1 EVM-compatible blockchain. We are providing these initial RPC endpoints so the community, developers, and node operators can freely connect to our testnet, request funds from us, and start building!