### PR TITLE
Add Mars Credit Network (chainId 110110)

### DIFF
--- a/constants/additionalChainRegistry/chainid-110110.js
+++ b/constants/additionalChainRegistry/chainid-110110.js
@@ -1,0 +1,19 @@
+export const data = {
+  name: "Mars Credit Network",
+  chain: "MARS",
+  icon: "marscredit",
+  rpc: ["https://rpc.marscredit.xyz"],
+  faucets: [],
+  nativeCurrency: { name: "Mars Credit", symbol: "MARS", decimals: 18 },
+  infoURL: "https://marscredit.xyz",
+  shortName: "mars",
+  chainId: 110110,
+  networkId: 110110,
+  explorers: [
+    {
+      name: "Mars Credit Blockscout",
+      url: "https://blockscan.marscredit.xyz",
+      standard: "EIP3091",
+    },
+  ],
+}


### PR DESCRIPTION
Adds Mars Credit Network to the additional chain registry so chainlist.org displays the correct RPC/explorer metadata alongside the upstream ethereum-lists/chains entry.

**Chain details**
- Name: Mars Credit Network
- Short: mars
- Chain ID / Network ID: 110110
- Native currency: MARS (18 decimals)
- Consensus: Ethash (PoW)
- RPC: https://rpc.marscredit.xyz
- Explorer (Blockscout, EIP-3091): https://blockscan.marscredit.xyz
- Info: https://marscredit.xyz

**Upstream context**
- Mainnet live since June 2024, currently at 4.94M+ blocks
- Corresponding ethereum-lists/chains entry: ethereum-lists/chains PR #8446 (merged 2026-07-26)
- viem chain export shipped in wevm/viem PR #4742 (merged 2026-07-02), released in viem 2.55.10

Following DefiLlama's own guidance ("ethereum-list is an upstream, PRs for new networks should be added there first") — this PR mirrors the merged upstream entry to ensure chainlist.org displays Mars Credit correctly.