### PR TITLE
Add Farm Chain (Chain ID 165)

### DIFF
--- a/constants/additionalChainRegistry/chainid-165.js
+++ b/constants/additionalChainRegistry/chainid-165.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Farm Chain",
+  "chain": "Farm Chain",
+  "icon": "farmchain",
+  "rpc": [
+    "https://rpc.fmcscan.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Farm Coin",
+    "symbol": "FMC",
+    "decimals": 18
+  },
+  "infoURL": "https://fmcscan.com",
+  "shortName": "Farm",
+  "chainId": 165,
+  "networkId": 165,
+  "explorers": [
+    {
+      "name": "FMCScan",
+      "url": "https://fmcscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2540,6 +2540,11 @@ export const extraRpcs = {
       },
     ],
   },
+  165: {
+    rpcs: [
+      "https://rpc.fmcscan.com",
+    ],
+  },
   256: {
     rpcs: ["https://hecotestapi.terminet.io/rpc"],
   },


### PR DESCRIPTION
## Summary

This PR adds Farm Chain to the additional chain registry.

### Network Information

- Network Name: Farm Chain
- Chain ID: 165
- Native Currency: Farm Coin (FMC)
- RPC: https://rpc.fmcscan.com
- Explorer: https://fmcscan.com

### Validation

- ✅ Duplicate key checks passed
- ✅ Production build completed successfully

### Notes

Farm Chain is an EVM-compatible blockchain.

There is an open discussion regarding Chain ID 165 in the ethereum-lists/chains repository:
https://github.com/ethereum-lists/chains/pull/8497

If project policy requires a different Chain ID, I am happy to update this PR accordingly.

Thank you for your review.