### PR TITLE
Add Snowside Mainnet (chainId 32904) and Testnet (chainId 33160)

### DIFF
--- a/constants/additionalChainRegistry/chainid-32904.js
+++ b/constants/additionalChainRegistry/chainid-32904.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "Snowside",
+  "chain": "ECX",
+  "rpc": ["https://rpc.snowside.network/mainnet"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ECash",
+    "symbol": "ECX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://snowside.network",
+  "shortName": "ecx",
+  "chainId": 32904,
+  "networkId": 32904,
+  "icon": "ipfs://bafkreig3ioaoqiyvd3uinf5p5qtvvhhzxbbvb3ukljezanccsrc5mfp62y",
+  "explorers": [{
+    "name": "Snowside Explorer",
+    "url": "https://explorer.snowside.network",
+    "icon": "ipfs://bafkreig3ioaoqiyvd3uinf5p5qtvvhhzxbbvb3ukljezanccsrc5mfp62y",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-33160.js
+++ b/constants/additionalChainRegistry/chainid-33160.js
@@ -1,0 +1,23 @@
+export const data = {
+  "name": "Snowside Testnet",
+  "chain": "ECX",
+  "rpc": ["https://rpc.snowside.network/testnet"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ECash",
+    "symbol": "ECX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://snowside.network",
+  "shortName": "ecx-testnet",
+  "chainId": 33160,
+  "networkId": 33160,
+  "icon": "ipfs://bafkreig3ioaoqiyvd3uinf5p5qtvvhhzxbbvb3ukljezanccsrc5mfp62y",
+  "explorers": [{
+    "name": "Snowside Testnet Explorer",
+    "url": "https://explorer-testnet.snowside.network",
+    "icon": "ipfs://bafkreig3ioaoqiyvd3uinf5p5qtvvhhzxbbvb3ukljezanccsrc5mfp62y",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
## Chains Added

| Property | Mainnet | Testnet |
|----------|---------|---------|
| Chain ID | 32904 | 33160 |
| Name | Snowside | Snowside Testnet |
| Native Currency | ECash (ECX) | ECash (ECX) |
| RPC | https://rpc.snowside.network/mainnet | https://rpc.snowside.network/testnet |
| Explorer | https://explorer.snowside.network | https://explorer-testnet.snowside.network |
| Website | https://snowside.network | https://snowside.network |

## About Snowside

Snowside is a dedicated Avalanche EVM L1/Subnet for eCash.com, featuring:
- Native BTC gas via the ECX token
- Blind merged mining (BIP-300/301 compatible)
- USDC bridging via Interchain Messaging (ICM)
- Custodial bridge MVP deployed and working (deposit + withdrawal verified on signet)

## Links

- GitHub: https://github.com/abitsuite/snowside
- Website: https://snowside.network
- Organization: https://github.com/abitsuite
