### PR TITLE
Add SELEMAN (73571) to chainIds.js for icon slug

### DIFF
--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -17,6 +17,7 @@ export const data = {
   shortName: "seleman",
   chainId: 73571,
   networkId: 73571,
+  chainSlug: "seleman",
   explorers: [
     {
       name: "seleman",

--- a/constants/additionalChainRegistry/chainid-73571.js
+++ b/constants/additionalChainRegistry/chainid-73571.js
@@ -18,6 +18,7 @@ export const data = {
   chainId: 73571,
   networkId: 73571,
   chainSlug: "seleman",
+  icon: "seleman",
   explorers: [
     {
       name: "seleman",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -254,7 +254,7 @@ export default {
   "70003": "pyra",
   "71394": "godwoken",
   "71402": "godwoken",
- "73571": "seleman",
+  "73571": "seleman",
   "78887": "lung",
   "80094": "berachain",
   "81457": "blast",

--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -254,6 +254,7 @@ export default {
   "70003": "pyra",
   "71394": "godwoken",
   "71402": "godwoken",
+ "73571": "seleman",
   "78887": "lung",
   "80094": "berachain",
   "81457": "blast",


### PR DESCRIPTION
## Summary
Adds `73571`: `seleman` to `constants/chainIds.js` and `chainSlug: seleman` on `chainid-73571.js` so Chainlist resolves the Llama CDN logo (same pattern as Sentrix #2714).

## Policy (Define101) — now satisfied
This PR was blocked by: *only chains live on defillama are able to get a logo*.

Live evidence (2026-09-05):
- DefiLlama-Adapters https://github.com/DefiLlama/DefiLlama-Adapters/pull/20779 **MERGED** (2026-09-04)
- `https://api.llama.fi/v2/chains` lists name SELEMAN, chainId 73571
- Adapters `projects/helper/chains.json` contains `seleman`
- Protocol page: https://api.llama.fi/protocol/seleman-dex (chain: SELEMAN)

## Companion
- Icon asset: https://github.com/DefiLlama/icons/pull/2459
- CDN after merge: `https://icons.llamao.fi/icons/chains/rsz_seleman.jpg` (currently 404)

## Context
- https://chainlist.org/chain/73571
- RPC https://seleman.monarcaproject.com/rpc (eth_chainId 0x11f63)
- CI validate: SUCCESS

## Test plan
- [x] chainIds.js maps 73571 to seleman
- [x] chainid-73571.js includes chainSlug seleman
- [ ] After icons #2459 merge, card shows logo instead of unknown-logo