### PR TITLE
Add Robinhood Chain (4663 + 46630 testnet) RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3490,6 +3490,22 @@ export const extraRpcs = {
     ],
   },
 
+  4663: {
+    rpcs: [
+      "https://rpc.mainnet.chain.robinhood.com",
+      {
+        url: "https://robinhood-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
+      {
+        url: "wss://robinhood-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
+    ],
+  },
+
   4689: {
     rpcs: [
       "https://babel-api.mainnet.iotex.io",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3506,6 +3506,22 @@ export const extraRpcs = {
     ],
   },
 
+  46630: {
+    rpcs: [
+      "https://rpc.testnet.chain.robinhood.com",
+      {
+        url: "https://robinhood-sepolia-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
+      {
+        url: "wss://robinhood-sepolia-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
+    ],
+  },
+
   4689: {
     rpcs: [
       "https://babel-api.mainnet.iotex.io",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3506,22 +3506,6 @@ export const extraRpcs = {
     ],
   },
 
-  46630: {
-    rpcs: [
-      "https://rpc.testnet.chain.robinhood.com",
-      {
-        url: "https://robinhood-sepolia-rpc.publicnode.com",
-        tracking: "none",
-        trackingDetails: privacyStatement.publicnode,
-      },
-      {
-        url: "wss://robinhood-sepolia-rpc.publicnode.com",
-        tracking: "none",
-        trackingDetails: privacyStatement.publicnode,
-      },
-    ],
-  },
-
   4689: {
     rpcs: [
       "https://babel-api.mainnet.iotex.io",
@@ -10223,10 +10207,21 @@ export const extraRpcs = {
   },
   46630: {
     rpcs: [
+      "https://rpc.testnet.chain.robinhood.com",
       {
         url: "https://robinhood-testnet.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+      {
+        url: "https://robinhood-sepolia-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
+      },
+      {
+        url: "wss://robinhood-sepolia-rpc.publicnode.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.publicnode,
       },
     ],
   },


### PR DESCRIPTION
Adds an extraRpcs entry for Robinhood Chain mainnet (chainId 4663), which had none, and fills out the existing testnet (46630) entry.

mainnet (4663, new entry):
- official rpc: https://rpc.mainnet.chain.robinhood.com
- publicnode https + wss: robinhood-rpc.publicnode.com (verified live, chainId 0x1237, synced at tip vs the official rpc)

testnet (46630, added to the existing drpc-only entry):
- official rpc: https://rpc.testnet.chain.robinhood.com
- publicnode https + wss: robinhood-sepolia-rpc.publicnode.com (verified live, chainId 0xb626, block heights match the official rpc)

publicnode entries use the existing privacyStatement.publicnode (tracking: none), same as the other publicnode endpoints in the file.