### PR TITLE
Add SELEMAN Chain (73571) RPCs with tracking: none

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -248,6 +248,8 @@ const privacyStatement = {
     "To route your requests, blockmachine temporarily processes your IP address for up to 2 minutes - used only to count and rate-limit requests. It is never stored beyond that window and cannot be linked to any individual user or account.",
   keccakio:
     "keccak.io does not require accounts, email, or KYC, does not log client IP addresses, and does not correlate requests to users. https://keccak.io/privacy",
+  seleman:
+    "SELEMAN public JSON-RPC does not store or track user data, does not log client IP addresses to persistent storage, and does not correlate requests with wallet addresses. Ephemeral in-memory rate-limit counters (≤60s) may be used solely for abuse prevention and are not retained as historical logs. No analytics or third-party tracking on the RPC path. https://seleman.monarcaproject.com/privacy",
 };
 
 export const extraRpcs = {
@@ -10397,6 +10399,20 @@ export const extraRpcs = {
         url: "https://flare-testnet.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    ],
+  },
+  73571: {
+    rpcs: [
+      {
+        url: "https://seleman.monarcaproject.com/rpc",
+        tracking: "none",
+        trackingDetails: privacyStatement.seleman,
+      },
+      {
+        url: "https://seleman-edge.mineriafjs.workers.dev/rpc",
+        tracking: "none",
+        trackingDetails: privacyStatement.seleman,
       },
     ],
   },


### PR DESCRIPTION
## Summary
Add public RPCs for **SELEMAN Chain** (chainId **73571**, already listed via `chainid-73571.js`) to `constants/extraRpcs.js` with `tracking: "none"` so the Chainlist **Privacy** column shows green.

### RPCs
- https://seleman.monarcaproject.com/rpc
- https://seleman-edge.mineriafjs.workers.dev/rpc

### Answers (Add Your RPC)
#### Link the service provider's website
https://seleman.monarcaproject.com/seleman-chain

#### Provide a link to your privacy policy
https://seleman.monarcaproject.com/privacy

#### Tracking
`none` — public JSON-RPC does not store/track user data, does not log client IPs to persistent storage, and does not correlate requests with wallet addresses. Ephemeral in-memory rate-limit counters (≤60s) only for abuse prevention.

## Test plan
- [ ] Open https://chainlist.org/chain/73571 after merge
- [ ] Expand RPC list → **Privacy** column green for both URLs
- [ ] Height/Latency still healthy