### PR TITLE
Fix validation workflow

### DIFF
--- a/.github/workflows/validate-chain-files.yml
+++ b/.github/workflows/validate-chain-files.yml
@@ -1,18 +1,23 @@
 name: Validate Chain Files
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'constants/additionalChainRegistry/*'
       - 'constants/extraRpcs.js'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 100
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         name: Install pnpm
@@ -27,9 +32,25 @@ jobs:
 
       - name: Set changed files
         id: files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep 'constants/additionalChainRegistry/' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
-          echo "EXTRA_RPC_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep 'constants/extraRpcs.js' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
+          gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[] | "\(.status)\t\(.filename)"' > /tmp/pr-files.txt
+          echo "PR files:"
+          cat /tmp/pr-files.txt
+
+          RELEVANT=$(awk -F'\t' '$2 ~ /^constants\/additionalChainRegistry\// || $2 == "constants/extraRpcs.js"' /tmp/pr-files.txt)
+          if [ -z "$RELEVANT" ]; then
+            echo "::error::Workflow was triggered by chain file changes, but change detection found none. Change detection is broken - failing instead of silently skipping validation."
+            exit 1
+          fi
+
+          # Deleted files can't (and shouldn't) be validated
+          NOT_REMOVED=$(echo "$RELEVANT" | awk -F'\t' '$1 != "removed" {print $2}')
+          echo "FILES_CHANGED=$(echo "$NOT_REMOVED" | grep 'constants/additionalChainRegistry/' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
+          echo "EXTRA_RPC_CHANGED=$(echo "$NOT_REMOVED" | grep 'constants/extraRpcs.js' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
 
       - name: Validate chain and extracRpcs files
         run: |
@@ -37,36 +58,9 @@ jobs:
           echo "Files changed: $FILES_CHANGED"
           echo "Extra RPC files changed: $EXTRA_RPC_CHANGED"
           if [ -z "$FILES_CHANGED" ] && [ -z "$EXTRA_RPC_CHANGED" ]; then
-            echo "No relevant files changed."
+            echo "Only deletions of relevant files detected; nothing to validate."
             exit 0
           fi
           pnpm install --frozen-lockfile
           ONLY_LIST_FILE=true pnpm run build
           node .github/scripts/validate-chain-files.js
-          
-        env:
-          FILES_CHANGED: ${{ env.FILES_CHANGED }}
-          EXTRA_RPC_CHANGED: ${{ env.EXTRA_RPC_CHANGED }}
-
-      - name: Comment on PR if validation fails
-        if: failure()
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            let errorContent = 'See workflow logs for details.';
-            
-            try {
-              if (fs.existsSync('/tmp/validation-errors.txt')) {
-                errorContent = fs.readFileSync('/tmp/validation-errors.txt', 'utf8');
-              }
-            } catch (error) {
-              console.log('Could not read validation errors file:', error.message);
-            }
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Validation failed for chain files. Please check the workflow logs for details.\n\nError message:\n```\n" + errorContent + "\n```"
-            })


### PR DESCRIPTION
Currently, the validation workflow fails to correctly compare changed files because both the checkout and target are set to main. This results in false-positive test passes and allows PRs with invalid syntax to make it into the main branch.

This change fixes the comparison and makes the test fail when there’s an issue, but removes the comment since we’re now executing untrusted PR code. Running both steps in the same workflow could potentially introduce security risks.