### PR TITLE
Add YNX Testnet (Chain ID 6423)

### DIFF
--- a/constants/additionalChainRegistry/chainid-6423.js
+++ b/constants/additionalChainRegistry/chainid-6423.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "YNX Testnet",
+  "chain": "YNX",
+  "icon": "ynx",
+  "rpc": ["https://evm.ynxweb4.com"],
+  "faucets": ["https://www.ynxweb4.com/dapp/faucet"],
+  "nativeCurrency": {
+    "name": "YNXT",
+    "symbol": "YNXT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://ynxweb4.com",
+  "shortName": "ynxtest",
+  "chainId": 6423,
+  "networkId": 6423,
+  "explorers": [
+    {
+      "name": "YNX Explorer",
+      "url": "https://explorer.ynxweb4.com",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+};


### PR DESCRIPTION
## Summary

Adds YNX Testnet to the additional chain registry.

### Network

* Name: YNX Testnet
* Chain ID: 6423
* Network ID: 6423
* Native currency: YNXT
* RPC: https://evm.ynxweb4.com/
* Faucet: https://www.ynxweb4.com/dapp/faucet
* Explorer: https://explorer.ynxweb4.com/
* Website: https://ynxweb4.com/

### Registry reference

YNX Testnet is already registered in `ethereum-lists/chains` as Chain ID 6423 via `ethereum-lists/chains#8531`.

This PR adds the corresponding DefiLlama Chainlist registry entry following the repository's `constants/additionalChainRegistry/chainid-{chainId}.js` format.