### PR TITLE
Add Haus Chain Testnet (2443)

### DIFF
--- a/constants/additionalChainRegistry/chainid-2443.js
+++ b/constants/additionalChainRegistry/chainid-2443.js
@@ -1,0 +1,24 @@
+export const data = {
+  name: "Haus Chain Testnet",
+  chain: "HAUS",
+  rpc: ["https://rpc-testnet.hausserver.xyz"],
+  faucets: ["https://faucet-testnet.hausserver.xyz"],
+  nativeCurrency: {
+    name: "Haus",
+    symbol: "HAUS",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://www.hausserver.xyz",
+  shortName: "t-haus",
+  chainId: 2443,
+  networkId: 2443,
+  icon: "haus",
+  explorers: [
+    {
+      name: "Haus Chain Testnet Explorer",
+      url: "https://explorer-testnet.hausserver.xyz",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
## Add Haus Chain Testnet — Chain ID 2443

Adds Haus Chain Testnet to DefiLlama Chainlist's
`additionalChainRegistry`.

### Network

- Name: Haus Chain Testnet
- Chain ID: `2443`
- Network ID: `2443`
- Chain ID hex: `0x98b`
- Native currency: `HAUS`
- Decimals: `18`
- Icon slug: `haus`
- EIP-155: Yes
- EIP-1559: Yes

### Public endpoints

- HTTP RPC: https://rpc-testnet.hausserver.xyz
- WebSocket RPC: wss://rpc-testnet.hausserver.xyz
- Explorer: https://explorer-testnet.hausserver.xyz
- Faucet: https://faucet-testnet.hausserver.xyz
- Website: https://www.hausserver.xyz

The Chainlist RPC array intentionally uses the public HTTP RPC. The canonical
ethereum-lists record also documents the WebSocket endpoint.

### Haus icon

Matching DefiLlama icon PR:

https://github.com/DefiLlama/icons/pull/2453

Asset:

`assets/chains/rsz_haus.png`

Chainlist references it with:

`icon: "haus"`

### Canonical registrations

ethereum-lists/chains — merged:

https://github.com/ethereum-lists/chains/pull/8582

Canonical data:

https://raw.githubusercontent.com/ethereum-lists/chains/master/_data/chains/eip155-2443.json

Blockscout ChainScout — merged:

https://github.com/blockscout/chainscout/pull/271

### Validation completed before submission

- Live `eth_chainId` = `0x98b`
- Live `net_version` = `2443`
- Latest block contains `baseFeePerGas`
- Canonical ethereum-lists data verified
- HTTP RPC reachable
- Explorer reachable
- Faucet reachable
- Website reachable
- Haus icon validated as 400×400 transparent PNG
- New Chainlist JS module imports successfully
- `npm test` passes
- `git diff --check` passes
- Full Chainlist build passes

This PR adds exactly one Chainlist registry file:
`constants/additionalChainRegistry/chainid-2443.js`
