### PR TITLE
Add GGCHAIN (chainId 2121217) to chainIds for chain icon

### DIFF
--- a/constants/chainIds.js
+++ b/constants/chainIds.js
@@ -286,6 +286,7 @@ export default {
   "888888": "vision",
   "900000": "posichain",
   "1440000": "xrpl_evm",
+  "2121217": "ggchain",
   "5064014": "ethereal",
   "7000700": "jmdt",
   "7225878": "saakuru",

--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -1,4 +1,6 @@
 export const privacyStatement = {
+  ggchain:
+    "The GGCHAIN public RPC does not store or track any user information. IP addresses are used only in-memory for rate limiting and DDoS protection and are never logged to disk, sold, or correlated with wallet addresses. No third-party analytics. https://gghyper.net/rpc-privacy.html",
   chainpulse:
       "We use client IP addresses for per-IP rate limiting, abuse prevention, and aggregated public RPC usage analytics. We do not sell personal data or use public RPC traffic for advertising profiles. Details: https://bsc-rpc.chainpulse.cc/privacy",
   blockswap:
@@ -11718,6 +11720,15 @@ export const extraRpcs = {
         url: "wss://shibarium.drpc.org",
         tracking: "none",
         trackingDetails: privacyStatement.drpc,
+      },
+    ],
+  },
+  2121217: {
+    rpcs: [
+      {
+        url: "https://rpc.gghyper.net",
+        tracking: "none",
+        trackingDetails: privacyStatement.ggchain,
       },
     ],
   },


### PR DESCRIPTION
Adds the chainId→slug mapping for **GGCHAIN Mainnet** (2121217) so its icon renders on chainlist.org.

- Chain registered in ethereum-lists/chains: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-2121217.json
- Companion icon PR: https://github.com/DefiLlama/icons/pull/2491 (assets/chains/rsz_ggchain.jpg)
- Website: https://gghyper.net | Explorer: https://explorer.gghyper.net | RPC: https://rpc.gghyper.net