### PR TITLE
Add Zagros Mainnet (chainId 21072026)

### DIFF
--- a/constants/additionalChainRegistry/chainid-21072026.js
+++ b/constants/additionalChainRegistry/chainid-21072026.js
@@ -15,6 +15,7 @@ export const data = {
     "shortName": "zagros",
     "chainId": 21072026,
     "networkId": 21072026,
+    "icon": "zagros",
     "explorers": [
       {
         "name": "ZagrosRadar",

--- a/constants/additionalChainRegistry/chainid-21072026.js
+++ b/constants/additionalChainRegistry/chainid-21072026.js
@@ -1,0 +1,25 @@
+export const data = {
+    "name": "Zagros Mainnet",
+    "chain": "ZAGROS",
+    "rpc": [
+      "https://rpc.zagros.network",
+      "https://rpc.zagrosnetwork.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Zagros",
+      "symbol": "ZAGROS",
+      "decimals": 18
+    },
+    "infoURL": "https://zagros.network",
+    "shortName": "zagros",
+    "chainId": 21072026,
+    "networkId": 21072026,
+    "explorers": [
+      {
+        "name": "ZagrosRadar",
+        "url": "https://zagrosradar.com",
+        "standard": "EIP3091"
+      }
+    ]
+  }


### PR DESCRIPTION
Adds Zagros Mainnet to the additional chain registry.

- chainId: 21072026
- Native currency: ZAGROS (18 decimals)
- RPC (2 public endpoints): https://rpc.zagros.network , https://rpc.zagrosnetwork.com
- Explorer: ZagrosRadar (https://zagrosradar.com), EIP-3091
- Info: https://zagros.network

Both RPC endpoints return eth_chainId 0x141889a (21072026). Also submitted to ethereum-lists/chains (#8665).