### PR TITLE
Add Midpoint Cross chain 1394 configuration

### DIFF
--- a/constants/additionalChainRegistry/chainid-1394.js
+++ b/constants/additionalChainRegistry/chainid-1394.js
@@ -1,0 +1,27 @@
+export const data = {
+  "name": "Midpoint Cross",
+  "chain": "MIDX",
+  "rpc": [
+    "https://mainnet.midpointcross.com"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Midpoint Cross",
+    "symbol": "MIDX",
+    "decimals": 18
+  },
+  "infoURL": "https://www.midpointcross.com",
+  "shortName": "midx",
+  "chainId": 1394,
+  "networkId": 1394,
+  "icon": "midpointcross",
+  "explorers": [
+    {
+      "name": "Midpoint Cross",
+      "url": "https://transactions.midpointcross.com",
+      "icon": "midpointcross",
+      "standard": "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
Adds **Midpoint Cross** (chain ID 1394) and **Midpoint Cross Testnet** (chain ID 139420) to Chainlist.

**Midpoint Cross — 1394**
- RPC: https://mainnet.midpointcross.com (returns chainId `0x572` / 1394)
- Explorer: https://transactions.midpointcross.com (EIP-3091)
- Native currency: Midpoint Cross (MIDX), 18 decimals
- Info: https://www.midpointcross.com

**Midpoint Cross Testnet — 139420**
- RPC: https://testnet.midpointcross.com (returns chainId `0x2209c` / 139420)
- Explorer: https://testnet-transactions.midpointcross.com (EIP-3091)
- Native currency: Midpoint Cross Testnet (tMIDX), 18 decimals, slip44 1
- Info: https://www.midpointcross.com

Two new files: `constants/additionalChainRegistry/chainid-1394.js` and `chainid-139420.js`.
Both chains are also registered upstream in ethereum-lists/chains (#8569, #8570).