### PR TITLE
Add NodeFlare public RPC endpoints for 16 chains; remove discontinued Viction entry

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -616,7 +616,7 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc-eth.blockmachine.io",
-        tracking: "no",
+        tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
       {
@@ -1490,6 +1490,11 @@ export const extraRpcs = {
   137: {
     rpcs: [
       {
+        url: "https://rpc.nodeflare.app/polygon/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
+      {
         url: "https://rpc.ankr.com/polygon",
         tracking: "limited",
         trackingDetails: privacyStatement.ankr,
@@ -1666,6 +1671,11 @@ export const extraRpcs = {
   },
   25: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/cronos/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://evm.cronos.org",
       "https://cronos-rpc.elk.finance/",
       {
@@ -2069,6 +2079,11 @@ export const extraRpcs = {
   },
   42170: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/nova/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://nova.arbitrum.io/rpc",
       {
         url: "https://arbitrum-nova.public.blastapi.io",
@@ -3843,13 +3858,17 @@ export const extraRpcs = {
   5551: {
     rpcs: ["https://l2.nahmii.io/"],
   },
-  88: {
+  4663: {
     rpcs: [
       {
-        url: "https://rpc.nodeflare.app/vic/public",
+        url: "https://rpc.nodeflare.app/robinhood/public",
         tracking: "none",
         trackingDetails: privacyStatement.nodeflare,
       },
+    ],
+  },
+  88: {
+    rpcs: [
       {
         url: "https://viction.drpc.org",
         tracking: "none",
@@ -4743,6 +4762,11 @@ export const extraRpcs = {
   },
   196: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/xlayer/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.xlayer.tech",
       "https://xlayerrpc.okx.com",
       {
@@ -5209,6 +5233,11 @@ export const extraRpcs = {
   },
   5000: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/mantle/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.mantle.xyz",
       {
         url: "https://mantle-mainnet.public.blastapi.io",
@@ -6621,6 +6650,11 @@ export const extraRpcs = {
   },
   59144: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/linea/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.linea.build",
       {
         url: "https://1rpc.io/linea",
@@ -7070,7 +7104,7 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc.blockmachine.io",
-        tracking: "no",
+        tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
     ],
@@ -7276,6 +7310,11 @@ export const extraRpcs = {
   },
   34443: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/mode/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://mainnet.mode.network",
       {
         url: "https://1rpc.io/mode",
@@ -7443,6 +7482,11 @@ export const extraRpcs = {
   // },
   60808: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/bob/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.gobob.xyz",
       "wss://rpc.gobob.xyz",
       {
@@ -7599,6 +7643,11 @@ export const extraRpcs = {
   },
   48900: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/zircuit/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       {
         url: "https://mainnet.zircuit.com",
         tracking: "none",
@@ -8242,6 +8291,11 @@ export const extraRpcs = {
   },
   1329: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/sei/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://evm-rpc.sei-apis.com",
       {
         url: "https://sei.drpc.org",
@@ -8283,6 +8337,11 @@ export const extraRpcs = {
   },
   130: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/unichain/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://mainnet.unichain.org/",
       {
         url: "https://unichain.api.onfinality.io/public",
@@ -8401,6 +8460,11 @@ export const extraRpcs = {
   },
   57073: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/ink/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc-gel.inkonchain.com",
       "https://rpc-qnd.inkonchain.com",
       "wss://rpc-gel.inkonchain.com",
@@ -8589,6 +8653,11 @@ export const extraRpcs = {
   },
   146: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/sonic/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.soniclabs.com",
       {
         url: "https://sonic.drpc.org",
@@ -8855,6 +8924,11 @@ export const extraRpcs = {
   },
   1868: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/soneium/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       "https://rpc.soneium.org",
       {
         url: "https://soneium.drpc.org",
@@ -9495,6 +9569,11 @@ export const extraRpcs = {
   },
   9745: {
     rpcs: [
+      {
+        url: "https://rpc.nodeflare.app/plasma/public",
+        tracking: "none",
+        trackingDetails: privacyStatement.nodeflare,
+      },
       {
         url: "https://plasma.drpc.org",
         tracking: "none",


### PR DESCRIPTION
Adds NodeFlare's free public endpoints (`https://rpc.nodeflare.app/{chain}/public`, tracking: none, existing `privacyStatement.nodeflare`) to: Unichain (130), Sonic (146), Polygon (137), Linea (59144), Mantle (5000), Zircuit (48900), XLayer (196), Soneium (1868), Arbitrum Nova (42170), BOB (60808), Ink (57073), Cronos (25), Mode (34443), Sei (1329), Plasma (9745).

All endpoints live and verified (correct eth_chainId, at tip, no key required, multi-region with failover). Follow-up to the previously merged NodeFlare PR.

