### PR TITLE
Fix chain 8 (c8ntinuum) icon slug and stale RPC

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -1,7 +1,7 @@
 export default {
   "0": "kardia",
   "1": "ethereum",
-  "8": "ubiq",
+  "8": "c8ntinuum",
   "9": "quai",
   "10": "optimism",
   "14": "flare",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -4356,9 +4356,6 @@ export const extraRpcs = {
       },
     ],
   },
-  8: {
-    rpcs: ["https://rpc.octano.dev"],
-  },
   5050: {
     rpcs: ["https://rpc.liquidchain.net/", "https://rpc.xlcscan.com/"],
   },


### PR DESCRIPTION
This PR fixes the c8ntinuum (chain ID 8) listing: two overrides point at the wrong network for that ID.

- `constants/chainIds.js`: slug `"8": "ubiq"` → `"c8ntinuum"` so the logo matches the chain. Icon added in DefiLlama/icons#2481 so please merge that PR first.
- `constants/extraRpcs.js`: drop `https://rpc.octano.dev` as it isn't a c8ntinuum endpoint.