### PR TITLE
feat: adopt eip-6963 for connected-wallet name and icon

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -6,6 +6,8 @@ import { formatAddress, getProvider } from "../../utils";
 import { walletIcons } from "../../constants/walletIcons";
 import useConnect from "../../hooks/useConnect";
 import useAccount from "../../hooks/useAccount";
+import useEip6963Providers from "../../hooks/useEip6963";
+import { resolveConnectedWalletInfo } from "../../utils/eip6963";
 
 function Header({ lang, chainName, setChainName }) {
   const t = useTranslations("Common", lang);
@@ -34,6 +36,13 @@ function Header({ lang, chainName, setChainName }) {
   const { data: accountData } = useAccount();
 
   const address = accountData?.address ?? null;
+
+  // Prefer the connected wallet's own EIP-6963 name/icon; fall back to the
+  // legacy `is*` allowlist (getProvider/walletIcons) for wallets that don't
+  // announce yet.
+  const eip6963Providers = useEip6963Providers();
+  const connectedProvider = typeof window !== "undefined" ? window.ethereum : null;
+  const discoveredWallet = resolveConnectedWalletInfo(eip6963Providers, connectedProvider);
 
   return (
     <div className="sticky top-0 z-50 rounded-[10px] dark:bg-[#181818] bg-[#f3f3f3] p-5 -m-5">
@@ -123,7 +132,12 @@ function Header({ lang, chainName, setChainName }) {
             >
               {address ? (
                 <>
-                  <img src={walletIcons[getProvider()]} width={20} height={20} alt="" />
+                  <img
+                    src={discoveredWallet?.icon ?? walletIcons[getProvider()]}
+                    width={20}
+                    height={20}
+                    alt={discoveredWallet?.name ?? getProvider()}
+                  />
                   <span>{formatAddress(address)}</span>
                 </>
               ) : (

--- a/hooks/useEip6963.jsx
+++ b/hooks/useEip6963.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { EIP6963_ANNOUNCE_EVENT, EIP6963_REQUEST_EVENT } from "../utils/eip6963";
+
+/**
+ * Discover injected wallets via EIP-6963.
+ *
+ * Listens for `eip6963:announceProvider` events, then asks every wallet to
+ * announce itself with `eip6963:requestProvider`. Announcements are de-duped by
+ * their `info.uuid`. Returns the list of announced provider details.
+ *
+ * SSR-safe: does nothing until mounted in the browser.
+ *
+ * https://eips.ethereum.org/EIPS/eip-6963
+ */
+export default function useEip6963Providers() {
+  const [providers, setProviders] = useState([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const seen = new Map();
+
+    const onAnnounce = (event) => {
+      const detail = event?.detail;
+      const uuid = detail?.info?.uuid;
+      if (!uuid || !detail?.provider) return;
+      if (seen.has(uuid)) return;
+      seen.set(uuid, detail);
+      setProviders(Array.from(seen.values()));
+    };
+
+    window.addEventListener(EIP6963_ANNOUNCE_EVENT, onAnnounce);
+    window.dispatchEvent(new Event(EIP6963_REQUEST_EVENT));
+
+    return () => window.removeEventListener(EIP6963_ANNOUNCE_EVENT, onAnnounce);
+  }, []);
+
+  return providers;
+}

--- a/tests/eip6963.test.js
+++ b/tests/eip6963.test.js
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the pure EIP-6963 matching helper.
+ * Run with: node --test tests/eip6963.test.js
+ */
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { resolveConnectedWalletInfo } = require("../utils/eip6963");
+
+// A tiny factory for the EIP-6963 provider-detail shape.
+const detail = (name, provider, icon = "data:image/svg+xml;base64,AAAA", uuid = name) => ({
+  info: { uuid, name, icon, rdns: `com.${name.toLowerCase()}` },
+  provider,
+});
+
+test("returns the name/icon of the announced provider matching window.ethereum", () => {
+  const rabby = {};
+  const metamask = {};
+  const providers = [detail("MetaMask", metamask), detail("Rabby", rabby)];
+
+  assert.deepEqual(resolveConnectedWalletInfo(providers, rabby), {
+    name: "Rabby",
+    icon: "data:image/svg+xml;base64,AAAA",
+  });
+});
+
+test("matches via selectedProvider when the wallet multiplexes", () => {
+  const inner = {};
+  const connected = { selectedProvider: inner };
+  const providers = [detail("Coinbase Wallet", inner)];
+
+  assert.deepEqual(resolveConnectedWalletInfo(providers, connected), {
+    name: "Coinbase Wallet",
+    icon: "data:image/svg+xml;base64,AAAA",
+  });
+});
+
+test("returns null when no announced provider matches the connected one", () => {
+  const providers = [detail("MetaMask", {}), detail("Rabby", {})];
+  assert.equal(resolveConnectedWalletInfo(providers, {}), null);
+});
+
+test("returns null for empty / missing inputs", () => {
+  assert.equal(resolveConnectedWalletInfo([], {}), null);
+  assert.equal(resolveConnectedWalletInfo([detail("MetaMask", {})], null), null);
+  assert.equal(resolveConnectedWalletInfo(null, {}), null);
+  assert.equal(resolveConnectedWalletInfo(undefined, {}), null);
+});
+
+test("icon is null when the announcement omits a usable icon", () => {
+  const p = {};
+  const noIcon = { info: { uuid: "x", name: "Weird Wallet" }, provider: p };
+  assert.deepEqual(resolveConnectedWalletInfo([noIcon], p), {
+    name: "Weird Wallet",
+    icon: null,
+  });
+});
+
+test("skips a matching provider that announced no usable name", () => {
+  const p = {};
+  const nameless = { info: { uuid: "x", name: "" }, provider: p };
+  assert.equal(resolveConnectedWalletInfo([nameless], p), null);
+});
+
+test("ignores malformed detail entries without throwing", () => {
+  const p = {};
+  const providers = [null, {}, { info: {} }, { provider: p }, detail("Rabby", p)];
+  assert.deepEqual(resolveConnectedWalletInfo(providers, p), {
+    name: "Rabby",
+    icon: "data:image/svg+xml;base64,AAAA",
+  });
+});

--- a/utils/eip6963.js
+++ b/utils/eip6963.js
@@ -1,0 +1,61 @@
+/**
+ * EIP-6963 (Multi Injected Provider Discovery) helpers.
+ *
+ * The connected-wallet name and icon used to come from a hardcoded allowlist of
+ * legacy `window.ethereum.is*` flags (see `getProvider` / `walletIcons`). Any
+ * wallet not on that list fell back to a generic name and the MetaMask icon.
+ *
+ * EIP-6963 lets every injected wallet announce itself with a standard
+ * `{ info: { uuid, name, icon, rdns }, provider }` detail, so we can show the
+ * real name/icon of whatever the user actually connected, and keep the legacy
+ * allowlist only as a fallback for wallets that don't announce yet.
+ *
+ * https://eips.ethereum.org/EIPS/eip-6963
+ *
+ * Kept as a plain CommonJS module with no React/DOM imports so the pure
+ * matching logic can be unit-tested with `node --test` (see
+ * tests/eip6963.test.js) and still be named-imported from the ESM app source.
+ */
+
+const EIP6963_ANNOUNCE_EVENT = "eip6963:announceProvider";
+const EIP6963_REQUEST_EVENT = "eip6963:requestProvider";
+
+/**
+ * Find the announced EIP-6963 provider that matches the currently connected
+ * injected provider, and return its display name + icon.
+ *
+ * Matching is by provider object identity: a spec-compliant wallet announces
+ * the very same object it injects as `window.ethereum`. We also check
+ * `selectedProvider`, which some multiplexing wallets (e.g. Coinbase) expose.
+ *
+ * @param {Array<{ info?: { name?: string, icon?: string }, provider?: unknown }>} providers
+ *   The list of announced EIP-6963 provider details.
+ * @param {unknown} connectedProvider The injected provider (`window.ethereum`).
+ * @returns {{ name: string, icon: string | null } | null}
+ *   The matched wallet's name/icon, or `null` when there is no match.
+ */
+function resolveConnectedWalletInfo(providers, connectedProvider) {
+  if (!Array.isArray(providers) || providers.length === 0 || !connectedProvider) {
+    return null;
+  }
+
+  const candidates = [connectedProvider, connectedProvider.selectedProvider].filter(Boolean);
+
+  for (const detail of providers) {
+    if (!detail || !detail.provider || !detail.info) continue;
+    if (!candidates.includes(detail.provider)) continue;
+
+    const { name, icon } = detail.info;
+    if (typeof name === "string" && name.length > 0) {
+      return { name, icon: typeof icon === "string" && icon.length > 0 ? icon : null };
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  EIP6963_ANNOUNCE_EVENT,
+  EIP6963_REQUEST_EVENT,
+  resolveConnectedWalletInfo,
+};


### PR DESCRIPTION
closes #2994

### what

Adopt [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) (Multi Injected Provider Discovery) for the connected-wallet name and icon.

Today the wallet chip in the header derives its name/icon from a hardcoded allowlist of legacy `window.ethereum.is*` flags (`getProvider()` + `constants/walletIcons.js`). Anything not on that list (Rabby, Zerion, Rainbow, Frame, OKX, ...) falls back to a generic name and the MetaMask icon, so a Rabby user sees a MetaMask fox next to their address.

This uses the wallet's own EIP-6963 announcement (`{ info: { name, icon, rdns, uuid }, provider }`) to show the real name/icon of whatever the user actually connected, and keeps the `is*` allowlist purely as a fallback for wallets that don't announce yet.

### how

- `utils/eip6963.js` - a small, dependency-free (no React/DOM) module with the pure matching helper `resolveConnectedWalletInfo(providers, connectedProvider)`. It matches the announced provider to the connected one by object identity (also checking `selectedProvider` for multiplexing wallets) and returns `{ name, icon }`, or `null` when nothing matches. Kept plain CJS so it can be unit-tested and named-imported from the ESM app source.
- `hooks/useEip6963.jsx` - SSR-safe discovery hook: listens for `eip6963:announceProvider`, dispatches `eip6963:requestProvider`, de-dupes announcements by `info.uuid`.
- `components/header/index.js` - the connected-wallet chip now prefers the discovered `icon`/`name`, falling back to `walletIcons[getProvider()]` / `getProvider()` exactly as before.

Additive and backwards-compatible: no behavior change for the wallets already on the allowlist; the fallback path is untouched.

### tests

`tests/eip6963.test.js` (Node's built-in runner, no new dep - matches the existing `tests/` convention):

```
$ node --test tests/eip6963.test.js
✔ returns the name/icon of the announced provider matching window.ethereum
✔ matches via selectedProvider when the wallet multiplexes
✔ returns null when no announced provider matches the connected one
✔ returns null for empty / missing inputs
✔ icon is null when the announcement omits a usable icon
✔ skips a matching provider that announced no usable name
✔ ignores malformed detail entries without throwing
ℹ pass 7  ℹ fail 0
```

`next build` passes.

### note

The pure matching logic is unit-tested; the thin event-listener glue in the hook is best verified live in a browser with a couple of injected wallets (e.g. MetaMask + Rabby) to confirm the announced icon renders. Happy to iterate if you'd like the same treatment extended to the "add to network" button copy in `renderProviderText`.
