### PR TITLE
add SWSS Chain (122605) chain slug

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -264,6 +264,7 @@ export default {
   "98866": "plume",
   "105105": "stratis",
   "111188": "real",
+  "122605": "swss",
   "153153": "odyssey",
   "167000": "taiko",
   "171717": "wchain",


### PR DESCRIPTION
Adds the chain slug mapping for SWSS Chain (chainId 122605) so the network
renders its icon instead of the placeholder.

The chain data entry was merged in #2899
(`constants/additionalChainRegistry/chainid-122605.js`), but without an entry
in `chainIds.js` the `chainSlug` is undefined, so `components/chain/index.js`
falls back to `/unknown-logo.png`.

The matching icon is submitted as DefiLlama/icons#2447
(`assets/chains/rsz_swss.jpg`, slug `swss`).

SWSS Chain is an EVM mainnet, live since 2024.
- Explorer: https://swssscan.swss.io
- RPC: https://swssrpc.swss.io
- Info: https://swss.io
