### PR TITLE
Add KriptoAman Mainnet chain 22028

### DIFF
--- a/constants/additionalChainRegistry/chainid-22028.js
+++ b/constants/additionalChainRegistry/chainid-22028.js
@@ -1,0 +1,26 @@
+{
+  "name": "KriptoAman Mainnet",
+  "chain": "KAM",
+  "rpc": [
+    "https://rpc.kriptoaman.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "KriptoAman",
+    "symbol": "KAM",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://kriptoaman.com",
+  "shortName": "kriptoaman",
+  "chainId": 22028,
+  "networkId": 22028,
+  "icon": "kriptoaman",
+  "explorers": [
+    {
+      "name": "KriptoAman Explorer",
+      "url": "https://explorer.kriptoaman.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add KriptoAman Mainnet (Chain ID 22028)

This pull request adds KriptoAman Mainnet to the Chainlist registry.

### Network details
- Network name: KriptoAman Mainnet
- Native currency: KAM
- Chain ID: 22028
- RPC: https://rpc.kriptoaman.com
- Block explorer: https://explorer.kriptoaman.com
- Official website: https://kriptoaman.com
- Network documentation: https://kriptoaman.com/KAMNetworkDocs

### RPC provider information

#### Link the service provider's website:
https://kriptoaman.com

The RPC is operated for KriptoAman Mainnet by the KriptoAman project / PT Kripto Aman Indonesia infrastructure team.

#### Provide a link to your privacy policy:
https://kriptoaman.com/PrivacyPolicy

#### If the RPC has none of the above and you still think it should be added, please explain why:
Not applicable. The RPC has an identifiable official provider website and a public privacy policy.

### Additional verification
- Ethereum Lists metadata:
  https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-22028.json
- Official repository:
  https://github.com/rahmanraden027-hue/kriptoaman

The public RPC is intentionally included at the end of the RPC array as required by the contribution template.