### PR TITLE
Add TTL Coin (chainId 7777) icon slug

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -188,6 +188,7 @@ export default {
   "7332": "horizen_eon",
   "7560": "cyeth",
   "7700": "canto",
+  "7777": "ttl",
   "7887": "kinto",
   "8008": "polynomial",
   "8217": "klaytn",


### PR DESCRIPTION
Adds `"7777": "ttl"` to `constants/chainIds.js` so TTL Coin shows its logo instead of the unknown-logo placeholder.

- Chain is live in chainid.network data: `eip155-7777.json` (name "TTL Coin", `"icon": "ttl"`).
- Companion PR with the icon image: DefiLlama/icons#2448 (`assets/chains/rsz_ttl.jpg`).

Chain info: https://github.com/okneo31/ttlcoin | RPC: https://rpc.ttl1.top | Explorer: https://scan.ttl1.top