### PR TITLE
Add Treasure Ruby (978657)

### DIFF
--- a/constants/additionalChainRegistry/chainid-978657.js
+++ b/constants/additionalChainRegistry/chainid-978657.js
@@ -1,0 +1,39 @@
+export const data = {
+  "name": "Treasure Ruby",
+  "chain": "TRS",
+  "rpc": [
+    "https://rpc-testnet.treasure.lol/http",
+    "wss://rpc-testnet.treasure.lol/ws"
+  ],
+  "faucets": [
+    "https://portal.treasure.lol/faucet"
+  ],
+  "nativeCurrency": {
+    "name": "Testnet MAGIC",
+    "symbol": "MAGIC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://portal.treasure.lol",
+  "shortName": "treasure-ruby",
+  "chainId": 978657,
+  "networkId": 978657,
+  "icon": "treasureruby",
+  "explorers": [
+    {
+      "name": "treasurescan",
+      "url": "https://testnet.treasurescan.io",
+      "icon": "treasure",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      {
+        "url": "https://portal.treasure.lol/bridge"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `constants/additionalChainRegistry/chainid-978657.js` for **Treasure Ruby** (chainId `978657`), Treasure's MAGIC testnet L2.
- Sourced from the Treasure Project EIP-155 chain registry (`eip155-978657.json`). This chain is currently missing from https://chainlist.org/rpcs.json (Ethereum Mainnet parent `eip155-1` is already listed).

## Notes
- Native currency: Testnet MAGIC
- RPC: `https://rpc-testnet.treasure.lol/http` (+ WS)
- Explorer: https://testnet.treasurescan.io (EIP3091)
- Faucet / bridge: portal.treasure.lol

## Test plan
- [ ] CI `validate-chain-files` passes on `chainid-978657.js`
- [ ] After merge, https://chainlist.org/chain/978657 lists the RPCs / explorer
- [ ] `https://chainlist.org/rpcs.json` includes `chainId: 978657`


Made with [Cursor](https://cursor.com)