### PR TITLE
Add Veri5 (chain ID 63868)

### DIFF
--- a/constants/additionalChainRegistry/chainid-63868.js
+++ b/constants/additionalChainRegistry/chainid-63868.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "Veri5",
+  "chain": "VERI5",
+  "icon": "https://explorer.veri5.network/assets/configs/network_icon.png",
+  "rpc": [
+    "https://rpc0.veri5.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Unit",
+    "symbol": "UNIT",
+    "decimals": 18
+  },
+  "infoURL": "https://veri5.technology",
+  "shortName": "veri5",
+  "chainId": 63868,
+  "networkId": 63868,
+  "explorers": [
+    {
+      "name": "Veri5 Explorer",
+      "url": "https://explorer.veri5.network",
+      "icon": "https://explorer.veri5.network/assets/configs/network_icon.png",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-63868.js
+++ b/constants/additionalChainRegistry/chainid-63868.js
@@ -1,7 +1,7 @@
 export const data = {
   "name": "Veri5",
   "chain": "VERI5",
-  "icon": "https://explorer.veri5.network/assets/configs/network_icon.png",
+  "icon": "https://gateway.pinata.cloud/ipfs/bafybeihqekabx2rg2m2crfg3r63fmcngqj5ghk4gucknmr66empihp6bfq",
   "rpc": [
     "https://rpc0.veri5.network"
   ],
@@ -19,7 +19,7 @@ export const data = {
     {
       "name": "Veri5 Explorer",
       "url": "https://explorer.veri5.network",
-      "icon": "https://explorer.veri5.network/assets/configs/network_icon.png",
+      "icon": "https://gateway.pinata.cloud/ipfs/bafybeihqekabx2rg2m2crfg3r63fmcngqj5ghk4gucknmr66empihp6bfq",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Adds **Veri5** (chain ID 63868) to Chainlist.

- **RPC:** https://rpc0.veri5.network (returns chainId `0xf97c` / 63868)
- **Explorer:** https://explorer.veri5.network (Blockscout, EIP-3091)
- **Native currency:** Unit (UNIT), 18 decimals
- **Info:** https://veri5.technology

Single new file `constants/additionalChainRegistry/chainid-63868.js`.