### PR TITLE
Add Liberty Reserve chain configuration

### DIFF
--- a/_data/chains/1410.json
+++ b/_data/chains/1410.json
@@ -1,0 +1,24 @@
+{
+  "name": "Liberty Reserve",
+  "chain": "LRX",
+  "rpc": [
+    "https://rpc.lrxmining.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Liberty Reserve",
+    "symbol": "LRX",
+    "decimals": 18
+  },
+  "infoURL": "https://lrxmining.com",
+  "shortName": "lrx",
+  "chainId": 1410,
+  "networkId": 1410,
+  "explorers": [
+    {
+      "name": "Liberty Reserve Explorer",
+      "url": "https://explorer.lrxmining.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
 {
  "name": "Liberty Reserve",
  "chain": "LRX",
  "rpc": [
    "https://rpc.lrxmining.com"
  ],
  "faucets": [],
  "nativeCurrency": {
    "name": "Liberty Reserve",
    "symbol": "LRX",
    "decimals": 18
  },
  "infoURL": "https://lrxmining.com",
  "shortName": "lrx",
  "chainId": 1410,
  "networkId": 1410,
  "explorers": [
    {
      "name": "Liberty Reserve Explorer",
      "url": "https://explorer.lrxmining.com",
      "standard": "EIP3091"
    }
  ]
}