### PR TITLE
Add LXS (chainId 22540)

### DIFF
--- a/constants/additionalChainRegistry/chainid-22540.js
+++ b/constants/additionalChainRegistry/chainid-22540.js
@@ -1,0 +1,19 @@
+export const data = {
+    "name": "LXS Network",
+    "chain": "LXS",
+    "rpc": [
+      "https://lxsnetwork.duckdns.org"
+    ],
+    "features": [{ "name": "EIP155" }],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "LXS",
+      "symbol": "LXS",
+      "decimals": 18
+    },
+    "infoURL": "https://lxs-network.github.io/",
+    "shortName": "lxs",
+    "chainId": 22540,
+    "networkId": 22540,
+    "explorers": []
+  }

--- a/constants/additionalChainRegistry/chainid-22540.js
+++ b/constants/additionalChainRegistry/chainid-22540.js
@@ -1,5 +1,5 @@
 export const data = {
-    "name": "LXS Network",
+    "name": "LXS",
     "chain": "LXS",
     "rpc": [
       "https://lxsnetwork.duckdns.org"


### PR DESCRIPTION
Adds LXS Network via additionalChainRegistry.

- Chain ID: 22540
- Native currency: LXS (18 decimals)
- RPC: https://lxsnetwork.duckdns.org
- Website: https://lxs-network.github.io/
- EVM proof-of-work L1, EIP-155. No explorer yet.