### PR TITLE
Add RANNTA X-Chain RPC privacy metadata

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -15617,6 +15617,16 @@ export const extraRpcs = {
       },
     ],
   },
+  13113: {
+    rpcs: [
+      {
+        url: "https://rpc.rannta.com/",
+        tracking: "none",
+        trackingDetails:
+          "RANNTA X-Chain public RPC does not track users or correlate RPC requests with individual users. No advertising or third-party analytics are used on the public RPC endpoint. https://rannta.com/privacy",
+      },
+    ],
+  },
 };
 
 export default extraRpcs;


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://rannta.com

#### Provide a link to your privacy policy:
https://rannta.com/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:
RANNTA X-Chain already has a public RPC endpoint at https://rpc.rannta.com/. This PR adds the RPC privacy metadata in constants/extraRpcs.js as requested.

Your RPC should always be added at the end of the array.