### PR TITLE
Add Vordium mainnet (chainId 101101)

### DIFF
--- a/constants/additionalChainRegistry/chainid-101101.js
+++ b/constants/additionalChainRegistry/chainid-101101.js
@@ -1,0 +1,24 @@
+export const data ={
+  "name": "Vordium",
+  "chain": "VORD",
+  "rpc": [
+    "https://rpc.vordium.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Vordium",
+    "symbol": "VORD",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vordium.com",
+  "shortName": "vord",
+  "chainId": 101101,
+  "networkId": 101101,
+  "icon": "vordium",
+  "explorers": [{
+    "name": "vordscan",
+    "url": "https://vordscan.io",
+    "standard": "EIP3091"
+  }]
+}

--- a/constants/additionalChainRegistry/chainid-101101.js
+++ b/constants/additionalChainRegistry/chainid-101101.js
@@ -10,7 +10,7 @@ export const data ={
     "symbol": "VORD",
     "decimals": 18
   },
-  "features": [{ "name": "EIP155" }],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://vordium.com",
   "shortName": "vord",
   "chainId": 101101,


### PR DESCRIPTION
This adds a new chain, not an RPC to an existing chain, so the template questions below are answered for our own first-party endpoint.

Adds `constants/additionalChainRegistry/chainid-101101.js`. This is a new file only — no existing entries are modified.

Vordium is an L1 with an EVM lane. chainId 101101 (`0x18aed`), native currency VORD (18 decimals), explorer https://vordscan.io. The chain is live and producing blocks.

We are also listed in ethereum-lists/chains, where the same move is in review as ethereum-lists/chains#8689 (our previous entry was chainId 1110, which we vacated because it collides with GRX Mainnet — already listed here at 1110. That entry is untouched by this PR).

Service provider for the RPC: the Vordium team, which operates https://rpc.vordium.com as the official first-party endpoint for its own chain. Project site: https://vordium.com