### PR TITLE
Add Liberty Reserve Chain (Chain ID: 1410)

### DIFF
--- a/_data/chains/_data/icons/lrx.json:
+++ b/_data/chains/_data/icons/lrx.json:
@@ -1,0 +1,6 @@
+ [{
+  "url": "https://rpc.lrxmining.com/lrx-logo.png",
+  "width": 512,
+  "height": 512,
+  "format": "png"
+}]

--- a/_data/chains/eip155-1410.json — chain info
+++ b/_data/chains/eip155-1410.json — chain info
@@ -1,0 +1,20 @@
+{
+  "name": "Liberty Reserve Chain",
+  "chain": "LRX",
+  "icon": "lrx",
+  "rpc": ["https://rpc.lrxmining.com"],
+  "nativeCurrency": {
+    "name": "Liberty Reserve",
+    "symbol": "LRX",
+    "decimals": 18
+  },
+  "infoURL": "https://lrxmining.com",
+  "shortName": "lrx",
+  "chainId": 1410,
+  "networkId": 1410,
+  "explorers": [{
+    "name": "LRXScan",
+    "url": "https://lrxmining.com",
+    "standard": "EIP3091"
+  }]
+}

--- a/_data/eip155-1410.json
+++ b/_data/eip155-1410.json
@@ -1,0 +1,24 @@
+{
+  "name": "Liberty Reserve Chain",
+  "chain": "LRX",
+  "rpc": [
+    "https://rpc.lrxmining.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Liberty Reserve",
+    "symbol": "LRX",
+    "decimals": 18
+  },
+  "infoURL": "https://lrxmining.com",
+  "shortName": "lrx",
+  "chainId": 1410,
+  "networkId": 1410,
+  "explorers": [
+    {
+      "name": "LRXScan",
+      "url": "https://scan.lrxmining.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/chainid-1410.json
+++ b/chainid-1410.json
@@ -1,0 +1,24 @@
+ {
+  "name": "Liberty Reserve Chain",
+  "chain": "LRX",
+  "rpc": [
+    "http://rpc.lrxmining.com/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Liberty Reserve",
+    "symbol": "LRX",
+    "decimals": 18
+  },
+  "infoURL": "http://swap.lrxmining.com",
+  "shortName": "lrx",
+  "chainId": 1410,
+  "networkId": 1410,
+  "explorers": [
+    {
+      "name": "LRX Explorer",
+      "url": "http://explorer.lrxmining.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
 #### Link the service provider's website:
https://lrxmining.com

#### Provide a link to your privacy policy:
https://lrxmining.com

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the official RPC for Liberty Reserve Chain (Chain ID: 1410). 
RPC URL: https://rpc.lrxmining.com
Explorer: https://scan.lrxmining.com
Native Currency: LRX