### PR TITLE
Add PulseHeartBeat RPC for PulseChain (369)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -5111,6 +5111,11 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.mijkpro,
       },
+      {
+        url: "https://rpc.pulseheartbeat.com",
+        tracking: "none",
+        trackingDetails: "PulseHeartBeat RPC does not track, log, or store user data.",
+      },
     ],
   },
   385: {


### PR DESCRIPTION
## Add PulseHeartBeat public RPC for PulseChain (chainId 369)

**RPC:** https://rpc.pulseheartbeat.com
**Privacy:** No tracking, logging, or data retention. Cloudflare edge provides DDoS protection and rate limiting with no origin-side data storage. **Notes:** Self-hosted public RPC for PulseChain. API restricted to eth, net, web3 namespaces. Rate limited to 10 requests per 10 seconds per IP.