### PR TITLE
Add Pexli Testnet (Chain ID 78901)

### DIFF
--- a/constants/additionalChainRegistry/chainid-78901.js
+++ b/constants/additionalChainRegistry/chainid-78901.js
@@ -1,0 +1,28 @@
+export const data = {
+  name: "Pexli Testnet",
+  chain: "PEX",
+  rpc: ["https://testrpc.pex.li"],
+  faucets: ["https://faucet.pex.li"],
+  features: [{ name: "EIP155" }],
+  nativeCurrency: {
+    name: "Pexli",
+    symbol: "PEX",
+    decimals: 18,
+  },
+  infoURL: "https://pex.li",
+  shortName: "pexli-testnet",
+  chainId: 78901,
+  networkId: 78901,
+  explorers: [
+    {
+      name: "Pexli Explorer",
+      url: "https://explorer.pex.li",
+      standard: "EIP3091",
+    },
+    {
+      name: "Pexli Testscan",
+      url: "https://testscan.pex.li",
+      standard: "EIP3091",
+    },
+  ],
+};

--- a/constants/additionalChainRegistry/chainid-78901.js
+++ b/constants/additionalChainRegistry/chainid-78901.js
@@ -19,10 +19,5 @@ export const data = {
       url: "https://explorer.pex.li",
       standard: "EIP3091",
     },
-    {
-      name: "Pexli Testscan",
-      url: "https://testscan.pex.li",
-      standard: "EIP3091",
-    },
   ],
 };


### PR DESCRIPTION
## Summary

Adds Pexli Testnet to Chainlist.

## Network details

- **Network:** Pexli Testnet
- **Chain ID / Network ID:** 78901
- **Native currency:** PEX (18 decimals)
- **RPC:** https://testrpc.pex.li
- **Faucet:** https://faucet.pex.li
- **Explorer:** https://explorer.pex.li
- **Network website:** https://pex.li

## RPC provider details

#### Link the service provider's website

https://pex.li

#### Provide a link to your privacy policy

No separate RPC privacy-policy URL is currently published.

#### If the RPC has none of the above and you still think it should be added, please explain why

testrpc.pex.li is the official public JSON-RPC endpoint linked from the Pexli network website and is required for wallets and Web3 clients to connect to Pexli Testnet.

## Verification

The RPC method eth_chainId returns 0x13435, which equals decimal chain ID 78901.