### PR TITLE
Add Base Vibenet (chainId 84538453)

### DIFF
--- a/constants/additionalChainRegistry/chainid-84538453.js
+++ b/constants/additionalChainRegistry/chainid-84538453.js
@@ -1,0 +1,28 @@
+export const data = {
+    "name": "Base Vibenet",
+    "chain": "ETH",
+    "icon": "base",
+    "rpc": [
+      "https://rpc.vibes.base.org"
+    ],
+    "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+    "faucets": [
+      "https://chain.base.org/vibenet/faucet"
+    ],
+    "nativeCurrency": {
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18
+    },
+    "infoURL": "https://docs.base.org/base-chain/quickstart/connecting-to-base",
+    "shortName": "base-vibenet",
+    "chainId": 84538453,
+    "networkId": 84538453,
+    "explorers": [
+      {
+        "name": "Base Vibenet Explorer",
+        "url": "https://chain.base.org/vibenet/explorer",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
## Add a chain

Adds a new chain file `constants/additionalChainRegistry/chainid-84538453.js` for **Base Vibenet**, following the structure documented in the README.

Base Vibenet is Base's experimental preview network where new chain-level features are made available before they roll out to Base Sepolia or Base Mainnet.

### Network details
| Field | Value |
| --- | --- |
| Name | Base Vibenet |
| Chain ID | 84538453 |
| RPC | https://rpc.vibes.base.org |
| Native currency | Ether (ETH), 18 decimals |
| Explorer | https://chain.base.org/vibenet/explorer |
| Faucet | https://chain.base.org/vibenet/faucet |

Source: [Base docs — Connecting to Base](https://docs.base.org/base-chain/quickstart/connecting-to-base)