### PR TITLE
Add solidrpc public rpcs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -245,6 +245,8 @@ const privacyStatement = {
     "To route your requests, blockmachine temporarily processes your IP address for up to 2 minutes - used only to count and rate-limit requests. It is never stored beyond that window and cannot be linked to any individual user or account.",
   keccakio:
     "keccak.io does not require accounts, email, or KYC, does not log client IP addresses, and does not correlate requests to users. https://keccak.io/privacy",
+  solidrpc:
+    "SolidRPC records request metadata including timestamp, chain, RPC method, response status, and byte count for service operation and usage analytics, but does not log RPC request bodies or responses. Cloudflare processes IP addresses for DDoS protection and edge rate limiting. https://solidrpc.io/privacy",
 };
 
 export const extraRpcs = {
@@ -616,13 +618,18 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc-eth.blockmachine.io",
-        tracking: "no",
+        tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
       {
         url: "https://eth-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/1",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -1190,6 +1197,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
       },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/56",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
+      },
     ],
   },
   97: {
@@ -1390,6 +1402,11 @@ export const extraRpcs = {
         url: "https://avax-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/43114",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -1661,6 +1678,11 @@ export const extraRpcs = {
         url: "https://polygon-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/137",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -2035,6 +2057,11 @@ export const extraRpcs = {
         url: "https://arb-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/42161",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -2852,6 +2879,11 @@ export const extraRpcs = {
         url: "https://op-rpc.keccak.io",
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/10",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -5857,6 +5889,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.keccakio,
       },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/8453",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
+      },
     ],
   },
   11235: {
@@ -7070,7 +7107,7 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc.blockmachine.io",
-        tracking: "no",
+        tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
     ],
@@ -10276,6 +10313,15 @@ export const extraRpcs = {
         url: "https://flare-testnet.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    ],
+  },
+  4663: {
+    rpcs: [
+      {
+        url: "https://rpc.solidrpc.io/public/evm/4663",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -618,7 +618,7 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc-eth.blockmachine.io",
-        tracking: "none",
+        tracking: "no",
         trackingDetails: privacyStatement.blockmachine,
       },
       {
@@ -7107,7 +7107,7 @@ export const extraRpcs = {
       },
       {
         url: "https://rpc.blockmachine.io",
-        tracking: "none",
+        tracking: "no",
         trackingDetails: privacyStatement.blockmachine,
       },
     ],

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -257,6 +257,8 @@
     "keccak.io does not require accounts, email, or KYC, does not log client IP addresses, and does not correlate requests to users. https://keccak.io/privacy",
   seleman:
     "SELEMAN public JSON-RPC does not store or track user data, does not log client IP addresses to persistent storage, and does not correlate requests with wallet addresses. Ephemeral in-memory rate-limit counters (≤60s) may be used solely for abuse prevention and are not retained as historical logs. No analytics or third-party tracking on the RPC path. https://seleman.monarcaproject.com/privacy",
+  solidrpc:
+    "SolidRPC records request metadata including timestamp, chain, RPC method, response status, and byte count for service operation and usage analytics, but does not log RPC request bodies or responses. Cloudflare processes IP addresses for DDoS protection and edge rate limiting. https://solidrpc.io/privacy",
 };
 
 export const extraRpcs = {
@@ -655,6 +657,11 @@ export const extraRpcs = {
         url: "wss://eth.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/1",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -1272,6 +1279,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/56",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
+      },
     ],
   },
   97: {
@@ -1492,6 +1504,11 @@ export const extraRpcs = {
         url: "https://rpc-avalanche.blockmachine.io",
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/43114",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -1782,6 +1799,11 @@ export const extraRpcs = {
         url: "https://rpc-polygon.blockmachine.io/",
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/137",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -2196,6 +2218,11 @@ export const extraRpcs = {
         url: "https://rpc-arbitrum.blockmachine.io/",
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/42161",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -3133,6 +3160,11 @@ export const extraRpcs = {
         url: "https://rpc-optimism.blockmachine.io/",
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/10",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -6774,6 +6806,11 @@ export const extraRpcs = {
         url: "wss://base.api.pocket.network",
         tracking: "none",
         trackingDetails: privacyStatement.pokt,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/8453",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },
@@ -15550,6 +15587,11 @@ export const extraRpcs = {
         url: "https://rpc-robinhood.blockmachine.io",
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
+      },
+      {
+        url: "https://rpc.solidrpc.io/public/evm/4663",
+        tracking: "limited",
+        trackingDetails: privacyStatement.solidrpc,
       },
     ],
   },


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://solidrpc.io

#### Provide a link to your privacy policy:

https://solidrpc.io/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Not applicable — both the provider website and privacy policy are provided above.

This PR adds SolidRPC public RPC endpoints for Ethereum, Optimism, BNB Smart Chain, Polygon, Robinhood Chain, Base, Arbitrum One, and Avalanche C-Chain. Each endpoint was appended at the end of its RPC array.

The public endpoints support wallet-safe `eth_*`, `net_*`, and `web3_*` methods. Debugging, tracing, and node-control namespaces are unavailable. `eth_getLogs` requests are limited to an inclusive 2,000-block range, and throttled requests return explicit HTTP 429 JSON-RPC responses.