### PR TITLE
feat: add Winmar Tech Chain (chainId 2640162) configuration and icon

### DIFF
--- a/constants/additionalChainRegistry/chainid-2640162.js
+++ b/constants/additionalChainRegistry/chainid-2640162.js
@@ -1,0 +1,25 @@
+export const data = {
+  name: "Winmar Tech Chain",
+  chain: "WTC",
+  icon: "wtc",
+  rpc: ["https://winmar.tech/rpc"],
+  faucets: ["https://winmar.tech/faucet"],
+  nativeCurrency: {
+    name: "Winmar Tech Chain",
+    symbol: "WTC",
+    decimals: 18,
+  },
+  infoURL: "https://winmar.tech",
+  shortName: "wtc",
+  chainId: 2640162,
+  networkId: 2640162,
+  explorers: [
+    {
+      name: "Winmar Explorer",
+      url: "https://winmar.tech/explorer",
+      standard: "EIP3091",
+    },
+  ],
+};
+
+export default data;


### PR DESCRIPTION
## Add Winmar Tech Chain (Chain ID: 2640162) Configuration & Icon

**Chain Name:** Winmar Tech Chain
**Chain ID:** 2640162 (0x284922)
**Native Currency:** WTC (18 decimals)
**RPC:** https://winmar.tech/rpc
**Explorer:** https://winmar.tech/explorer
**Info URL:** https://winmar.tech

- Icon IPFS is pinned & active at `ipfs://bafkreicqxwwlqef65b35il2fx2t4pxwz2x6wsp3occu2uv7g4o2eomnqse`
- CORS on RPC endpoint `https://winmar.tech/rpc` is verified and responding with HTTP 200.
