### PR TITLE
fix: update NetX Testnet endpoints

### DIFF
--- a/constants/additionalChainRegistry/chainid-587.js
+++ b/constants/additionalChainRegistry/chainid-587.js
@@ -2,7 +2,7 @@ export const data = {
   "name": "NetX Testnet",
   "chain": "NETX",
   "rpc": [
-    "https://test-rpc.netxscan.io"
+    "https://testnetrpc.netxscan.io"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -14,14 +14,14 @@ export const data = {
     { "name": "EIP155" },
     { "name": "EIP1559" }
   ],
-  "infoURL": "https://test.netxscan.io/",
+  "infoURL": "https://netx.world/",
   "shortName": "netx-testnet",
   "chainId": 587,
   "networkId": 587,
   "explorers": [
     {
       "name": "NetXScan Testnet",
-      "url": "https://test.netxscan.io",
+      "url": "https://testnet.netxscan.io",
       "standard": "EIP3091"
     }
   ]

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3551,7 +3551,7 @@ export const extraRpcs = {
   },
   587: {
     rpcs: [
-      "https://test-rpc.netxscan.io",
+      "https://testnetrpc.netxscan.io",
     ],
   },
   589: {


### PR DESCRIPTION
Updates the NetX Testnet endpoints after the RPC and explorer migration.

Changes:

- RPC: https://test-rpc.netxscan.io -> https://testnetrpc.netxscan.io
- Explorer: https://test.netxscan.io -> https://testnet.netxscan.io
- Info URL: https://test.netxscan.io/ -> https://netx.world/

The old endpoints currently fail during TLS connection. The new RPC is publicly reachable and returns chain ID 587 (`0x24b`).

This updates the NetX registration originally added in #2629.