### PR TITLE
Add Humanity Protocol relaunched mainnet (chainId 13600000)

### DIFF
--- a/constants/additionalChainRegistry/chainid-13600000.js
+++ b/constants/additionalChainRegistry/chainid-13600000.js
@@ -1,0 +1,34 @@
+export const data = {
+  "name": "Humanity",
+  "chain": "Humanity",
+  "rpc": [
+    "https://humanity-main.g.alchemy.com/public"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "H",
+    "symbol": "H",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://humanity.org",
+  "shortName": "hp",
+  "chainId": 13600000,
+  "networkId": 13600000,
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-42161",
+    "bridges": [
+      {
+        "url": "https://bridge.humanity.org"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "name": "Humanity Mainnet explorer",
+      "url": "https://humanity-main.explorer.alchemy.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the relaunched Humanity Protocol mainnet via `additionalChainRegistry`.

- **Chain ID:** 13600000 (relaunch of Humanity Protocol; the previous chain 6985385 is being deprecated — ethereum-lists PR pending as ethereum-lists/chains#8518, green but waiting on maintainer review)
- **RPC:** `https://humanity-main.g.alchemy.com/public` — verified: `eth_chainId` returns `0xcf8500` (13600000)
- **Explorer:** https://humanity-main.explorer.alchemy.com (Blockscout, EIP3091) — live
- **Native currency:** H (18 decimals); L2 on Arbitrum One
- `node tests/check-duplicate-keys.js` passes; `list.js` generation verified locally

Operated by the Humanity Protocol team (we registered the original 6985385 chain). Happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)