### PR TITLE
Add GL1Infra public RPC endpoint for GenesisL1

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3985,7 +3985,9 @@ export const extraRpcs = {
     websiteUrl: "https://shibachain.net/",
   },
   29: {
-    rpcs: ["https://rpc.genesisl1.org"],
+    rpcs: ["https://rpc.genesisl1.org",
+           "https://evm.gl1infra.online",
+    ],
   },
   33: {
     rpcs: ["https://rpc.goodata.io"],


### PR DESCRIPTION
## Summary

This PR adds an additional public EVM RPC endpoint for GenesisL1 (Chain ID 29).

### RPC Endpoint

https://evm.gl1infra.online

### Validation

The endpoint has been tested with:

- MetaMask
- Rabby Wallet
- eth_chainId
- eth_blockNumber
- eth_getBalance
- eth_call
- eth_estimateGas
- Public HTTPS access

The infrastructure is actively maintained and monitored.

Thanks!