### PR TITLE
Update MetaFlux Devnet RPC URL (chain ID 114514)

### DIFF
--- a/constants/additionalChainRegistry/chainid-114514.js
+++ b/constants/additionalChainRegistry/chainid-114514.js
@@ -2,7 +2,7 @@ export const data = {
   "name": "MetaFlux Devnet",
   "chain": "MetaFluxEVM",
   "rpc": [
-    "https://devnet-gateway.mtf.exchange/evm"
+    "https://api.devnet.mtf.exchange/evm"
   ],
   "faucets": [
     "https://devnet.mtf.exchange/faucet"


### PR DESCRIPTION
Our team consolidated the official RPC endpoint for MetaFlux Devnet onto a single hostname, so this updates the URL in `constants/additionalChainRegistry/chainid-114514.js`.

`https://devnet-gateway.mtf.exchange/evm` → `https://api.devnet.mtf.exchange/evm`

This is not a new RPC provider — it is the same team-operated endpoint at a new hostname. Verified before opening:

```
curl -X POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  https://api.devnet.mtf.exchange/evm

{"id":1,"jsonrpc":"2.0","result":"0x1bf52"}   # 114514
```

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://mtf.exchange — the endpoint is operated by the MetaFlux team, who also maintain this chain entry.