### PR TITLE
Fix custom chain icon fallback

### DIFF
--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import RPCList from "../RPCList";
-import { renderProviderText } from "../../utils";
+import { getChainIcon, renderProviderText } from "../../utils";
 import { useRouter } from "next/router";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
@@ -15,7 +15,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
   const router = useRouter();
 
   const icon = React.useMemo(() => {
-    return chain.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const chainId = useChain((state) => state.id);

--- a/constants/additionalChainRegistry/chainid-20260532.js
+++ b/constants/additionalChainRegistry/chainid-20260532.js
@@ -13,6 +13,7 @@ export const data = {
   shortName: "gridmindt",
   chainId: 20260532,
   networkId: 20260532,
+  icon: "https://www.grid-mind.com/logo.png",
   explorers: [
     {
       name: "GridMind Testnet Explorer",

--- a/pages/add-network/[chain].js
+++ b/pages/add-network/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../utils";
+import { getChainIcon, notTranslation as useTranslations } from "../../utils";
 import { populateChain, fetchWithCache } from "../../utils/fetch";
 import AddNetwork from "../../components/chain";
 import Layout from "../../components/Layout";
@@ -71,7 +71,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "en");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const chainName = chain.name === "OP Mainnet" ? "Optimism Maninnet" : chain.name;

--- a/pages/chain/[chain].js
+++ b/pages/chain/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../utils";
+import { getChainIcon, notTranslation as useTranslations } from "../../utils";
 import { populateChain, fetchWithCache } from "../../utils/fetch";
 import AddNetwork from "../../components/chain";
 import Layout from "../../components/Layout";
@@ -85,7 +85,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "en");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   const { data: blockGasLimit } = useQuery({

--- a/pages/zh/chain/[chain].js
+++ b/pages/zh/chain/[chain].js
@@ -2,7 +2,7 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 // import { useTranslations } from "next-intl";
-import { notTranslation as useTranslations } from "../../../utils";
+import { getChainIcon, notTranslation as useTranslations } from "../../../utils";
 import { populateChain, fetchWithCache } from "../../../utils/fetch";
 import AddNetwork from "../../../components/chain";
 import Layout from "../../../components/Layout";
@@ -72,7 +72,7 @@ function Chain({ chain }) {
   const t = useTranslations("Common", "zh");
 
   const icon = React.useMemo(() => {
-    return chain?.chainSlug ? `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg` : "/unknown-logo.png";
+    return getChainIcon(chain);
   }, [chain]);
 
   return (

--- a/utils/index.js
+++ b/utils/index.js
@@ -82,6 +82,20 @@ export const renderProviderText = (address) => {
   }
 };
 
+export const getChainIcon = (chain) => {
+  if (!chain) {
+    return "/unknown-logo.png";
+  }
+
+  if (chain.chainSlug) {
+    return `https://icons.llamao.fi/icons/chains/rsz_${chain.chainSlug}.jpg`;
+  }
+
+  const icon = typeof chain.icon === "string" ? chain.icon : chain.icon?.url;
+
+  return icon?.startsWith("http") ? icon : "/unknown-logo.png";
+};
+
 export const notTranslation =
   (ns, lang = "en") =>
   (key) => {


### PR DESCRIPTION
## Summary

- Adds the GridMind hosted logo URL to the GridMind Testnet registry entry.
- Centralizes ChainList icon selection in `getChainIcon()`.
- Keeps existing `chainSlug` icons for listed chains and falls back to an HTTP `chain.icon` before `/unknown-logo.png` for custom chains.

## Validation

- `node -e "import('./utils/index.js').then(({getChainIcon}) => { ... })"`
- `node --input-type=module -e "import { pathToFileURL } from 'node:url'; await import(pathToFileURL(process.cwd() + '/constants/additionalChainRegistry/chainid-20260532.js'))"`
- Generated `out/rpcs.json` with `node generate-json.js` and confirmed GridMind Testnet includes `icon: https://www.grid-mind.com/logo.png`.

Note: `pnpm test` has a Windows-local path issue in this checkout because the test harness imports raw `C:\...` paths as ESM specifiers; the equivalent file URL syntax import passes.