### PR TITLE
Add Rabbit Chain Testnet (9280)

### DIFF
--- a/constants/additionalChainRegistry/chainid-9280.js
+++ b/constants/additionalChainRegistry/chainid-9280.js
@@ -1,0 +1,30 @@
+export const data = {
+  "name": "Rabbit Chain Testnet",
+  "chain": "RAB",
+  "rpc": [
+    "https://rpc-testnet.rabbitchain.org"
+  ],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "faucets": [
+    "https://rabbitchain.org/platform/faucet"
+  ],
+  "nativeCurrency": {
+    "name": "Test RAB",
+    "symbol": "tRAB",
+    "decimals": 18
+  },
+  "infoURL": "https://rabbitchain.org",
+  "shortName": "rabt",
+  "chainId": 9280,
+  "networkId": 9280,
+  "explorers": [
+    {
+      "name": "Rabbit Chain Testnet Explorer",
+      "url": "https://explorer-testnet.rabbitchain.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Rabbit Chain Testnet to the additional chain registry.

Network details:
- Name: Rabbit Chain Testnet
- Chain ID: 9280
- Network ID: 9280
- Native currency: tRAB
- Decimals: 18
- RPC: https://rpc-testnet.rabbitchain.org
- Faucet: https://rabbitchain.org/platform/faucet
- Explorer: https://explorer-testnet.rabbitchain.org
- Website: https://rabbitchain.org
- Features: EIP-155, EIP-1559

Validation completed:
- JavaScript syntax check: PASS
- npm test: PASS
- duplicate key checks: PASS