### PR TITLE
Add ValueX Chain (90000) - Create chainid-90000.js

### DIFF
--- a/constants/additionalChainRegistry/chainid-90000.js
+++ b/constants/additionalChainRegistry/chainid-90000.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "ValueX Chain",
+  chain: "VLX",
+  rpc: ["https://node.valuex-foundation.com/rpc"],
+  faucets: [],
+  nativeCurrency: {
+    name: "ValueX Token",
+    symbol: "VLX",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }],
+  infoURL: "https://valuex-foundation.com",
+  shortName: "valuex",
+  chainId: 90000,
+  networkId: 90000,
+  icon: "vlx",
+  explorers: [
+    {
+      name: "VLX Explorer",
+      url: "https://scan.valuex-foundation.com",
+      icon: "vlx",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds a new chain entry to constants/additionalChainRegistry: ValueX Chain, an Avalanche-based EVM L1.

| Field | Value |
|---|---|
| name | ValueX Chain |
| chainId / networkId | 90000 |
| shortName | valuex |
| native currency | VLX (18 decimals) |
| RPC | https://node.valuex-foundation.com/rpc (live, `eth_chainId` returns `0x15f90`) |
| explorer | https://scan.valuex-foundation.com (EIP-3091) |
| infoURL | https://valuex-foundation.com |

File added: `constants/additionalChainRegistry/chainid-90000.js`. It exports `const data` per the repo convention and imports cleanly as an ES module.