### PR TITLE
Fix chainlist 314169

### DIFF
--- a/constants/additionalChainRegistry/chainid-314169.js
+++ b/constants/additionalChainRegistry/chainid-314169.js
@@ -4,7 +4,9 @@
   "rpc": [
     "https://rpc.vcrchain.com"
   ],
-  "faucets": [],
+  "faucets": [
+    "https://vcrchain.com/faucet"
+  ],
   "nativeCurrency": {
     "name": "CCR",
     "symbol": "CCR",

--- a/constants/additionalChainRegistry/chainid-314169.js
+++ b/constants/additionalChainRegistry/chainid-314169.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "VCR Chain",
   "chain": "VCR",
   "rpc": [

--- a/constants/additionalChainRegistry/chainid-314169.js
+++ b/constants/additionalChainRegistry/chainid-314169.js
@@ -1,0 +1,28 @@
+{
+  "name": "VCR Chain",
+  "chain": "VCR",
+  "rpc": [
+    "https://rpc.vcrchain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CCR",
+    "symbol": "CCR",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://www.vcrchain.com",
+  "shortName": "vcr",
+  "chainId": 314169,
+  "networkId": 314169,
+  "explorers": [
+    {
+      "name": "VCR Chain Explorer",
+      "url": "https://scan.vcrchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.vcrchain.com


#### Provide a link to your privacy policy:


#### If the RPC has none of the above and you still think it should be added, please explain why:

This PR registers a brand-new chain (VCR Chain, chainId 314169), not a
third-party RPC added to an existing chain. The endpoint
https://rpc.vcrchain.com is the chain's own canonical public node, operated
by the same team that runs the network — there is no external RPC provider
or commercial data processor involved, so a separate provider privacy policy
does not apply.

The node is a stock Hyperledger Besu client (besu/v26.7.0) serving standard
JSON-RPC. It is the only RPC in the array, so ordering does not apply.

Your RPC should always be added at the end of the array.