### PR TITLE
Add Prismo Glassnet (101001000)

### DIFF
--- a/constants/additionalChainRegistry/chainid-101001000.js
+++ b/constants/additionalChainRegistry/chainid-101001000.js
@@ -1,0 +1,33 @@
+export const data ={
+  name: "Prismo Glassnet",
+  chain: "PRISMO",
+  rpc: [
+    "https://rpc.glassnet.prismo.network",
+    "wss://rpc.glassnet.prismo.network"
+  ],
+  faucets: [
+    "https://faucet.glassnet.prismo.network"
+  ],
+  nativeCurrency: {
+    name: "USDC",
+    symbol: "USDC",
+    decimals: 18
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://prismo.technology",
+  shortName: "prsm",
+  chainId: 101001000,
+  networkId: 101001000,
+  icon: {
+    url: "ipfs://bafkreihx2y5xfpk5kzhypo4z4ugzjqgnslqkfgyhpl5uo2wba77epg4lgq",
+    format: "svg",
+    width: 512,
+    height: 512
+  },
+  explorers: [{
+    name: "Glassnet Explorer",
+    url: "https://explorer.glassnet.prismo.network",
+    icon: "blockscout",
+    standard: "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adds a new chain entry to `constants/additionalChainRegistry`: **Prismo Glassnet**, an EVM Layer 2.

| Field | Value |
|---|---|
| name | Prismo Glassnet |
| chainId / networkId | 101001000 |
| shortName | prsm |
| native currency | USDC (18 decimals) |
| explorer | https://explorer.glassnet.prismo.network (Blockscout, EIP-3091) |
| infoURL | https://prismo.technology |

File added: `constants/additionalChainRegistry/chainid-101001000.js`. It exports `const data` per the repo convention and imports cleanly as an ES module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)