### PR TITLE
Add Xitcoin Testnet RPC

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -15674,6 +15674,9 @@ export const extraRpcs = {
       },
     ],
   },
+  101089: {
+    rpcs: ["https://evm-rpc-testnet.xitcoin.org"],
+  },
 };
 
 export default extraRpcs;


### PR DESCRIPTION
Adds the operational public RPC for Xitcoin Testnet (chain ID 101089).

RPC: https://evm-rpc-testnet.xitcoin.org
Expected eth_chainId: 0x18ae1
HTTPS and browser CORS are enabled.

This changes only the testnet entry. Xitcoin mainnet chain ID 101088 remains unchanged.