### PR TITLE
Add Marschain icon

### DIFF
--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -16,7 +16,7 @@ export const data = {
   shortName: "mars",
   chainId: 890,
   networkId: 890,
-  icon: "marschain",
+  icon: "ipfs://bafkreidjevwbk3kslq6gspdpzdn3jrm7kxepd2oaem3o7u2zspmqlk7ksa",
   explorers: [
     {
       name: "Mars Explorer",

--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -16,7 +16,7 @@ export const data = {
   shortName: "mars",
   chainId: 890,
   networkId: 890,
-  icon: "ipfs://bafkreidjevwbk3kslq6gspdpzdn3jrm7kxepd2oaem3o7u2zspmqlk7ksa",
+  icon: "https://marschain.net/logo-mars.png",
   explorers: [
     {
       name: "Mars Explorer",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,6 +102,7 @@ export default {
   "8379": "bery",
   "841": "tara",
   "888": "wanchain",
+  "890": "marschain",
   "957": "lyra",
   "964": "bittensor_evm",
   "988": "stable",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,7 +102,6 @@ export default {
   "8379": "bery",
   "841": "tara",
   "888": "wanchain",
-  "890": "marschain",
   "957": "lyra",
   "964": "bittensor_evm",
   "988": "stable",


### PR DESCRIPTION
## Summary

- Replace the unresolved `marschain` icon identifier with the verified IPFS-hosted Marschain icon.
- Icon metadata: JPEG, 1024 × 1024, 36,511 bytes.

No RPC or other chain metadata is changed.