### PR TITLE
Map YNX icon for Chain ID 6423

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -176,6 +176,7 @@ export default {
   "5551": "nahmii",
   "5887": "flynet",
   "6001": "bouncebit",
+  "6423": "ynx",
   "6699": "ox",
   "6880": "mtt network",
   "6900": "nibiru",


### PR DESCRIPTION
Adds the missing Chain ID → icon slug mapping for YNX Testnet.

Chain ID 6423 maps to icon slug `ynx`.

The chain entry is already merged in #3051, and the icon asset is submitted in DefiLlama/icons#2457.