### PR TITLE
fix: update Marschain RPC

### DIFF
--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -1,9 +1,7 @@
 export const data = {
   name: "Marschain",
   chain: "MARS",
-  rpc: [
-    "https://marsdata.tuibi.com"
-  ],
+  rpc: ["https://rpcs.marschain.net/"],
   faucets: [],
   nativeCurrency: {
     name: "Mars",
@@ -26,4 +24,4 @@ export const data = {
       standard: "EIP3091"
     }
   ]
-}
+};


### PR DESCRIPTION
## Summary
- replace the inactive Marschain RPC endpoint
- use the official public RPC https://rpcs.marschain.net/

## Verification
- eth_chainId returns 0x37a (890)

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://marschain.net

#### Provide a link to your privacy policy:

N/A

#### If the RPC has none of the above and you still think it should be added, please explain why:

This is the official public RPC for Marschain (chain ID 890). It replaces the inactive endpoint https://marsdata.tuibi.com. The new endpoint responds successfully to eth_chainId with 0x37a (890).