### PR TITLE
Update Blockmaze Testnet V2 RPC and Explorer endpoints

### DIFF
--- a/constants/additionalChainRegistry/chainid-6162.js
+++ b/constants/additionalChainRegistry/chainid-6162.js
@@ -2,10 +2,10 @@ export const data = {
   name: "Blockmaze Testnet V2",
   chain: "BLOCKMAZE",
   rpc: [
-    "https://v2-evm-rpc.testnet.stackflow.site",
-    "https://v2-evm-rpc-arc.testnet.stackflow.site",
-    "wss://v2-evm-ws-arc.testnet.stackflow.site",
-    "wss://v2-evm-ws.testnet.stackflow.site",
+    "https://testnet-evm-rpc.blockmaze.com",
+    "https://testnet-evm-rpc-arc.blockmaze.com",
+    "wss://testnet-evm-ws-arc.blockmaze.com",
+    "wss://testnet-evm-ws.blockmaze.com",
   ],
   faucets: [],
   nativeCurrency: {
@@ -22,7 +22,7 @@ export const data = {
   explorers: [
     {
       name: "Blockmaze testnet explorer",
-      url: "https://explorer.testnet.stackflow.site",
+      url: "https://testnet-explorer.bmzscan.com/",
     },
   ],
 };


### PR DESCRIPTION
This Pull Request updates the RPC and Explorer endpoints for the **Blockmaze Testnet V2** chain configuration (`chainId: 6162`) to point to the new domains.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://blockmaze.com

