### PR TITLE
Improve explorer links and filtered chain results

### DIFF
--- a/components/ExplorerList/index.js
+++ b/components/ExplorerList/index.js
@@ -1,5 +1,4 @@
 import { notTranslation as useTranslations } from "../../utils";
-import CopyUrl from "../CopyUrl";
 import { explorerBlacklist } from "../../constants/explorerBlacklist";
 
 export default function ExplorerList({ chain, lang }) {
@@ -46,7 +45,18 @@ const ExplorerRow = ({ isLoading, explorer, className }) => {
     <tr className={className}>
       <td className="px-3 py-1 text-sm border text-center">{isLoading ? <Shimmer /> : explorer?.name}</td>
       <td className="border px-3 py-1 max-w-[40ch] text-center">
-        {isLoading ? <Shimmer /> : explorer?.url ? <CopyUrl url={explorer.url} /> : null}
+        {isLoading ? (
+          <Shimmer />
+        ) : explorer?.url ? (
+          <a
+            href={explorer.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block max-w-[40ch] px-2 py-[2px] -my-[2px] overflow-hidden text-ellipsis dark:hover:text-white hover:underline"
+          >
+            {explorer.url}
+          </a>
+        ) : null}
       </td>
     </tr>
   );

--- a/components/chain/index.js
+++ b/components/chain/index.js
@@ -9,7 +9,7 @@ import { useChain } from "../../stores";
 import useAccount from "../../hooks/useAccount";
 import useAddToNetwork from "../../hooks/useAddToNetwork";
 
-export default function Chain({ chain, buttonOnly, lang }) {
+export default function Chain({ chain, autoExpand = false, buttonOnly, lang }) {
   const t = useTranslations("Common", lang);
 
   const router = useRouter();
@@ -29,7 +29,7 @@ export default function Chain({ chain, buttonOnly, lang }) {
     }
   };
 
-  const showAddlInfo = chain.chainId === chainId;
+  const showAddlInfo = autoExpand || chain.chainId === chainId;
 
   const { data: accountData } = useAccount();
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -38,11 +38,25 @@ function Home({ chains }) {
         <React.Suspense fallback={<div className="h-screen"></div>}>
           <div className="dark:text-[#B3B3B3] text-black grid gap-5 grid-cols-1 place-content-between pb-4 sm:pb-10 sm:grid-cols-[repeat(auto-fit,_calc(50%_-_15px))] 3xl:grid-cols-[repeat(auto-fit,_calc(33%_-_20px))] isolate grid-flow-dense">
             {finalChains.slice(0, 2).map((chain) => {
-              return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
+              return (
+                <Chain
+                  chain={chain}
+                  autoExpand={finalChains.length === 1}
+                  key={JSON.stringify(chain) + "en"}
+                  lang="en"
+                />
+              );
             })}
             <AdBanner />
             {finalChains.slice(2, end).map((chain) => {
-              return <Chain chain={chain} key={JSON.stringify(chain) + "en"} lang="en" />;
+              return (
+                <Chain
+                  chain={chain}
+                  autoExpand={finalChains.length === 1}
+                  key={JSON.stringify(chain) + "en"}
+                  lang="en"
+                />
+              );
             })}
           </div>
         </React.Suspense>


### PR DESCRIPTION
Block explorer URLs now behave as external links, while RPC endpoints retain their copy interaction. Searches that narrow the home page to one chain now reveal its RPC details automatically.

- Open block explorer URLs in a new tab with safe link attributes
- Keep RPC URL copying unchanged
- Auto-expand the sole chain card after filtering without synchronized state or effects