### PR TITLE
Add SELEMAN Chain (chainId 73571)

### DIFF
--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -1,0 +1,29 @@
+/**
+ * SELEMAN Chain — DefiLlama/chainlist additionalChainRegistry
+ * Public RPC/explorer only. No secrets.
+ */
+export const data = {
+  name: "SELEMAN Chain",
+  chain: "SMN",
+  rpc: ["https://seleman.monarcaproject.com/rpc"],
+  faucets: [],
+  nativeCurrency: {
+    name: "SELEMAN",
+    symbol: "SMN",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }],
+  infoURL: "https://seleman.monarcaproject.com/seleman-chain",
+  shortName: "seleman",
+  chainId: 73571,
+  networkId: 73571,
+  icon: "seleman",
+  explorers: [
+    {
+      name: "seleman",
+      url: "https://seleman.monarcaproject.com",
+      icon: "seleman",
+      standard: "EIP3091",
+    },
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -5,7 +5,7 @@ export const data = {
     "https://seleman.monarcaproject.com/rpc",
     "https://seleman-edge.mineriafjs.workers.dev/rpc"
   ],
-  faucets: [],
+  faucets: ["https://seleman.monarcaproject.com/trust-wallet"],
   nativeCurrency: {
     name: "SELEMAN",
     symbol: "SMN",

--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -1,28 +1,25 @@
-/**
- * SELEMAN Chain — DefiLlama/chainlist additionalChainRegistry
- * Public RPC/explorer only. No secrets.
- */
 export const data = {
   name: "SELEMAN Chain",
   chain: "SMN",
-  rpc: ["https://seleman.monarcaproject.com/rpc"],
+  rpc: [
+    "https://seleman.monarcaproject.com/rpc",
+    "https://seleman-edge.mineriafjs.workers.dev/rpc"
+  ],
   faucets: [],
   nativeCurrency: {
     name: "SELEMAN",
     symbol: "SMN",
     decimals: 18,
   },
-  features: [{ name: "EIP155" }],
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
   infoURL: "https://seleman.monarcaproject.com/seleman-chain",
   shortName: "seleman",
   chainId: 73571,
   networkId: 73571,
-  icon: "seleman",
   explorers: [
     {
       name: "seleman",
       url: "https://seleman.monarcaproject.com",
-      icon: "seleman",
       standard: "EIP3091",
     },
   ],


### PR DESCRIPTION
## Summary
- Adds `constants/additionalChainRegistry/chainid-73571.js` for **SELEMAN Chain**
- Public RPC: `https://seleman.monarcaproject.com/rpc` (`eth_chainId` = `0x11f63` / 73571)
- Explorer (EIP-3091): `https://seleman.monarcaproject.com`
- infoURL: `https://seleman.monarcaproject.com/seleman-chain`

## Verification
```bash
curl -s https://seleman.monarcaproject.com/rpc \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
# {"jsonrpc":"2.0","id":1,"result":"0x11f63"}
```

## Notes
- Entry contains **public URLs only** (no API keys / private keys).
- Icon field is `seleman` (logo on DefiLlama may require separate listing later).
