### PR TITLE
network: add AGLAIS

### DIFF
--- a/constants/additionalChainRegistry/chainid-20033.js
+++ b/constants/additionalChainRegistry/chainid-20033.js
@@ -13,5 +13,11 @@ export const data = {
   shortName: "agls",
   chainId: 20033,
   networkId: 20033,
-  explorers: [],
+  explorers: [
+    {
+      name: "Aglais Explorer",
+      url: "https://explorer.testnet.quip.network",
+      standard: "EIP3091",
+    },
+  ],
 };

--- a/constants/additionalChainRegistry/chainid-20033.js
+++ b/constants/additionalChainRegistry/chainid-20033.js
@@ -1,0 +1,17 @@
+export const data = {
+  name: "Aglais Testnet (Quip Network)",
+  chain: "AGLS",
+  icon: "ipfs://QmbVscoh7LthwT7U3gyyTErSokYG5SM85EpSETpmHuATwi",
+  rpc: ["https://evm-rpc.testnet.quip.network:20049"],
+  faucets: [],
+  nativeCurrency: {
+    name: "AGLS",
+    symbol: "AGLS",
+    decimals: 18,
+  },
+  infoURL: "https://agls.quip.network",
+  shortName: "agls",
+  chainId: 20033,
+  networkId: 20033,
+  explorers: [],
+};


### PR DESCRIPTION
RPC: https://evm-rpc.testnet.quip.network:20049 (returns chainId 20033)
Native currency: Aglais (AGLS), 18 decimals
Info: https://agls.quip.network