### PR TITLE
Add zano-execution-layer netwok

### DIFF
--- a/constants/additionalChainRegistry/chainid-9350.js
+++ b/constants/additionalChainRegistry/chainid-9350.js
@@ -1,0 +1,22 @@
+export const data = {
+  "name": "Zano Execution Layer Testnet",
+  "chain": "ZEL",
+  "rpc": [
+    "https://eth-rpc.node1.testnet.zano.org"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Zel",
+    "symbol": "ZEL",
+    "decimals": 18
+  },
+  "infoURL": "https://zano.com",
+  "shortName": "zel",
+  "chainId": 9350,
+  "networkId": 9350,
+  "explorers": [{
+    "name": "zel",
+    "url": "https://explorer.testnet.zano.org/",
+  }]
+}


### PR DESCRIPTION
Add Zano Execution Layer Testnet network (chainId 9350) to Chainlist

website: https://zano.org/
rpc: https://eth-rpc.node1.testnet.zano.org/
explorer: https://explorer.testnet.zano.org/
native currency: ZEL (18 decimals)