### PR TITLE
Add bloXroute RPC for Robinhood Chain (4663)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10189,6 +10189,15 @@ export const extraRpcs = {
       },
     ],
   },
+  4663: {
+    rpcs: [
+      {
+        url: "https://robinhood.rpc.blxrbdn.com",
+        tracking: "yes",
+        trackingDetails: privacyStatement.bloxroute,
+      },
+    ],
+  },
   46630: {
     rpcs: [
       {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

Link the service provider's website (the company/protocol/individual providing the RPC): https://bloxroute.com/

Provide a link to your privacy policy: Our privacy policy is already listed in extraRpcs.js

Verification:
curl https://robinhood.rpc.blxrbdn.com -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_chainId","id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x1237"}