### PR TITLE
Add rpc.welshdag.trade to chain 1404 (BlockDAG)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1404.js
+++ b/constants/additionalChainRegistry/chainid-1404.js
@@ -3,7 +3,7 @@ export const data = {
   "chain": "BDAG",
   "icon": "BDAG",
   "rpc": [
-    "​https://rpc.bdagscan.com",
+    "https://rpc.bdagscan.com",
   ],
   "faucets": [],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
@@ -20,6 +20,11 @@ export const data = {
     {
       "name": "BlockDAG Explorer",
       "url": "https://bdagscan.com/",
+    },
+    {
+      "name": "WelshDAG Explorer",
+      "url": "https://scan.welshdag.trade",
+      "standard": "EIP3091",
     },
   ],
   "status": "active"


### PR DESCRIPTION
Adds a second public RPC endpoint and block explorer for BlockDAG Network (chainId 1404).

- RPC `https://rpc.welshdag.trade` - community-operated full archive node.
  Verified: eth_chainId = 0x57c (1404), net_version = 1404, EIP-1559 active
  (baseFeePerGas present), CORS allows https://chainlist.org.
- Explorer `https://scan.welshdag.trade` - Blockscout instance indexing the
  same node. EIP-3091 compliant (/block/, /tx/, /address/ routes verified).

Also removes a zero-width space (U+200B) preceding the `h` in the existing
`https://rpc.bdagscan.com` entry, which prevents that URL from parsing.
