### PR TITLE
add tenderly gateway to ronin, the other rpcs cap getLogs at 100-200 blocks

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -11049,6 +11049,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.dwellir,
       },
+      {
+        url: "https://ronin.gateway.tenderly.co",
+        tracking: "yes",
+        trackingDetails: privacyStatement.tenderly,
+      },
     ],
   },
   31: {


### PR DESCRIPTION
Every Ronin RPC currently listed for chainId 2020 either caps `eth_getLogs` to a very small range or fails outright, which makes the chain unusable for anything that reads logs over a daily window.

Tested with a single 800-block `eth_getLogs`:

| endpoint | result |
| --- | --- |
| `https://api.roninchain.com/rpc` | `requested block range 801 exceeds the limit of 200` |
| `https://ronin.drpc.org` | 500, `Temporary internal error` |
| `https://ronin-mainnet.gateway.tatum.io/` | `Requested range is over limit of 100` |
| `https://lb.routeme.sh/rpc/evm/2020` | `public rate limit exceeded` |
| `https://api-ronin-mainnet.n.dwellir.com/…` | carries an embedded key, not usable publicly |

Ronin runs ~3s blocks, so a day is roughly 28,800 blocks and a 100-200 block ceiling means ~150-290 requests per adapter per day.

Adding the Tenderly gateway, which has no small range ceiling and serves archive logs:

| check | result |
| --- | --- |
| `eth_getLogs` 800 blocks | 115 logs |
| `eth_getLogs` 10,000 blocks | 1,601 logs |
| `eth_getLogs` 30,000 blocks | 6,240 logs |
| `eth_getLogs` 2,000 blocks, 200k blocks back | 367 logs (archive) |
| `eth_chainId` | `0x7e4` (2020) |
| `eth_call` (multicall3) | ok |
| `eth_getBlockByNumber` latest | current, synced at tip |
| 4 consecutive calls | 200 each time |

30,000 blocks in one call covers a full Ronin day.

Tenderly gateways already appear 48 times in this file and `privacyStatement.tenderly` exists, so the entry follows the existing shape (`tracking: "yes"`).

Checked for the duplicate-key hazard: 1,022 chainId keys, no duplicates, and `2020` appears exactly once. The file still imports cleanly and Ronin now lists 6 RPCs.

Context: this surfaced from DefiLlama/dimension-adapters#8713, every log-based Ronin adapter (Katana DEX, Katana DEX V3, Tristero Spot, Axie Infinity) stopped recording on 2026-08-04/05 while the chain is still trading (46 UniswapV2 `Swap` logs across 11 pairs in the last ~10 minutes).
