### PR TITLE
Add Aether Mainnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-2107.js
+++ b/constants/additionalChainRegistry/chainid-2107.js
@@ -1,26 +1,25 @@
-export const data = {
-    "name": "IBVM Testnet",
-    "chain": "IBVM Testnet",
-    "icon": "ibvmtest",
-    "rpc": [
-      "https://rpc-testnet.ibvm.io/"
-    ],
-    "faucets": ["https://faucet.ibvm.io"],
-    "nativeCurrency": {
-      "name": "IBVM Bitcoin",
-      "symbol": "IBVM",
-      "decimals": 18
-    },
-    "infoURL": "https://ibvm.io/",
-    "shortName": "IBVMT",
-    "chainId": 2107,
-    "networkId": 2107,
-    "explorers": [
-      {
-        "name": "IBVM Testnet explorer",
-        "url": "https://testnet.ibvmscan.io",
-        "standard": "EIP3091"
-      }
-    ],
-    "status": "active"
-  }
+export default {
+  "name": "Aether",
+  "chain": "AETHER",
+  "rpc": [
+    "https://aether.signaturesoftware.co.in/rpc/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Aether",
+    "symbol": "AETH",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://aether.signaturesoftware.co.in",
+  "shortName": "aeth",
+  "chainId": 2107,
+  "networkId": 2107,
+  "icon": "aether",
+  "explorers": [{
+    "name": "Aether Explorer",
+    "url": "https://aether.signaturesoftware.co.in",
+    "icon": "aether",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adding the official Aether Mainnet to ChainList.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://aether.signaturesoftware.co.in

#### Provide a link to your privacy policy:
https://aether.signaturesoftware.co.in/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the official RPC and network for Aether Mainnet. 

**Note:** The current domain (`aether.signaturesoftware.co.in`) is being used for our testing phase. Once the testing is complete, we will submit another PR to update these URLs to our permanent main domain.