### PR TITLE
Add HyveChain (chainId 7847)

### DIFF
--- a/constants/additionalChainRegistry/chainid-7847.js
+++ b/constants/additionalChainRegistry/chainid-7847.js
@@ -1,0 +1,26 @@
+export const data = {
+  "name": "HyveChain",
+  "chain": "HYVE",
+  "icon": "hyvechain",
+  "rpc": [
+    "https://rpc.hyvechain.com"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "HYVE",
+    "symbol": "HYVE",
+    "decimals": 18
+  },
+  "infoURL": "https://hyvechain.com",
+  "shortName": "hyve",
+  "chainId": 7847,
+  "networkId": 7847,
+  "explorers": [
+    {
+      "name": "HyveChain Explorer",
+      "url": "https://explorer.hyvechain.com"
+    }
+  ],
+  "status": "active"
+};


### PR DESCRIPTION
Adds HyveChain to `constants/additionalChainRegistry`.

| | |
|---|---|
| chainId / networkId | 7847 |
| RPC | https://rpc.hyvechain.com |
| Explorer | https://explorer.hyvechain.com |
| Native currency | HYVE, 18 decimals |
| Live since | March 2026 — ~3.44M blocks, ~3.3 s block time |

**Measured against the live endpoint before opening this PR:**

- `eth_chainId` → `0x1ea7` (7847), matching both `chainId` and `networkId`
- `baseFeePerGas` → `0x3b9aca00` on the latest block, `eth_feeHistory` returns a series, `eth_maxPriorityFeePerGas` answers — so `EIP1559` is claimed on evidence rather than assumption
- Valid TLS, `Access-Control-Allow-Origin: *` present exactly once on both the preflight (204) and the POST (200), so browser wallets can reach it
- ~240 ms TTFB measured from outside the network, 20/20 rapid requests returned 200

A parallel submission to `ethereum-lists/chains` is open as [#8577](https://github.com/ethereum-lists/chains/pull/8577); the `icon` field here refers to the `hyvechain` icon added there.

**One thing worth flagging:** `node tests/check-duplicate-keys.js` currently fails on `extraRpcs.js` and `chainIds.js` with *Octal escape sequences are not allowed in strict mode*. I verified this failure is present on a clean checkout without my change — removing my file and re-running produces the identical two errors — so it is pre-existing and unrelated to this PR.