### PR TITLE
Add Zenith EVM Testnet (chain ID 936485)

### DIFF
--- a/constants/additionalChainRegistry/chainid-936485.js
+++ b/constants/additionalChainRegistry/chainid-936485.js
@@ -1,0 +1,23 @@
+export const data = {
+  name: "Zenith EVM Testnet",
+  chain: "ZENITH",
+  rpc: ["https://rpc.testnet.zenith.network/"],
+  faucets: ["https://explorer.testnet.zenith.network/faucet"],
+  nativeCurrency: {
+    name: "Zenith token",
+    symbol: "ZTH",
+    decimals: 18,
+  },
+  features: [{ name: "EIP155" }, { name: "EIP1559" }],
+  infoURL: "https://docs.zenith.network/zenith-testnet",
+  shortName: "zenith-evm-testnet",
+  chainId: 936485,
+  networkId: 936485,
+  explorers: [
+    {
+      name: "Zenith EVM Explorer",
+      url: "https://explorer.testnet.zenith.network",
+      standard: "EIP3091",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Add Zenith EVM Testnet to Chainlist's additional chain registry.

| Field | Value |
| --- | --- |
| Name | `Zenith EVM Testnet` |
| Chain ID / network ID | `936485` (`0xe4a25`) |
| Legacy chain code | `ZENITH` |
| Short name | `zenith-evm-testnet` |
| Native currency | `Zenith token` (`ZTH`, 18 decimals) |
| RPC | `https://rpc.testnet.zenith.network/` |
| Explorer | `https://explorer.testnet.zenith.network` |
| Faucet | `https://explorer.testnet.zenith.network/faucet` |
| Documentation | `https://docs.zenith.network/zenith-testnet` |

The RPC is live and returns chain ID and network ID `936485`. The explorer's block, transaction, address, and token routes were verified against EIP-3091. Chainlist's chain-file validator passes for this entry.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://zenith.network/

#### Provide a link to your privacy policy:

https://zenith.network/privacy-policy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Not applicable. The RPC is operated by Zenith, and the provider website and privacy policy are linked above.
