### PR TITLE
Add ETCMC public RPC for Ethereum Classic (chain 61)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -39,6 +39,8 @@
     "Except for the data that is publicly accessible on the blockchain, RadiumBlock does not collect or keep any user information (like location, IP address, etc.) transmitted via our RPC. For more information about our customer privacy policy please visit https://radiumblock.com/privacy.html",
   etcnetworkinfo:
     "We do use analytics at 3rd party tracking websites (Google Analytics & Google Search Console) the following interactions with our systems are automatically logged when you access our services, such as your Internet Protocol (IP) address as well as accessed services and pages(Packet details are discarded / not logged!). Data redemption is varying based on traffic, but deleted after 31 days We do use these infos to improve our services.",
+  etcmc:
+    "ETCMC public RPC minimizes data collection. We do not log request payloads or correlate wallet addresses with IP addresses. Limited operational data may be processed for rate limiting, abuse prevention, and service reliability. https://etcmc.xyz/privacy",
   omnia:
     "All the data and metadata remain private to the users. No third party is able to access, analyze or track it. OMNIA leverages different technologies and approaches to guarantee the privacy of their users, from front-running protection and private mempools, to obfuscation and random dispatching. https://blog.omniatech.io/how-omnia-handles-your-personal-data",
   blockpi:
@@ -4676,6 +4678,11 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.routemesh,
       },
       "https://etc.etcdesktop.com",
+      {
+        url: "https://rpc.etcmc.xyz",
+        tracking: "none",
+        trackingDetails: privacyStatement.etcmc,
+      },
       {
         url: "https://etc.rivet.link",
         tracking: "none",


### PR DESCRIPTION
﻿If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):

https://etcmc.xyz

#### Provide a link to your privacy policy:

https://etcmc.xyz/privacy

#### If the RPC has none of the above and you still think it should be added, please explain why:

Adds the ETCMC public RPC (`https://rpc.etcmc.xyz`) for Ethereum Classic mainnet (chain 61). The endpoint is synced, CORS-enabled, and listed with `tracking: "none"` plus a privacy statement.

