### PR TITLE
fix: validate-chain-files CI never actually validated the PR's changes

### DIFF
--- a/.github/workflows/validate-chain-files-comment.yml
+++ b/.github/workflows/validate-chain-files-comment.yml
@@ -1,0 +1,86 @@
+name: Comment on Chain File Validation Failure
+
+# Runs after "Validate Chain Files" completes, with elevated (write) permissions
+# to comment on the PR. It never checks out or executes any code from the PR.
+# It downloads the plain-text artifact the validation job produced, but only
+# for the ERROR MESSAGE - which PR to comment on is resolved independently via
+# the GitHub API from workflow_run.head_sha (a field GitHub itself sets on the
+# trusted workflow_run event, populated before the validation job - which runs
+# attacker-controlled build/validation code - ever executes). The artifact is
+# never treated as authoritative for *which* PR to comment on: a PR's own build
+# step could otherwise pre-plant a read-only pr_number file that this job's
+# "if: failure()" upload step would publish even if a later overwrite failed,
+# letting one PR spoof a validation-failure comment onto an unrelated issue.
+# This split exists so untrusted PR code only ever runs under the limited,
+# read-only token that `pull_request` (not `pull_request_target`) grants; this
+# workflow is the only place with write access, and it has nothing to exploit.
+
+on:
+  workflow_run:
+    workflows: ['Validate Chain Files']
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number from head SHA
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+            const open = data.find((pr) => pr.state === 'open');
+            if (!open) {
+              throw new Error(`No open PR found for head SHA ${context.payload.workflow_run.head_sha}`);
+            }
+            core.setOutput('number', String(open.number));
+
+      - name: Download validation errors
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-comment-info
+          path: /tmp/pr-comment-info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+
+            const MAX_LEN = 2000;
+            let errorContent = 'See workflow logs for details.';
+            try {
+              if (fs.existsSync('/tmp/pr-comment-info/validation-errors.txt')) {
+                errorContent = fs.readFileSync('/tmp/pr-comment-info/validation-errors.txt', 'utf8');
+              }
+            } catch (error) {
+              console.log('Could not read validation errors file:', error.message);
+            }
+            // Neutralize embedded fences so attacker-influenced error text can't
+            // break out of the surrounding code block, and cap the length.
+            errorContent = errorContent.replace(/```/g, "'''");
+            if (errorContent.length > MAX_LEN) {
+              errorContent = errorContent.slice(0, MAX_LEN) + '\n... (truncated)';
+            }
+
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Validation failed for chain files. Please check the workflow logs for details.\n\nError message:\n```\n" + errorContent + "\n```"
+            })

--- a/.github/workflows/validate-chain-files.yml
+++ b/.github/workflows/validate-chain-files.yml
@@ -1,10 +1,17 @@
 name: Validate Chain Files
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'constants/additionalChainRegistry/*'
       - 'constants/extraRpcs.js'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-chain-files-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -28,8 +35,8 @@ jobs:
       - name: Set changed files
         id: files
         run: |
-          echo "FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep 'constants/additionalChainRegistry/' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
-          echo "EXTRA_RPC_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep 'constants/extraRpcs.js' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
+          echo "FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep 'constants/additionalChainRegistry/' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
+          echo "EXTRA_RPC_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep 'constants/extraRpcs.js' | tr '\n' ' ' | sed 's/ $//' || true)" >> $GITHUB_ENV
 
       - name: Validate chain and extracRpcs files
         run: |
@@ -43,30 +50,26 @@ jobs:
           pnpm install --frozen-lockfile
           ONLY_LIST_FILE=true pnpm run build
           node .github/scripts/validate-chain-files.js
-          
         env:
           FILES_CHANGED: ${{ env.FILES_CHANGED }}
           EXTRA_RPC_CHANGED: ${{ env.EXTRA_RPC_CHANGED }}
 
-      - name: Comment on PR if validation fails
+      # Only the error text is handed off here - never the PR number. The PR/head
+      # SHA that gets commented on is resolved independently by the comment
+      # workflow from the trusted workflow_run event, via the GitHub API, precisely
+      # so this step's output (written after PR-controlled code has already run in
+      # "Validate chain and extracRpcs files") can never be trusted to say WHICH PR
+      # to comment on - only what to say.
+      - name: Save validation errors for comment workflow
         if: failure()
-        uses: actions/github-script@v8
+        run: |
+          mkdir -p /tmp/pr-comment-info
+          cp /tmp/validation-errors.txt /tmp/pr-comment-info/validation-errors.txt 2>/dev/null || echo 'See workflow logs for details.' > /tmp/pr-comment-info/validation-errors.txt
+
+      - name: Upload validation errors
+        if: failure()
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            let errorContent = 'See workflow logs for details.';
-            
-            try {
-              if (fs.existsSync('/tmp/validation-errors.txt')) {
-                errorContent = fs.readFileSync('/tmp/validation-errors.txt', 'utf8');
-              }
-            } catch (error) {
-              console.log('Could not read validation errors file:', error.message);
-            }
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Validation failed for chain files. Please check the workflow logs for details.\n\nError message:\n```\n" + errorContent + "\n```"
-            })
+          name: pr-comment-info
+          path: /tmp/pr-comment-info/
+          retention-days: 1


### PR DESCRIPTION
Related to (but different from, see below) #2738 - it self-closed as an incomplete draft, this finishes the job.

## tl;dr

`validate-chain-files.yml` has never actually validated a PR's real file changes. It's been silently diffing against unrelated commits pulled from whatever landed on `main` between PR-open and workflow-run time, because `pull_request_target`'s `github.sha` resolves to the base branch tip, not the PR head.

## The bug

`pull_request_target` + `git diff base.sha github.sha`. For `pull_request_target`, `github.sha` is the last commit on the **base** branch, not the PR's head or a merge commit - and `actions/checkout` with no explicit `ref` also defaults to checking out the base branch for this event. So the job never checked out the PR's content, and the diff was comparing two points on `main` itself.

Real evidence, not theory - a run where the PR touched exactly one file (`chainid-114514.js`) produced `FILES_CHANGED` with 13 unrelated files pulled from `main`'s own recent history:
https://github.com/DefiLlama/chainlist/actions/runs/33494463530

I locally simulated the fixed diff computation against two real merged PRs and confirmed it now produces exactly the right file list in both cases:
- #3090 → `chainid-271831.js`, `chainid-271832.js` (matches `gh pr view 3090 --json files` exactly)
- #3083 → `chainid-4959.js` (matches `gh pr view 3083 --json files` exactly)

## The fix

- Trigger on `pull_request` instead of `pull_request_target` - checkout now defaults to the real PR merge ref, and `head.sha` is meaningful.
- Diff `base.sha...head.sha` (three-dot) instead of two endpoints, so a PR branch that's behind `main` doesn't pick up base-only changes.
- Add `permissions: contents: read`.

`pull_request_target` was almost certainly there so the job could comment on PRs from forks with a write-scoped token - plain `pull_request` can't do that (this is exactly the gap #2738 hit and self-closed on: it switched triggers but just deleted the comment step with nothing replacing it). So the comment-on-failure step moves to a second workflow (`validate-chain-files-comment.yml`), triggered by `workflow_run`, that never checks out or runs any PR code and holds the only write permission - the standard GitHub-recommended split for "build untrusted PR code safely, still comment with a privileged token."

The two jobs only hand off the error text via an artifact. **Which PR to comment on is resolved independently** from `workflow_run.head_sha` via `repos.listPullRequestsAssociatedWithCommit`, not trusted from the artifact - the validation job runs PR-controlled build/validation code *before* the artifact-save step, so a PR could otherwise plant its own read-only `pr_number` file that the `if: failure()` upload step would publish unmodified if the overwrite failed, letting one PR spoof a validation-failure comment onto an unrelated issue. Also truncated + fence-escaped the error text in the comment body (same unbounded/injectable pattern existed in the original), and added a `concurrency` group on the validate workflow so a stale failing run from an old push can't out-race a newer passing one and leave a misleading comment behind.

Known, accepted tradeoff: `pull_request` (vs `pull_request_target`) means first-time contributors' workflow runs may need a maintainer's manual approval, and the job won't run for PRs GitHub can't auto-merge-ref (conflicting PRs). That's the intended safety tradeoff this fix buys - not a regression to route around.

## Testing

- `actionlint` clean on both files (one pre-existing shellcheck SC2086 info nit on the untouched `Set changed files` line, confirmed present on `main` before this PR too).
- Verified `repos.listPullRequestsAssociatedWithCommit` resolves the correct PR for a real head SHA via `gh api repos/DefiLlama/chainlist/commits/<sha>/pulls`.
- No runtime/UI surface here (pure CI workflow config) - verification is the diff-simulation against real PR data above plus static lint, not a sim/screenshot.
