### PR TITLE
Add DNetwork chain (Chain ID 1991)

### DIFF
--- a/constants/additionalChainRegistry/chainid-1991.js
+++ b/constants/additionalChainRegistry/chainid-1991.js
@@ -1,0 +1,24 @@
+export const data = {
+  "name": "DNetwork",
+  "chain": "DNetwork",
+  "rpc": [
+    "https://rpc.dnetwork.ai"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "D Network Asset",
+    "symbol": "DNA",
+    "decimals": 18
+  },
+  "infoURL": "https://dnetwork.ai",
+  "shortName": "dna",
+  "chainId": 1991,
+  "networkId": 1991,
+  "explorers": [
+    {
+      "name": "DNetwork Scan",
+      "url": "https://scan.dnetwork.ai",
+      "standard": "EIP3091"
+    }
+  ]
+};


### PR DESCRIPTION
## Summary

Adds DNetwork to Chainlist.

- Chain ID: 1991
- Network ID: 1991
- Native currency: DNA (D Network Asset)
- RPC: https://rpc.dnetwork.ai
- Website: https://dnetwork.ai
- Explorer: https://scan.dnetwork.ai

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://dnetwork.ai

#### Provide a link to your privacy policy:
N/A

#### If the RPC has none of the above and you still think it should be added, please explain why:
This is the official public RPC endpoint for DNetwork.
