### PR TITLE
Add HIPERCAPITAL FINANCE Chain configuration

### DIFF
--- a/constants/additionalChainRegistry/chainid-240884.js
+++ b/constants/additionalChainRegistry/chainid-240884.js
@@ -1,0 +1,14 @@
+export const data = {
+    "name": "HIPERCAPITAL FINANCE Chain",
+    "chain": "HIPCF",
+    "icon": "hipercapital",
+    "rpc": ["https://rpc.hipercapitalfinance.com"],
+    "features": [{ "name": "EIP155" }],
+    "faucets": [],
+    "nativeCurrency": { "name": "HIPERCAPITAL FINANCE Token", "symbol": "HIP", "decimals": 18 },
+    "infoURL": "https://hipercapitalfinance.com",
+    "shortName": "hipcf",
+    "chainId": 240884,
+    "networkId": 240884,
+    "explorers": [{ "name": "HIPERCAPITAL FINANCE Explorer", "url": "https://explorer.hipercapitalfinance.com", "standard": "EIP3091" }]
+  }


### PR DESCRIPTION
<img width="512" height="512" alt="logo_hipcf" src="https://github.com/user-attachments/assets/8dc18816-4d0f-4cd9-81f8-e4bfc21f7d8b" />
Adds HIPERCAPITAL FINANCE Chain (chainId 240884) to constants/additionalChainRegistry.
Please add the attached image as the chain icon named "hipercapital".