### PR TITLE
Add Kryvora Testnet

### DIFF
--- a/constants/additionalChainRegistry/chainid-73829164.js
+++ b/constants/additionalChainRegistry/chainid-73829164.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   name: "Kryvora Testnet",
   chain: "KRY",
   rpc: [

--- a/constants/additionalChainRegistry/chainid-73829164.js
+++ b/constants/additionalChainRegistry/chainid-73829164.js
@@ -1,0 +1,26 @@
+{
+  name: "Kryvora Testnet",
+  chain: "KRY",
+  rpc: [
+    "https://rpc-testnet.kryvora.network/"
+  ],
+  faucets: [],
+  nativeCurrency: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18
+  },
+  features: [
+    { name: "EIP155" },
+    { name: "EIP1559" }
+  ],
+  infoURL: "https://kryvora.network",
+  shortName: "kryvora",
+  chainId: 73829164,
+  networkId: 73829164,
+  explorers: [{
+    name: "Kryvora Explorer",
+    url: "https://explorer-testnet.kryvora.network",
+    standard: "EIP3091"
+  }]
+}


### PR DESCRIPTION
Add Kryvora Testnet with Chain ID 73829164.

Network Name: Kryvora Testnet
RPC: https://rpc-testnet.kryvora.network/
Native Currency: ETH
Explorer: https://explorer-testnet.kryvora.network