### PR TITLE
Add Robinscan as primary explorer for Robinhood Chain (4663)

### DIFF
--- a/constants/additionalChainRegistry/chainid-4663.js
+++ b/constants/additionalChainRegistry/chainid-4663.js
@@ -14,6 +14,11 @@ export const data = {
   networkId: 4663,
   explorers: [
     {
+      name: "Robinscan",
+      url: "https://robinscan.io",
+      standard: "EIP3091",
+    },
+    {
       name: "Robinhood Chain Blockscout Explorer",
       url: "https://robinhoodchain.blockscout.com",
       standard: "EIP3091",


### PR DESCRIPTION
Adds [Robinscan](https://robinscan.io) as the primary block explorer for Robinhood Chain (chain ID 4663), with Blockscout kept as a secondary option.

Robinscan is currently the fastest explorer for Robinhood Chain and is the explorer that most platforms are switching to.