### PR TITLE
Remove NodeFlare Sei endpoint (chain 1329) — node retired

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -9754,11 +9754,6 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.routemesh,
       },
-      {
-        url: "https://rpc.nodeflare.app/sei/public",
-        tracking: "none",
-        trackingDetails: privacyStatement.nodeflare,
-      },
       "https://evm-rpc.sei-apis.com",
       {
         url: "https://sei.drpc.org",


### PR DESCRIPTION
Removes one endpoint we ourselves added in #2923.

We retired our Sei node on 11 August 2026 and are not replacing it, so
`https://rpc.nodeflare.app/sei/public` no longer resolves to a chain we serve — it
now returns `404 unknown_chain`. Rather than leave it listed and let people hit a
dead endpoint from chainlist, it should come out.

**Scope:** one entry deleted from `constants/extraRpcs.js` under chain `1329`.
Nothing else touched. Our remaining 22 NodeFlare entries are unaffected and still
answer; verified after the change that the module still imports and that `1329` no
longer references us.

Sorry for the churn — the node came out of the fleet shortly after that PR merged.