### PR TITLE
Add Efikcoin Mainnet Chain ID 20488

### DIFF
--- a/constants/additionalChainRegistry/chainid-20488.js
+++ b/constants/additionalChainRegistry/chainid-20488.js
@@ -1,0 +1,23 @@
+// Chain ID 20488 - Efikcoin Mainnet
+export default {
+  chainId: 20488,
+  chain: "EFC",
+  name: "Efikcoin Mainnet",
+  shortName: "efikcoin",
+  networkId: 20488,
+  nativeCurrency: {
+    name: "Efikcoin",
+    symbol: "EFC",
+    decimals: 18
+  },
+  rpc: ["https://rpc.efikcoin.com/rpc"],
+  faucets: [],
+  explorers: [{
+    name: "Efikcoin Explorer",
+    url: "https://explorer.efikcoin.com",
+    standard: "EIP3091"
+  }],
+  infoURL: "https://efikcoin.com",
+  sourceToken: "0x677Ce9CBa67f7484ea951a12897CE780cFd8fED1",
+  founder: "0xC5AD5cfcF81AD63a94227334b898eafCe6B27cCA"
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):https://efikcoin.com
Official RPC: https://rpc.efikcoin.com/rpc - Provided by Efikcoin Mainnet Team


#### Provide a link to your privacy policy:https://efikcoin.com/privacy
No user tracking, no logs kept, public good RPC for Chain ID 20488


#### If the RPC has none of the above and you still think it should be added, please explain why:Efikcoin Mainnet Chain ID 20488 is independent EVM mainnet with native EFC gas (not BNB). Founder 0xC5AD5cfcF81AD63a94227334b898eafCe6B27cCA. Migrated from BEP20 0x677Ce9CBa67f7484ea951a12897CE780cFd8fED1. Explorer https://explorer.efikcoin.com. RPC is live and needed for MetaMask, TrustWallet, Remix IDE. RPC added at end of array as required.

Your RPC should always be added at the end of the array.