### PR TITLE
Update Nowa Testnet (22052010) Explorer URL

### DIFF
--- a/constants/additionalChainRegistry/chainid-22052010.js
+++ b/constants/additionalChainRegistry/chainid-22052010.js
@@ -23,8 +23,9 @@ export const data = {
   explorers: [
     {
       name: "Nowa Testnet Explorer",
-      url: "https://explorer.nowa.finance",
-      standard: "EIP3091"
+      url: "https://testnet.nowa.finance",
+      standard: "EIP3091",
+      icon: "https://nowa.finance/favicon.svg",
     }
   ]
 };


### PR DESCRIPTION
This PR updates the official explorer URL for Nowa Testnet (Chain ID `22052010`) to `https://testnet.nowa.finance`.

*(Note: I deleted the default RPC template as this PR only updates an existing explorer URL and Icon placement).*
