### PR TITLE
Add SELEMAN (73571) public WSS RPC

### DIFF
--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -3,7 +3,8 @@ export const data = {
   chain: "SMN",
   rpc: [
     "https://seleman.monarcaproject.com/rpc",
-    "https://seleman-edge.mineriafjs.workers.dev/rpc"
+    "https://seleman-edge.mineriafjs.workers.dev/rpc",
+    "wss://seleman.monarcaproject.com/ws"
   ],
   faucets: ["https://seleman.monarcaproject.com/trust-wallet"],
   nativeCurrency: {

--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -4,7 +4,7 @@ export const data = {
   rpc: [
     "https://seleman.monarcaproject.com/rpc",
     "https://seleman-edge.mineriafjs.workers.dev/rpc",
-    "wss://seleman.monarcaproject.com/ws"
+    "wss://seleman-ws.monarcaproject.com"
   ],
   faucets: ["https://seleman.monarcaproject.com/trust-wallet"],
   nativeCurrency: {


### PR DESCRIPTION
## Summary
- Adds `wss://seleman-ws.monarcaproject.com` to SELEMAN Chain RPC list (alongside existing HTTPS endpoints).
- Dedicated tunnel hostname (not `/ws` path) so Cloudflare Universal SSL covers the cert; enables `eth_subscribe`.

## Test plan
- [x] `wss://seleman-ws.monarcaproject.com` returns `eth_chainId` → `0x11f63` (73571)
- [ ] chainlist.org/chain/73571 lists the WSS URL after merge
- [ ] HTTPS RPCs unchanged and still score green