### PR TITLE
Add privacy metadata for G4MM4 PulseChain RPCs

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -259,6 +259,8 @@ export const privacyStatement = {
     "keccak.io does not require accounts, email, or KYC, does not log client IP addresses, and does not correlate requests to users. https://keccak.io/privacy",
   seleman:
     "SELEMAN public JSON-RPC does not store or track user data, does not log client IP addresses to persistent storage, and does not correlate requests with wallet addresses. Ephemeral in-memory rate-limit counters (≤60s) may be used solely for abuse prevention and are not retained as historical logs. No analytics or third-party tracking on the RPC path. https://seleman.monarcaproject.com/privacy",
+  g4mm4:
+    "G4MM4 does not retain RPC request logs and does not store client IP addresses. We do not correlate wallet addresses with IP addresses, and we do not sell or share user data with third parties. https://www.g4mm4.io/disclaimer",
 };
 
 export const extraRpcs = {
@@ -5055,7 +5057,11 @@ export const extraRpcs = {
         trackingDetails: privacyStatement.pulsechain,
       },
       "https://rpc.gigatheminter.com",
-      "https://rpc-pulsechain.g4mm4.io",
+      {
+        url: "https://rpc-pulsechain.g4mm4.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.g4mm4,
+      },
       "https://evex.cloud/pulserpc",
       "wss://evex.cloud/pulsews",
       {
@@ -7567,7 +7573,11 @@ export const extraRpcs = {
         tracking: "none",
         trackingDetails: privacyStatement.publicnode,
       },
-      "https://rpc-testnet-pulsechain.g4mm4.io",
+      {
+        url: "https://rpc-testnet-pulsechain.g4mm4.io",
+        tracking: "none",
+        trackingDetails: privacyStatement.g4mm4,
+      },
     ],
   },
   10086: {


### PR DESCRIPTION
If you are adding a new RPC, please answer the following questions.

#### Link the service provider's website (the company/protocol/individual providing the RPC):
https://www.g4mm4.io

#### Provide a link to your privacy policy:
https://www.g4mm4.io/disclaimer

#### If the RPC has none of the above and you still think it should be added, please explain why:

N/A — both the website and privacy policy links exist (the PRIVACY AND DATA HANDLING section of the linked disclaimer states the endpoint's posture: no retained RPC request logs, no client IP storage, no wallet-address-to-IP correlation, and no selling or sharing of user data).
This PR does not add a new RPC URL. It adds privacy/tracking metadata to the two existing G4MM4 entries (the PulseChain mainnet chain-369 list and the testnet chain-943 list), converting the plain URL strings to { url, tracking: "none", trackingDetails: privacyStatement.g4mm4 } objects in place, so the array order remains unchanged. The privacyStatement.g4mm4 key is appended to the end of the privacyStatement object, per the append convention.