### PR TITLE
Map Marschain chain icon

### DIFF
--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -16,7 +16,7 @@ export const data = {
   shortName: "mars",
   chainId: 890,
   networkId: 890,
-  icon: "marschain",
+  icon: "ipfs://bafkreidjevwbk3kslq6gspdpzdn3jrm7kxepd2oaem3o7u2zspmqlk7ksa",
   explorers: [
     {
       name: "Mars Explorer",

--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -16,7 +16,7 @@ export const data = {
   shortName: "mars",
   chainId: 890,
   networkId: 890,
-  icon: "https://marschain.net/logo-mars.png",
+  icon: "marschain",
   explorers: [
     {
       name: "Mars Explorer",

--- a/constants/additionalChainRegistry/chainid-890.js
+++ b/constants/additionalChainRegistry/chainid-890.js
@@ -16,7 +16,7 @@ export const data = {
   shortName: "mars",
   chainId: 890,
   networkId: 890,
-  icon: "ipfs://bafkreidjevwbk3kslq6gspdpzdn3jrm7kxepd2oaem3o7u2zspmqlk7ksa",
+  icon: "https://marschain.net/logo-mars.png",
   explorers: [
     {
       name: "Mars Explorer",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,6 +102,7 @@ export default {
   "8379": "bery",
   "841": "tara",
   "888": "wanchain",
+  "890": "marschain",
   "957": "lyra",
   "964": "bittensor_evm",
   "988": "stable",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -102,7 +102,6 @@ export default {
   "8379": "bery",
   "841": "tara",
   "888": "wanchain",
-  "890": "marschain",
   "957": "lyra",
   "964": "bittensor_evm",
   "988": "stable",


### PR DESCRIPTION
## Summary

- Map Chain ID `890` to the `marschain` icon slug.
- Keep the existing `icon: "marschain"` registry value unchanged.

## Why

Chainlist renders chain icons through `chainSlug`, which is populated from `constants/chainIds.js`. Without the Chain ID mapping, Marschain falls back to the unknown logo even though its registry entry already uses the correct slug.

## Companion icon PR

- https://github.com/DefiLlama/icons/pull/2454

No RPC or other chain metadata is changed.
