### PR TITLE
Add Midpoint Cross Testnet chain configuration

### DIFF
--- a/constants/additionalChainRegistry/chainid-139420.js
+++ b/constants/additionalChainRegistry/chainid-139420.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "Midpoint Cross Testnet",
+  "chain": "MIDX",
+  "rpc": [
+    "https://testnet.midpointcross.com"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Midpoint Cross Testnet",
+    "symbol": "tMIDX",
+    "decimals": 18
+  },
+  "infoURL": "https://www.midpointcross.com",
+  "shortName": "midxt",
+  "chainId": 139420,
+  "networkId": 139420,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "Midpoint Cross Testnet",
+      "url": "https://testnet-transactions.midpointcross.com",
+      "standard": "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
Adds **Midpoint Cross Testnet** (chain ID 139420) to Chainlist.

**Midpoint Cross Testnet — 139420**
- RPC: https://testnet.midpointcross.com (returns chainId `0x2209c` / 139420)
- Explorer: https://testnet-transactions.midpointcross.com (EIP-3091)
- Native currency: Midpoint Cross Testnet (tMIDX), 18 decimals, slip44 1
- Info: https://www.midpointcross.com

**Midpoint Cross — 1394**
- RPC: https://mainnet.midpointcross.com (returns chainId `0x572` / 1394)
- Explorer: https://transactions.midpointcross.com (EIP-3091)
- Native currency: Midpoint Cross (MIDX), 18 decimals
- Info: https://www.midpointcross.com

Two new files: `constants/additionalChainRegistry/chainid-1394.js` and `chainid-139420.js`. Both chains are also registered upstream in ethereum-lists/chains (#8569, #8570).
