### PR TITLE
Add SELEMAN (73571) to chainIds.js for icon slug

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -252,6 +252,7 @@ export default {
   "59144": "linea",
   "60808": "bob",
   "70003": "pyra",
+  "73571": "seleman",
   "71394": "godwoken",
   "71402": "godwoken",
   "78887": "lung",


### PR DESCRIPTION
## Summary
- Maps chainId `73571` → slug `seleman` so Chainlist UI resolves `icons.llamao.fi/icons/chains/rsz_seleman.jpg` instead of `unknown-logo.png`.
- Complements open PR DefiLlama/icons#2433 (icon asset) and live additionalChainRegistry entry from #2967.

## Test plan
- [ ] After icons CDN has rsz_seleman.jpg, chainlist.org/chain/73571 shows SELEMAN logo (not unknown-logo)
- [ ] No other chainIds keys changed
