### PR TITLE
remove 21 duplicate rpc urls and add a test that catches them

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -3216,11 +3216,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.omnia,
       },
       {
-        url: "https://endpoints.omniatech.io/v1/merlin/mainnet/public",
-        tracking: "none",
-        trackingDetails: privacyStatement.omnia,
-      },
-      {
         url: "https://merlin.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
@@ -3799,16 +3794,6 @@ export const extraRpcs = {
         url: "https://moonbeam.public.curie.radiumblock.co/ws",
         tracking: "none",
         trackingDetails: privacyStatement.radiumblock,
-      },
-      {
-        url: "https://moonbeam.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
-      },
-      {
-        url: "wss://moonbeam.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
       },
       {
         url: "https://rpc.poolz.finance/moonbeam",
@@ -4586,7 +4571,6 @@ export const extraRpcs = {
       "https://rpc.xdc.org",
       "https://rpc.xdc.network",
       "https://earpc.xinfin.network/",
-      "https://erpc.xinfin.network/",
       "wss://ews.xinfin.network/ws",
       {
         url: "https://rpc.ankr.com/xdc",
@@ -4611,7 +4595,6 @@ export const extraRpcs = {
       "https://apothem.xdcrpc.com",
       "https://rpc.ankr.com/xdc_testnet",
       "https://earpc.apothem.network/",
-      "https://erpc.apothem.network/",
       "wss://eaws.apothem.network/",
       {
         url: "https://xdc-testnet.drpc.org",
@@ -5665,7 +5648,6 @@ export const extraRpcs = {
       "https://rpc.dogechain.dog",
       "https://rpc-us.dogechain.dog",
       "https://rpc-sg.dogechain.dog",
-      "https://rpc.dogechain.dog",
       "https://rpc01-sg.dogechain.dog",
       "https://rpc02-sg.dogechain.dog",
       "https://rpc03-sg.dogechain.dog",
@@ -6224,7 +6206,6 @@ export const extraRpcs = {
       "https://rpc-evm.testnet.evmos.dragonstake.io",
       "https://evmos-testnet-rpc.stake-town.com",
       "https://evmos-testnet-jsonrpc.stake-town.com",
-      "https://api.evmos-test.theamsolutions.info",
       "https://jsonrpc-t.evmos.nodestake.top",
       "https://evmos-testnet-jsonrpc.autostake.com",
       "https://evmos-testnet-jsonrpc.alkadeta.com",
@@ -6735,11 +6716,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.dwellir,
       },
       {
-        url: "https://base.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
-      },
-      {
         url: "wss://base.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
@@ -7007,11 +6983,6 @@ export const extraRpcs = {
         url: "https://scroll.therpc.io",
         tracking: "limited",
         trackingDetails: privacyStatement.therpc,
-      },
-      {
-        url: "https://scroll.api.pocket.network",
-        tracking: "none",
-        trackingDetails: privacyStatement.pokt,
       },
       {
         url: "https://api-scroll-mainnet.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c",
@@ -7359,7 +7330,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.routemesh,
       },
       "https://palm-testnet.infura.io/v3/${INFURA_API_KEY}",
-      "https://palm-testnet.public.blastapi.io",
       {
         url: "https://palm-testnet.public.blastapi.io",
         tracking: "limited",
@@ -7652,7 +7622,6 @@ export const extraRpcs = {
   },
   50001: {
     rpcs: [
-      "https://rpc.oracle.liveplex.io",
       {
         url: "https://rpc.oracle.liveplex.io",
         tracking: "yes",
@@ -7913,11 +7882,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.omnia,
       },
       {
-        url: "https://rpc.ankr.com/scroll_sepolia_testnet",
-        tracking: "none",
-        trackingDetails: privacyStatement.ankr,
-      },
-      {
         url: "https://scroll-sepolia.therpc.io",
         tracking: "limited",
         trackingDetails: privacyStatement.therpc,
@@ -7989,7 +7953,6 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.routemesh,
       },
-      "https://rpc.jfinchain.com",
       {
         url: "https://rpc.jfinchain.com",
         tracking: "limited",
@@ -8965,7 +8928,6 @@ export const extraRpcs = {
         tracking: "limited",
         trackingDetails: privacyStatement.routemesh,
       },
-      "https://rpc-v2.powerloom.network",
       {
         url: "https://rpc-v2.powerloom.network",
         tracking: "yes",
@@ -9142,8 +9104,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.routemesh,
       },
       "https://rpc.immutable.com",
-      "https://immutable-zkevm.drpc.org",
-      "wss://immutable-zkevm.drpc.org",
       {
         url: "https://immutable-zkevm.drpc.org",
         tracking: "none",
@@ -9351,7 +9311,6 @@ export const extraRpcs = {
   },
   20230825: {
     rpcs: [
-      "https://testnet.vcity.app",
       {
         url: "https://testnet.vcity.app",
         tracking: "none",
@@ -9487,7 +9446,6 @@ export const extraRpcs = {
   16600: {
     rpcs: [
       "https://evmrpc-testnet.0g.ai",
-      "https://0g-json-rpc-public.originstake.com",
       "https://og-testnet-jsonrpc.blockhub.id",
       {
         url: "https://0g-json-rpc-public.originstake.com",
@@ -10435,11 +10393,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.ankr,
       },
       {
-        url: "https://rpc.ankr.com/monad_testnet",
-        tracking: "none",
-        trackingDetails: privacyStatement.ankr,
-      },
-      {
         url: "https://monad-testnet.gateway.tatum.io/",
         tracking: "yes",
         trackingDetails: privacyStatement.tatum,
@@ -10450,11 +10403,6 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.onfinality,
       },
       "https://rpc-testnet.monadinfra.com",
-      {
-        url: "https://monad-testnet.api.onfinality.io/public",
-        tracking: "limited",
-        trackingDetails: privacyStatement.onfinality,
-      },
       {
         url: "https://monad-testnet-rpc.huginn.tech",
         tracking: "none",
@@ -10787,11 +10735,6 @@ export const extraRpcs = {
         url: "https://lens-mainnet.g.alchemy.com/public",
         tracking: "yes",
         trackingDetails: privacyStatement.alchemy,
-      },
-      {
-        url: "https://lens.drpc.org",
-        tracking: "none",
-        trackingDetails: privacyStatement.drpc,
       },
       {
         url: "https://lens.drpc.org",

--- a/tests/check-duplicate-keys.js
+++ b/tests/check-duplicate-keys.js
@@ -146,6 +146,64 @@ function checkChainIdsDuplicates() {
   console.log(`✓ No duplicate keys found in chainIds (checked ${chainIds.size} keys)`);
 }
 
+/**
+ * Check for the same rpc url listed more than once inside one chain's rpcs array.
+ * Arrays keep every entry, so these are invisible to the duplicate-key checks above.
+ */
+function checkDuplicateRpcUrls() {
+  console.log("Checking extraRpcs for duplicate rpc urls within a chain...");
+
+  const filePath = path.join(__dirname, "../constants/extraRpcs.js");
+  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+
+  const normalize = (url) => url.trim().replace(/\/+$/, "").toLowerCase();
+  const duplicates = [];
+  let chainId = null;
+  let inRpcs = false;
+  let seen = new Set();
+  let checked = 0;
+
+  for (const line of lines) {
+    const chainMatch = line.match(/^\s{2}(\d+):\s*\{/);
+    if (chainMatch) {
+      chainId = chainMatch[1];
+      inRpcs = false;
+      seen = new Set();
+      continue;
+    }
+    if (/^\s{4}rpcs:\s*\[/.test(line)) {
+      inRpcs = true;
+      continue;
+    }
+    if (inRpcs && /^\s{4}\],/.test(line)) {
+      inRpcs = false;
+      continue;
+    }
+    if (!inRpcs || chainId === null) continue;
+
+    const urlMatch =
+      line.match(/^\s{6}"((?:https?|wss?):\/\/[^"]+)",?\s*$/) ||
+      line.match(/^\s{8}url:\s*"([^"]+)"/);
+    if (!urlMatch) continue;
+
+    const key = normalize(urlMatch[1]);
+    checked++;
+    if (seen.has(key)) {
+      duplicates.push(`${chainId}: ${urlMatch[1]}`);
+    } else {
+      seen.add(key);
+    }
+  }
+
+  if (duplicates.length > 0) {
+    console.error("ERROR: Duplicate rpc urls found in extraRpcs:");
+    duplicates.forEach((d) => console.error(`  - ${d}`));
+    throw new Error(`Duplicate rpc urls found in extraRpcs: ${duplicates.length}`);
+  }
+
+  console.log(`✓ No duplicate rpc urls found in extraRpcs (checked ${checked} urls)`);
+}
+
 // Run all tests and collect errors
 console.log("=".repeat(60));
 console.log("Running syntax and duplicate key checks...");
@@ -181,6 +239,12 @@ try {
 
 try {
   checkChainIdsDuplicates();
+} catch (error) {
+  errors.push(error.message);
+}
+
+try {
+  checkDuplicateRpcUrls();
 } catch (error) {
   errors.push(error.message);
 }


### PR DESCRIPTION
Fixes #3067

`tests/check-duplicate-keys.js` catches duplicate `chainId` keys, but the rpcs are an array and arrays keep every entry, so the same url listed twice inside one chain was invisible to it. there were 21 across 18 chains.

removes all 21 and adds `checkDuplicateRpcUrls()` in the same source-parsing style as the existing checks. it normalises trailing slashes and case, so the `https://erpc.xinfin.network` / `https://erpc.xinfin.network/` pair on chain 50 is caught too.

where the same url appeared once as a bare string and once as an object, the object is kept; it carries `tracking` and `trackingDetails`, so nothing is lost. that covers 8 of them (13371, 16600, 20230825, 3501, 50001, 7869, 11297108099). the rest were identical entries and the first is kept.

one needs your call. chain 534351 had `https://rpc.ankr.com/scroll_sepolia_testnet` twice with the *same* `privacyStatement.ankr` but disagreeing on `tracking`, one `"limited"`, one `"none"`. i kept the first (`"limited"`) because it is the conservative claim, not because i think it is right: ankr is inconsistent across the whole file (50 entries `"none"`, 16 `"limited"`, 3 `"yes"`), so there is no convention to follow. happy to flip it if `"none"` is correct, and the wider ankr inconsistency is probably worth its own pass.

```
$ node tests/check-duplicate-keys.js
✓ No duplicate chainId keys found in extraRpcs (checked 1024 keys)
✓ No duplicate keys found in chainIds (checked 311 keys)
✓ No duplicate rpc urls found in extraRpcs (checked 2774 urls)
✓ All duplicate key checks passed!
```

and with a duplicate put back:

```
ERROR: Duplicate rpc urls found in extraRpcs:
  - 50: https://rpc.xdcrpc.com/
✗ 1 test(s) failed:
  - Duplicate rpc urls found in extraRpcs: 1
```
