### PR TITLE
Add Efikcoin Mainnet Chain ID 20488

### DIFF
--- a/_data/chains/chainid-20488.js
+++ b/_data/chains/chainid-20488.js
@@ -1,0 +1,5 @@
+{
+  "name": "Efikcoin Mainnet",
+  "chainId": 20488,
+  ...
+}

--- a/constants/additionalChainRegistry/chainid-20488.js
+++ b/constants/additionalChainRegistry/chainid-20488.js
@@ -1,0 +1,23 @@
+// Chain ID 20488 - Efikcoin Mainnet
+export default {
+  chainId: 20488,
+  chain: "EFC",
+  name: "Efikcoin Mainnet",
+  shortName: "efikcoin",
+  networkId: 20488,
+  nativeCurrency: {
+    name: "Efikcoin",
+    symbol: "EFC",
+    decimals: 18
+  },
+  rpc: ["https://rpc.efikcoin.com/rpc"],
+  faucets: [],
+  explorers: [{
+    name: "Efikcoin Explorer",
+    url: "https://explorer.efikcoin.com",
+    standard: "EIP3091"
+  }],
+  infoURL: "https://efikcoin.com",
+  sourceToken: "0x677Ce9CBa67f7484ea951a12897CE780cFd8fED1",
+  founder: "0xC5AD5cfcF81AD63a94227334b898eafCe6B27cCA"
+}


### PR DESCRIPTION
### Link the service provider's website (the company/protocol/individual providing the RPC):
https://efikcoin.com
RPC is operated by Efikcoin Foundation core team — Founder Ece Coin
RPC URL: https://rpc.efikcoin.com/rpc — Mainnet Chain ID 20488, Symbol EFC

### Provide a link to your privacy policy:
https://efikcoin.com/privacy
Efikcoin RPC does not track IPs, no personal data collected. Public blockchain RPC.

### If the RPC has none of the above and you still think it should be added, please explain why:
Efikcoin Mainnet Chain ID 20488 is live with block explorer https://explorer.efikcoin.com and active validators. 
Faucet not needed (mainnet). Explorer is EIP3091 standard.
We are listed on chainlist already for wallets — this PR adds us to DeFiLlama chainlist for DeFi integration.
RPC is stable and used by Efikcoinwallet.

RPC added at end of array as required.