### PR TITLE
Update Altcoinchain (chainId 2330) RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -2933,7 +2933,7 @@ export const extraRpcs = {
     ],
   },
   2330: {
-    rpcs: ["http://138.197.152.181:8145", "https://rpc0.altcoinchain.org/rpc"],
+    rpcs: ["https://rpc.wattxchange.app"],
   },
   1773: {
     rpcs: ["http://138.197.152.181:8245"],


### PR DESCRIPTION
Both RPCs currently listed for Altcoinchain (chainId 2330) are dead:

- `http://138.197.152.181:8145` — connection refused
- `https://rpc0.altcoinchain.org/rpc` — domain no longer resolves

This PR replaces them with the current public endpoint:

- `https://rpc.wattxchange.app`

Verification:
```
$ curl -s -X POST https://rpc.wattxchange.app -H 'content-type: application/json' \
    --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc":"2.0","id":1,"result":"0x91a"}   # 0x91a = 2330
```

The endpoint is synced and serving live blocks (height ~6,945,000 at time of writing).