### PR TITLE
Add Molibra chain (20226)

### DIFF
--- a/constants/additionalChainRegistry/chainid-20226.js
+++ b/constants/additionalChainRegistry/chainid-20226.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "Molibra",
+  "chain": "MOLI",
+  "rpc": [
+    "https://molibra.org"
+  ],
+  "features": [{ "name": "EIP155" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Molibra",
+    "symbol": "MOLI",
+    "decimals": 18
+  },
+  "infoURL": "https://molibra.org",
+  "shortName": "moli",
+  "chainId": 20226,
+  "networkId": 20226,
+  "explorers": [
+    {
+      "name": "Moliscan",
+      "url": "https://molibra.org/molibra/moliscan",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Molibra to `constants/additionalChainRegistry`, per the README.

RPC `https://molibra.org` answers `eth_chainId` → `0x4f02` at the bare origin, over TLS.
Explorer: Moliscan — https://molibra.org/molibra/moliscan

Source: https://github.com/BaronOdon/molibra