### PR TITLE
Add RANNTA X-Chain direct registry entry and icon

### DIFF
--- a/constants/additionalChainRegistry/chainid-13113.js
+++ b/constants/additionalChainRegistry/chainid-13113.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "RANNTA X-Chain",
+  chain: "RANNTA",
+  rpc: ["https://rpc.rannta.com/"],
+  nativeCurrency: {
+    name: "RANNTA Core X",
+    symbol: "RNTX",
+    decimals: 18,
+  },
+  features: [],
+  infoURL: "https://rannta.com/",
+  shortName: "rntx",
+  chainId: 13113,
+  networkId: 13113,
+  icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+  explorers: [
+    {
+      name: "RANNTA X-Chain Explorer",
+      url: "https://explorer.rannta.com/",
+      icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+      standard: "EIP3091",
+    },
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-13113.js
+++ b/constants/additionalChainRegistry/chainid-13113.js
@@ -12,12 +12,12 @@ export const data = {
   shortName: "rntx",
   chainId: 13113,
   networkId: 13113,
-  icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+  icon: "https://emerald-important-bat-644.mypinata.cloud/ipfs/bafkreidh2qtmdplg7wi2le7ump57gvfhoyrg565m4tgua3d4b6zgmojqwm",
   explorers: [
     {
       name: "RANNTA X-Chain Explorer",
       url: "https://explorer.rannta.com/",
-      icon: "https://ranntaexchange.com/brand/rannta-xchain-256.png",
+      icon: "https://emerald-important-bat-644.mypinata.cloud/ipfs/bafkreidh2qtmdplg7wi2le7ump57gvfhoyrg565m4tgua3d4b6zgmojqwm",
       standard: "EIP3091",
     },
   ],


### PR DESCRIPTION
Adds RANNTA X-Chain directly to ChainList's additionalChainRegistry.

Network:
- Name: RANNTA X-Chain
- Chain ID / Network ID: 13113
- Native currency: RANNTA Core X (RNTX)
- Decimals: 18
- RPC: https://rpc.rannta.com/
- Explorer: https://explorer.rannta.com/
- Website: https://rannta.com/

Icon:
- 256×256 PNG
- Permanently pinned IPFS asset
- CID: bafkreidh2qtmdplg7wi2le7ump57gvfhoyrg565m4tgua3d4b6zgmojqwm

The previous PR #2807 was closed without merge because the chain was already visible through upstream chain data. However, the direct file constants/additionalChainRegistry/chainid-13113.js was never added, and the ChainList icon remained missing.