### PR TITLE
feat(chain): add Ticko Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-84257.js
+++ b/constants/additionalChainRegistry/chainid-84257.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Ticko Testnet",
+  "chain": "Ticko",
+  "rpc": [
+    "https://miner.testnet.ticko.xyz:4556"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://testnet.ticko.xyz/",
+  "shortName": "ticko-testnet",
+  "chainId": 84257,
+  "networkId": 84257,
+  "icon": "ticko",
+  "explorers": [{
+    "name": "ticko explorer",
+    "url": "https://testnet.ticko.xyz/explorer",
+    "icon": "ticko",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://testnet.ticko.xyz/

#### Provide a link to your privacy policy:

https://docs.ticko.xyz/resources/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Ticko Testnet is being added as a new EVM testnet chain. The RPC is the public endpoint required for wallet connectivity.

Validation:
- Ran `ONLY_LIST_FILE=true pnpm run build`
- Ran `FILES_CHANGED='constants/additionalChainRegistry/chainid-84257.js' EXTRA_RPC_CHANGED='' node .github/scripts/validate-chain-files.js`