### PR TITLE
Add public RPC for BlockDAG Network (1404)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -661,6 +661,16 @@ export const extraRpcs = {
       },
     ],
   },
+  1404: {
+    rpcs: [
+      {
+        url: "https://rpc.kenny-us-pool.com",
+        tracking: "yes",
+        trackingDetails:
+          "This RPC endpoint may log request metadata (IP address, request method, timestamps) for rate-limiting, abuse prevention, and service reliability purposes.",
+      },
+    ],
+  },
   2517: {
     rpcs: [
       "https://svp-dataseed1-testnet.svpchain.org",


### PR DESCRIPTION
Adding a public RPC endpoint for BlockDAG Network (chain ID 1404).

- Endpoint: https://rpc.kenny-us-pool.com
- Verified eth_chainId returns 0x57c
- CORS enabled (access-control-allow-origin: *), HTTPS via nginx
- Tracking: request metadata (IP, method, timestamp) may be logged for rate-limiting/abuse prevention