### PR TITLE
Fix MBTX Nexus (271832) native currency: ETH -> XTBM

### DIFF
--- a/constants/additionalChainRegistry/chainid-271832.js
+++ b/constants/additionalChainRegistry/chainid-271832.js
@@ -7,8 +7,8 @@ export const data = {
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Ether",
-    "symbol": "ETH",
+    "name": "XTBM",
+    "symbol": "XTBM",
     "decimals": 18
   },
   "features": [


### PR DESCRIPTION
L2 (Polygon CDK rollup) uses XTBM as native gas token — verified on-chain:

WETH contract (0xe493F4...) returns name="Wrapped XTBM", symbol="XTBM"
Gas is paid in XTBM on chainId 271832
L1 (271831) correctly uses MBTX
Chainlist entry was showing ETH due to default template.