### PR TITLE
Add E Canna Mainnet (4111) and E Canna Testnet (4112)

### DIFF
--- a/constants/additionalChainRegistry/chainid-4111.js
+++ b/constants/additionalChainRegistry/chainid-4111.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "E Canna Mainnet",
+  "chain": "ECNA",
+  "rpc": ["https://rpc.ecnascan.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "E Canna",
+    "symbol": "ECNA",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://ecnascan.com",
+  "shortName": "ecna",
+  "chainId": 4111,
+  "networkId": 4111,
+  "explorers": [
+    {
+      "name": "ecnascan",
+      "url": "https://explorer.ecnascan.com",
+      "standard": "EIP3091"
+    }
+  ]
+};

--- a/constants/additionalChainRegistry/chainid-4112.js
+++ b/constants/additionalChainRegistry/chainid-4112.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "E Canna Testnet",
+  "chain": "tECNA",
+  "rpc": ["https://testnetrpc.ecnascan.com"],
+  "faucets": ["https://testnetexplorer.ecnascan.com/faucet"],
+  "nativeCurrency": {
+    "name": "E Canna Testnet",
+    "symbol": "tECNA",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://ecnascan.com",
+  "shortName": "tecna",
+  "chainId": 4112,
+  "networkId": 4112,
+  "explorers": [
+    {
+      "name": "ecnascan-testnet",
+      "url": "https://testnetexplorer.ecnascan.com",
+      "standard": "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- Add **E Canna Mainnet** (chainId **4111**, symbol **ECNA**)
- Add **E Canna Testnet** (chainId **4112**, symbol **tECNA**)

## Network details
| | Mainnet | Testnet |
|--|---------|---------|
| Chain ID | 4111 | 4112 |
| Native | ECNA | tECNA |
| RPC | https://rpc.ecnascan.com | https://testnetrpc.ecnascan.com |
| Explorer | https://explorer.ecnascan.com | https://testnetexplorer.ecnascan.com |
| Info | https://ecnascan.com | https://ecnascan.com |
| Faucet | — | https://testnetexplorer.ecnascan.com/faucet |

## Provider
- Website: https://ecnascan.com

Made with [Cursor](https://cursor.com)