### PR TITLE
Add second GL1Infra public RPC endpoint for GenesisL1

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4523,6 +4523,7 @@ export const extraRpcs = {
       "https://api.lcserve.net",
       "https://api.lcserve.org",
       "https://genesisl1.evm.utsa.tech/",
+      "https://evm.vicky.gl1infra.online",
     ],
   },
   33: {


### PR DESCRIPTION
This PR adds a second public RPC endpoint for GenesisL1 (chain ID 29), 
operated as part of the GL1Infra public infrastructure alongside the 
existing endpoint.

Endpoint: https://evm.vicky.gl1infra.online

Testing performed:
- Verified eth_chainId, eth_blockNumber respond correctly
- Latency tested from multiple independent locations: ~50-150ms average
- SSL/HTTPS properly configured (Let's Encrypt)
- Fully synced with chain, monitored 24/7 via automated health checks

This provides redundancy for the GenesisL1 network — if one endpoint 
is temporarily unavailable, users can fall back to the other.