### PR TITLE
fix: use the app's QueryClient in useConnect/useAddToNetwork

### DIFF
--- a/hooks/useAddToNetwork.jsx
+++ b/hooks/useAddToNetwork.jsx
@@ -1,5 +1,5 @@
 import * as Fathom from "fathom-client";
-import { useMutation, QueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FATHOM_EVENTS_ID, FATHOM_DROPDOWN_EVENTS_ID, FATHOM_NO_EVENTS_ID, CHAINS_MONITOR } from "./useAnalytics";
 import { connectWallet } from "./useConnect";
 
@@ -53,7 +53,7 @@ export async function addToNetwork({ address, chain, rpc }) {
 }
 
 export default function useAddToNetwork() {
-  const queryClient = new QueryClient();
+  const queryClient = useQueryClient();
 
   return useMutation(addToNetwork, {
     onSettled: () => {

--- a/hooks/useConnect.jsx
+++ b/hooks/useConnect.jsx
@@ -1,4 +1,4 @@
-import { useMutation, QueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export async function connectWallet() {
   try {
@@ -20,7 +20,7 @@ export async function connectWallet() {
 }
 
 export default function useConnect() {
-  const queryClient = new QueryClient();
+  const queryClient = useQueryClient();
 
   return useMutation(() => connectWallet(), {
     onSettled: () => {


### PR DESCRIPTION
closes #3052

## bug

`useConnect` and `useAddToNetwork` each build a **new** `QueryClient` and invalidate it:

```js
const queryClient = new QueryClient();
// ...
onSettled: () => { queryClient.invalidateQueries(); }
```

That client is disconnected from the one in `pages/_app.js` (`<QueryClientProvider client={queryClient}>`), so `invalidateQueries()` invalidates an empty, unused cache. After connecting a wallet or adding a network, the app's queries never refetch.

## fix

Use `useQueryClient()` to get the client from context, so the invalidation targets the app's real cache. Two-line change in each hook (react-query v4, `useQueryClient` is the v4 hook).

## receipts

```
next build  →  ✓ Compiled successfully
```

Both hooks call `useQueryClient()` unconditionally at the top of the hook (rules-of-hooks safe), and the `QueryClientProvider` in `pages/_app.js` supplies the client.
