### PR TITLE
Add Emberchain configuration for chain ID 7773

### DIFF
--- a/constants/additionalChainRegistry/chainid-7773.js
+++ b/constants/additionalChainRegistry/chainid-7773.js
@@ -1,0 +1,29 @@
+{
+  "name": "Emberchain",
+  "chain": "EMBR",
+  "rpc": [
+    "https://emberchain.org/api/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ember",
+    "symbol": "EMBR",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" }
+  ],
+  "infoURL": "https://emberchain.org",
+  "shortName": "embr",
+  "chainId": 7773,
+  "networkId": 7773,
+  "icon": "https://emberchain.org/ember-coin.svg",
+  "explorers": [
+    {
+      "name": "Emberchain Explorer",
+      "url": "https://emberchain.org/ledger",
+      "icon": "https://emberchain.org/ember-coin.svg",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/constants/additionalChainRegistry/chainid-7773.js
+++ b/constants/additionalChainRegistry/chainid-7773.js
@@ -1,4 +1,4 @@
-{
+export const data = {
   "name": "Emberchain",
   "chain": "EMBR",
   "rpc": [


### PR DESCRIPTION
## Emberchain

Adds Emberchain (EMBR) to Chainlist.

- Chain ID: 7773
- Network ID: 7773
- Native currency: EMBR
- RPC: https://emberchain.org/api/rpc
- Explorer: https://emberchain.org/ledger
- Website: https://emberchain.org
- Official chain/native currency icon: https://emberchain.org/ember-coin.svg

Emberchain is an EVM-compatible Proof-of-Work blockchain with built in privacy features.