### PR TITLE
Add alternative public RPC for Robinhood Chain (ID 4663)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -10189,6 +10189,15 @@ export const extraRpcs = {
       },
     ],
   },
+  4663: {
+    rpcs: [
+      {
+        url: "https://rpc.degenprotocol.io/robinhood",
+        tracking: "none",
+        trackingDetails: "No user tracking or data collection",
+      },
+    ],
+  },
   46630: {
     rpcs: [
       {


### PR DESCRIPTION
**Link the service provider's website (the company/protocol/individual providing the RPC):**
https://degenprotocol.io

**Provide a link to your privacy policy:**
https://degenprotocol.io/privacy

**If the RPC has none of the above and you still think it should be added, please explain why:**
This is a high-performance alternative public RPC proxy node for the brand new Robinhood L2 Chain to improve network redundancy and prevent single-point-of-failure rate-limiting on the main official network endpoint.