### PR TITLE
Create chainid-5641.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-5641.js
+++ b/constants/additionalChainRegistry/chainid-5641.js
@@ -1,0 +1,31 @@
+export const data = {
+  name: "Evorium Nova Testnet",
+  chain: "EvoriumEVM",
+  rpc: [
+    "https://rpc-nova.evorium.network"
+  ],
+  faucets: [
+    "https://faucet-nova.evorium.network"
+  ],
+  nativeCurrency: {
+    name: "Testnet EVO",
+    symbol: "tEVO",
+    decimals: 18
+  },
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  infoURL: "https://evorium.network",
+  shortName: "evo-nova",
+  chainId: 5641,
+  networkId: 5641,
+  icon: "https://evorium.network/assets/evorium-logo-BvLsajxH.png",
+  explorers: [
+    {
+      name: "Evorium Nova Explorer",
+      url: "https://testnet.evorium.network",
+      standard: "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
Please Check And Approve 5641 Evorium Nova testnet network Perpetual Dex System

#### Provide a link to your privacy policy:

A dedicated public privacy policy page is currently being prepared.

#### If the RPC has none of the above and you still think it should be added, please explain why:

The RPC is operated directly by the Evorium Network team and is the official public endpoint for Evorium Nova Testnet, Chain ID 5641.

The endpoint is necessary for public testnet access, wallet integration, smart contract deployment, explorer access, and development testing.

Official RPC:
https://rpc-nova.evorium.network

Official Website:
https://evorium.network/

Official Explorer:
https://testnet.evorium.network

Official Faucet:
https://faucet-nova.evorium.network

Official Documentation:
https://evorium.gitbook.io/evorium-docs