### PR TITLE
Map MFENX chain ID 177155 to its icon

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -267,6 +267,7 @@ export default {
   "153153": "odyssey",
   "167000": "taiko",
   "171717": "wchain",
+  "177155": "mfenx",
   "190415": "hpp",
   "200901": "bitlayer",
   "222222": "hydradx",


### PR DESCRIPTION
Maps the existing MFENX chain (`177155`) to the `mfenx` icon slug consumed by ChainList.

The matching first-party image is submitted to `DefiLlama/icons` in PR #2464. The duplicate-key and JavaScript syntax checks pass.