### PR TITLE
Fix RouteMesh chain ID for Robinhood Chain (4663) + add RouteMesh RPC for Viction (88)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -15527,7 +15527,7 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.pokt,
       },
       {
-        url: "https://lb.routeme.sh/rpc/evm/88",
+        url: "https://lb.routeme.sh/rpc/evm/4663",
         tracking: "limited",
         trackingDetails: privacyStatement.routemesh,
       },

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4321,6 +4321,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
       },
+      {
+        url: "https://lb.routeme.sh/rpc/evm/88",
+        tracking: "limited",
+        trackingDetails: privacyStatement.routemesh,
+      },
     ],
   },
   246: {


### PR DESCRIPTION
## Fix RouteMesh chain ID for Robinhood Chain (4663) + add RouteMesh RPC for Viction (88)

Two related changes to RouteMesh (`https://lb.routeme.sh/rpc/evm/<chain_id>`) endpoints:

### 1. Fix wrong chain ID for Robinhood Chain (4663)

The RouteMesh endpoint listed under Robinhood Chain (chainId **4663**) pointed to the wrong route:

```diff
-  url: "https://lb.routeme.sh/rpc/evm/88"
+  url: "https://lb.routeme.sh/rpc/evm/4663"
```

RouteMesh registers its endpoints by chain ID, so this URL routed Robinhood Chain traffic to chain 88 (Viction) instead of Robinhood Chain.

### 2. Add RouteMesh RPC for Viction (88)

RouteMesh also serves chain 88 (Viction), but the Viction block in `constants/extraRpcs.js` had no RouteMesh endpoint — the only `/rpc/evm/88` URL in the file was the misplaced Robinhood one. This adds the correct entry to the Viction block (at the end of the array, per convention):

```diff
+      {
+        url: "https://lb.routeme.sh/rpc/evm/88",
+        tracking: "limited",
+        trackingDetails: privacyStatement.routemesh,
+      },
```

Both chain IDs were verified against the RouteMesh chain registry (`88` = "Viction", `4663` = "Robinhood Chain"). I also audited all RouteMesh endpoints in this file by comparing each URL's chain ID against its enclosing chain block — these were the only discrepancies.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://routeme.sh

#### Provide a link to your privacy policy:

https://routeme.sh/privacy (already referenced via `privacyStatement.routemesh` in this file — tracking metadata is unchanged and consistent with the existing RouteMesh entries)
