### PR TITLE
Add CashCat Chain (chainId 2274228)

### DIFF
--- a/constants/additionalChainRegistry/chainid-2274228.js
+++ b/constants/additionalChainRegistry/chainid-2274228.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "CashCat Chain",
+  "chain": "CASHCAT",
+  "rpc": [
+    "https://rpc.cashcat.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Cash Cat",
+    "symbol": "CASHCAT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://cashcat.network",
+  "shortName": "cashcat",
+  "chainId": 2274228,
+  "networkId": 2274228,
+  "explorers": [
+    {
+      "name": "CashCat Explorer",
+      "url": "https://explorer.cashcat.network",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds CashCat Chain (chainId 2274228) to the additional chain registry.

CashCat Chain is an EVM chain (Arbitrum Orbit L3) whose native gas token is **CASHCAT**.

- **RPC:** https://rpc.cashcat.network
- **Explorer:** https://explorer.cashcat.network (Blockscout, EIP-3091)
- **Native currency:** Cash Cat (CASHCAT), 18 decimals
- **Chain ID / Network ID:** 2274228
- **Info:** https://cashcat.network