### PR TITLE
Add privacy metadata for SELEMAN WSS RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -15603,6 +15603,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.seleman,
       },
+      {
+        url: "wss://seleman-ws.monarcaproject.com",
+        tracking: "none",
+        trackingDetails: privacyStatement.seleman,
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Marks wss://seleman-ws.monarcaproject.com as tracking: none.
- Reuses the existing SELEMAN privacy statement used by both HTTPS endpoints.

## Evidence
- WSS eth_chainId returns 0x11f63 (73571).
- The live ChainList WSS row lacks a green Privacy indicator because it is absent from extraRpcs metadata.

## Test plan
- [x] Change is limited to constants/extraRpcs.js.
- [x] Repository duplicate-key checks pass for privacy statements and chain IDs.
- [x] The repository test's module-syntax failure reproduces on unmodified upstream/main with the available Node runtime.
- [ ] After merge/deploy, verify the live WSS row shows green Privacy.