### PR TITLE
Update extraRpcs.js

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4532,11 +4532,6 @@ export const extraRpcs = {
   },
   29: {
     rpcs: [
-      {
-        url: "https://lb.routeme.sh/rpc/evm/29",
-        tracking: "limited",
-        trackingDetails: privacyStatement.routemesh,
-      },
       "https://rpc.genesisl1.org",
       "https://evm.gl1infra.online",
       "https://api.lcserve.net",


### PR DESCRIPTION
Remove corrupt RPC aggregator

The https://lb.routeme.sh/rpc/evm/29 RPC seems to aggregate all other RPC endpoints put pressure on their latency and is unsupported by GenesisL1 community. 

We expand this PR as an incident, and hope to get this version of genesisL1 chain 29 continued. 

We want to make reviewers aware about the sudden appearance on multiple chains. 

Focussing on this one first. 

In great respect for Chainlist,
Yours, 
JoMfN 