### PR TITLE
Add Robinscan explorer for Robinhood Chain (4663)

### DIFF
--- a/constants/additionalChainRegistry/chainid-4663.js
+++ b/constants/additionalChainRegistry/chainid-4663.js
@@ -14,6 +14,11 @@ export const data = {
   networkId: 4663,
   explorers: [
     {
+      name: "Robinscan",
+      url: "https://robinscan.io",
+      standard: "EIP3091",
+    },
+    {
       name: "Robinhood Chain Blockscout Explorer",
       url: "https://robinhoodchain.blockscout.com",
       standard: "EIP3091",


### PR DESCRIPTION
Adds [Robinscan](https://robinscan.io) as a block explorer for Robinhood Chain (chain ID 4663), alongside the existing Blockscout explorer.