### PR TITLE
Add privacy metadata for official Telos RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3671,7 +3671,12 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.routemesh,
       },
-      "https://rpc.telos.net",
+      {
+        url: "https://rpc.telos.net",
+        tracking: "limited",
+        trackingDetails:
+          "Requests pass through Cloudflare, which processes end-user IP addresses and traffic metadata for security, routing, and analytics. The RPC origins also retain limited HTTP request metadata.",
+      },
       {
         url: "https://public.1rpc.io/telos/evm",
         tracking: "none",


### PR DESCRIPTION
## Summary

- classify the existing official `https://rpc.telos.net` endpoint as `tracking: "limited"`
- add a concise privacy tooltip describing the limited request metadata processed at Cloudflare and the RPC origins
- leave the endpoint URL and all chain behavior unchanged

## Why `limited`

An operator audit on 2026-09-01 found that the endpoint is proxied through Cloudflare and that the current RPC origins retain limited Nginx HTTP access metadata.

- [Cloudflare's Privacy Policy](https://www.cloudflare.com/policies/privacy/) says its processing for end users may include IP addresses, traffic-routing data, system configuration, and other traffic information. Data exposed to the customer through its dashboard is defined as Customer Logs.
- [Cloudflare Security Analytics](https://developers.cloudflare.com/waf/analytics/security-analytics/) covers incoming HTTP requests, exposes detailed sampled request logs and source-IP filtering, and retains Security Analytics data for up to seven days on the current Pro plan.
- The origin audit found Nginx access logging enabled with the default `combined` format and daily rotation with 14 rotations retained. [Nginx documents](https://nginx.org/en/docs/http/ngx_http_log_module.html) that this format includes the remote address, request line, status, response size, referrer, and user agent.
- No `$request_body` or `$request_body_file` logging directive was found in the current Nginx configuration. This PR therefore does not claim that JSON-RPC request bodies or wallet addresses are logged.

These findings do not support `tracking: "none"`; `limited` is the conservative classification supported by the current configuration.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://telos.net

#### Provide a link to your privacy policy:

Cloudflare processor policy: https://www.cloudflare.com/policies/privacy/

No RPC-specific Telos privacy policy is currently published.

#### If the RPC has none of the above and you still think it should be added, please explain why:

Not applicable. This PR adds privacy metadata to an existing official RPC; it does not add a new endpoint.

## Verification

- `pnpm test`
- `ONLY_LIST_FILE=true pnpm run build`
- `FILES_CHANGED='' EXTRA_RPC_CHANGED=constants/extraRpcs.js node .github/scripts/validate-chain-files.js`
- `git diff --check`
