### PR TITLE
Update extraRpcs.js - Add GlobalStake Robinhood RPC (chainId 4663)

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -15551,6 +15551,16 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.blockmachine,
       },
+      {
+        url: "https://rpc-robinhood.globalstake.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.GlobalStake,
+      },
+      {
+        url: "wss://rpc-robinhood.globalstake.io/ws",
+        tracking: "none",
+        trackingDetails: privacyStatement.GlobalStake,
+      },
     ],
   },
   46630: {


### PR DESCRIPTION
Add GlobalStake Robinhood Mainnet RPC (chainId 4663)

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://globalstake.io/

#### Provide a link to your privacy policy:
https://globalstake.io/privacy-policy/

#### If the RPC has none of the above and you still think it should be added, please explain why:

Your RPC should always be added at the end of the array.