### PR TITLE
Update BlockRazor RPC info

### DIFF
--- a/constants/extraRpcs.js
+++ b/constants/extraRpcs.js
@@ -186,7 +186,7 @@ export const privacyStatement = {
   buildbear:
     "Usage Data is collected automatically when using the Service.Usage Data may include information such as Your Device's Internet Protocol address (e.g. IP address), browser type, browser version, the pages of our Service that You visit, the time and date of Your visit, the time spent on those pages, unique device identifiers and other diagnostic data.https://www.buildbear.io/privacy-policy",
   BlockRazor:
-    "Privacy notice: BlockRazor RPC does not track any kind of user information (i.e. IP, location, etc.). Only information that is public on the blockchain are preserved, such as timestamp of a transaction. For more information please visit: https://blockrazor.gitbook.io/blockrazor/scutum-mev-protect-rpc#privacy-statement",
+    "Privacy notice: BlockRazor RPC does not track any kind of user information (i.e. IP, location, etc.). Only information that is public on the blockchain are preserved, such as timestamp of a transaction. For more information please visit: https://docs.blockrazor.io/statement/privacy-statement",
   numa: "Usage Data may include information such as Your Device's Internet Protocol address (e.g. IP address), browser type, browser version, the pages of our Service that You visit, the time and date of Your visit, the time spent on those pages, unique device identifiers, and other diagnostic data. Check out our Terms of use: https://app.numa.network/terms-of-use/ and Privacy Policy: https://app.numa.network/privacy-policy/",
   Histori:
     "At Histori, we do not log, store, or track your IP address, country, location, or any personal data while making RPC requests and REST API calls. Learn more at: https://histori.xyz/support/privacy-policy",
@@ -554,6 +554,16 @@ export const extraRpcs = {
       },
       {
         url: "https://eth.blockrazor.xyz",
+        tracking: "none",
+        trackingDetails: privacyStatement.BlockRazor,
+      },
+      {
+        url: "https://eth.blockrazor.xyz/fullprivacy",
+        tracking: "none",
+        trackingDetails: privacyStatement.BlockRazor,
+      },
+      {
+        url: "https://eth.blockrazor.xyz/maxbackrun",
         tracking: "none",
         trackingDetails: privacyStatement.BlockRazor,
       },
@@ -1190,6 +1200,16 @@ export const extraRpcs = {
       },
       {
         url: "https://bsc.blockrazor.xyz",
+        tracking: "none",
+        trackingDetails: privacyStatement.BlockRazor,
+      },
+      {
+        url: "https://bsc.blockrazor.xyz/fullprivacy",
+        tracking: "none",
+        trackingDetails: privacyStatement.BlockRazor,
+      },
+      {
+        url: "https://bsc.blockrazor.xyz/maxbackrun",
         tracking: "none",
         trackingDetails: privacyStatement.BlockRazor,
       },


### PR DESCRIPTION
1. Update privacy policy link to https://docs.blockrazor.io/statement/privacy-statement
2. Add https://eth.blockrazor.xyz/fullprivacy and https://eth.blockrazor.xyz/maxbackrun for BlockRazor ETH RPC
3. Add https://bsc.blockrazor.xyz/fullprivacy and https://bsc.blockrazor.xyz/maxbackrun for BlockRazor BSC RPC