### PR TITLE
fix(sepolia): replace poisoned faucet URL and drop leaked Alchemy key

### DIFF
--- a/constants/additionalChainRegistry/chainid-11155111.js
+++ b/constants/additionalChainRegistry/chainid-11155111.js
@@ -1,0 +1,72 @@
+export const data = {
+  "name": "Ethereum Sepolia",
+  "title": "Ethereum Testnet Sepolia",
+  "chain": "ETH",
+  "rpc": [
+    { "url": "https://lb.routeme.sh/rpc/evm/11155111", "tracking": "limited" },
+    { "url": "https://eth-sepolia.g.alchemy.com/v2/demo", "tracking": "yes" },
+    { "url": "https://eth-sepolia.public.blastapi.io", "tracking": "limited" },
+    { "url": "https://eth-sepolia-public.unifra.io", "tracking": "limited" },
+    { "url": "https://sepolia.gateway.tenderly.co", "tracking": "yes" },
+    { "url": "https://gateway.tenderly.co/public/sepolia", "tracking": "yes" },
+    { "url": "https://sphinx.shardeum.org", "tracking": "yes" },
+    { "url": "https://dapps.shardeum.org", "tracking": "yes" },
+    { "url": "https://api.zan.top/eth-sepolia", "tracking": "limited" },
+    { "url": "https://rpc.notadegen.com/eth/sepolia" },
+    { "url": "https://ethereum-sepolia-rpc.publicnode.com", "tracking": "none" },
+    { "url": "wss://ethereum-sepolia-rpc.publicnode.com", "tracking": "none" },
+    { "url": "https://public.1rpc.io/sepolia", "tracking": "none" },
+    { "url": "https://eth-sepolia.api.onfinality.io/public", "tracking": "limited" },
+    { "url": "https://public.stackup.sh/api/v1/node/ethereum-sepolia", "tracking": "limited" },
+    { "url": "https://ethereum-sepolia-public.nodies.app", "tracking": "limited" },
+    { "url": "https://eth-testnet.4everland.org/v1/37fa9972c1b1cd5fab542c7bdd4cde2f", "tracking": "limited" },
+    { "url": "wss://eth-testnet.4everland.org/ws/v1/37fa9972c1b1cd5fab542c7bdd4cde2f", "tracking": "limited" },
+    { "url": "https://endpoints.omniatech.io/v1/eth/sepolia/public", "tracking": "none" },
+    { "url": "https://0xrpc.io/sep", "tracking": "none" },
+    { "url": "wss://0xrpc.io/sep", "tracking": "none" },
+    { "url": "https://rpc.owlracle.info/sepolia/70d38ce1826c4a60bb2a8e05a6c8b20f", "tracking": "limited" },
+    { "url": "https://ethereum-sepolia.therpc.io", "tracking": "limited" },
+    { "url": "https://ethereum-sepolia.gateway.tatum.io", "tracking": "yes" },
+    { "url": "https://eth-sepolia-testnet.api.pocket.network", "tracking": "none" },
+    { "url": "https://sepolia.rpc.sentio.xyz", "tracking": "limited" },
+    { "url": "wss://eth-sepolia-testnet.api.pocket.network", "tracking": "none" },
+    { "url": "https://rpc.sepolia.org" },
+    { "url": "https://rpc2.sepolia.org" },
+    { "url": "https://rpc.sepolia.ethpandaops.io" },
+    { "url": "wss://sepolia.gateway.tenderly.co" },
+    { "url": "https://sepolia.drpc.org" },
+    { "url": "wss://sepolia.drpc.org" }
+  ],
+  "faucets": [
+    "https://cloud.google.com/application/web3/faucet/ethereum/sepolia",
+    "https://sepolia-faucet.pk910.de"
+  ],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://sepolia.otterscan.io",
+  "shortName": "sep",
+  "chainId": 11155111,
+  "networkId": 11155111,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "etherscan-sepolia",
+      "url": "https://sepolia.etherscan.io",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "otterscan-sepolia",
+      "url": "https://sepolia.otterscan.io",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Routescan",
+      "url": "https://11155111.testnet.routescan.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "isTestnet": true
+}


### PR DESCRIPTION
## Problem

Fixes #2567

The faucet entry for Ethereum Sepolia (chainId 11155111) still points to `fauceth.komputing.org` in production `rpcs.json` — confirmed live today. The domain expired and now redirects to an unrelated gambling site.

The upstream RPC list for this chain also carries a hardcoded Alchemy API key in one of the RPC URLs (`eth-sepolia.g.alchemy.com/v2/<key>`), which shouldn't be shipped in a public config.

A prior PR (#2699) attempted the same fix and was closed without a merge — reopening with the same core approach since the underlying bug is still live, verified against the current `chainlist.org/rpcs.json` output.

## Changes

- Added `constants/additionalChainRegistry/chainid-11155111.js` to override the upstream Sepolia entry (matches the existing override pattern used elsewhere in this file).
- Replaced the broken faucet with two faucets I checked are live today:
  - `https://cloud.google.com/application/web3/faucet/ethereum/sepolia`
  - `https://sepolia-faucet.pk910.de`
- Dropped the RPC entry containing the leaked Alchemy key; kept the public `/v2/demo` Alchemy endpoint and every other RPC/explorer entry unchanged.

## Verification

- `ONLY_LIST_FILE=1 bash scripts/build.sh` regenerates `list.js` with the new import (465 chains, up from 464).
- `node tests/check-duplicate-keys.js` passes.
- Confirmed via `node --input-type=module` that the file exports valid data with the corrected `faucets` array.