### PR TITLE
Add ElyonChain mainnet (55452773)

### DIFF
--- a/constants/additionalChainRegistry/chainid-55452773.js
+++ b/constants/additionalChainRegistry/chainid-55452773.js
@@ -1,0 +1,25 @@
+export const data = {
+  "name": "ElyonChain",
+  "chain": "ELN",
+  "icon": "elyon",
+  "rpc": [
+    "https://mainnet.elyon.network/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ELN",
+    "symbol": "ELN",
+    "decimals": 18
+  },
+  "infoURL": "https://elyon.network",
+  "shortName": "elyon",
+  "chainId": 55452773,
+  "networkId": 55452773,
+  "explorers": [
+    {
+      "name": "Elyon Explorer",
+      "url": "https://explorer.elyon.network",
+      "standard": "none"
+    }
+  ]
+};


### PR DESCRIPTION
Please add ElyonChain mainnet to Chainlist.

Network name: ElyonChain
Chain ID: 55452773
Native currency: ELN
Decimals: 18
Public RPC: https://mainnet.elyon.network/rpc
Block explorer: https://explorer.elyon.network
Official website: https://elyon.network

ELN is the native currency used to pay transaction fees on ElyonChain.