### PR TITLE
Add Amero X Network (chainId 3535)

### DIFF
--- a/constants/additionalChainRegistry/chainid-3535.js
+++ b/constants/additionalChainRegistry/chainid-3535.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "Amero X Network",
+  chain: "AMX",
+  rpc: ["https://amxrpc.link/public/rpc"],
+  faucets: [],
+  nativeCurrency: {
+    name: "Amero X",
+    symbol: "AMX",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }],
+  infoURL: "https://amxscan.com",
+  shortName: "amx",
+  chainId: 3535,
+  networkId: 3535,
+  icon: "https://amxscan.com/images/amero_x_logo.png",
+  explorers: [
+    {
+      name: "Amero X Scan",
+      url: "https://amxscan.com",
+      icon: "https://amxscan.com/images/amero_x_logo.png",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
Adds Amero X Network, a public EVM chain (chainId 3535).

- RPC: https://amxrpc.link/public/rpc (HTTPS, CORS enabled, returns 0xdcf)
- Explorer: https://amxscan.com (EIP-3091)
- Native currency: AMX (18 decimals)
- chainId 3535 confirmed unclaimed in the registry.